### PR TITLE
godoc: correct fsRoot to prevent misleading message about cmd/

### DIFF
--- a/godoc/pres.go
+++ b/godoc/pres.go
@@ -116,10 +116,11 @@ func NewPresentation(c *Corpus) *Presentation {
 		},
 	}
 	p.cmdHandler = handlerServer{
-		p:       p,
-		c:       c,
-		pattern: "/cmd/",
-		fsRoot:  "/src",
+		p:           p,
+		c:           c,
+		pattern:     "/cmd/",
+		stripPrefix: "cmd/",
+		fsRoot:      "/src/cmd",
 	}
 	p.pkgHandler = handlerServer{
 		p:           p,


### PR DESCRIPTION
Fixes golang/go#14447