### PR TITLE
godoc: correct abspath when looking for cmds

### DIFF
--- a/godoc/cmdline.go
+++ b/godoc/cmdline.go
@@ -69,8 +69,8 @@ func CommandLine(w io.Writer, fs vfs.NameSpace, pres *Presentation, args []strin
 		abspath = pathpkg.Join(pres.PkgFSRoot(), toolsPath+path)
 		cinfo = pres.GetCmdPageInfo(abspath, relpath, mode)
 		if cinfo.IsEmpty() {
-			// Then try $GOROOT/cmd.
-			abspath = pathpkg.Join(pres.CmdFSRoot(), path)
+			// Then try $GOROOT/src/cmd.
+			abspath = pathpkg.Join(pres.CmdFSRoot(), cmdPrefix, path)
 			cinfo = pres.GetCmdPageInfo(abspath, relpath, mode)
 		}
 	}

--- a/godoc/cmdline_test.go
+++ b/godoc/cmdline_test.go
@@ -202,7 +202,7 @@ package main
 		p:       p,
 		c:       c,
 		pattern: "/cmd/",
-		fsRoot:  "/src/cmd",
+		fsRoot:  "/src",
 	}
 	p.pkgHandler = handlerServer{
 		p:       p,


### PR DESCRIPTION
godoc is erroneously detecting paths like syscall and unsafe as possible
commands.

A previous attempt at a fix adjusted the parameters of pkgHandler in
pres.go, but that change had unexpected ripple effects that broke links
and other features of godoc. This change is scoped only to the godoc
command line tool.

cmdline_test.go is updated to match the parameters used in the real
pkgHandler in pres.go.

Fixes golang/go#14447