### PR TITLE
tools/present: add support for full screen mode

### DIFF
--- a/cmd/present/doc.go
+++ b/cmd/present/doc.go
@@ -10,6 +10,7 @@ It may be run as a stand-alone command or an App Engine app.
 
 Usage of present:
   -base="": base path for slide template and static resources
+  -fullscreen=false: enable full screen mode
   -http="127.0.0.1:3999": HTTP service address (e.g., '127.0.0.1:3999')
   -nacl=false: use Native Client environment playground (prevents non-Go code execution)
   -notes=false: enable presenter notes (press 'N' from the browser to display them)

--- a/cmd/present/local.go
+++ b/cmd/present/local.go
@@ -32,6 +32,7 @@ var (
 func main() {
 	flag.BoolVar(&present.PlayEnabled, "play", true, "enable playground (permit execution of arbitrary user code)")
 	flag.BoolVar(&present.NotesEnabled, "notes", false, "enable presenter notes (press 'N' from the browser to display them)")
+	flag.BoolVar(&present.FullScreenEnabled, "fullscreen", false, "enable full screen mode")
 	flag.Parse()
 
 	if *basePath == "" {

--- a/cmd/present/static/styles.css
+++ b/cmd/present/static/styles.css
@@ -250,6 +250,12 @@
   }
 }
 
+/* Styles for full screen mode */
+.slides.fullscreen > article.next, .slides.fullscreen > article.far-next,
+.slides.fullscreen > article.past, .slides.fullscreen > article.far-past {
+  display: none;
+}
+
 /* Styles for slides */
 
 .slides > article {

--- a/cmd/present/templates/slides.tmpl
+++ b/cmd/present/templates/slides.tmpl
@@ -40,7 +40,11 @@
 
   <body style='display: none'>
 
+  {{if .FullScreenEnabled}}
+    <section class='slides layout-widescreen fullscreen'>
+  {{else}}
     <section class='slides layout-widescreen'>
+  {{end}}
 
       <article>
         <h1>{{.Title}}</h1>

--- a/present/parse.go
+++ b/present/parse.go
@@ -26,6 +26,9 @@ var (
 	funcs   = template.FuncMap{}
 )
 
+// FullScreenEnabled specifies whether slides should be displayed in the full screen mode.
+var FullScreenEnabled = false
+
 // Template returns an empty template with the action functions in its FuncMap.
 func Template() *template.Template {
 	return template.New("").Funcs(funcs)
@@ -35,10 +38,11 @@ func Template() *template.Template {
 func (d *Doc) Render(w io.Writer, t *template.Template) error {
 	data := struct {
 		*Doc
-		Template     *template.Template
-		PlayEnabled  bool
-		NotesEnabled bool
-	}{d, t, PlayEnabled, NotesEnabled}
+		Template          *template.Template
+		PlayEnabled       bool
+		NotesEnabled      bool
+		FullScreenEnabled bool
+	}{d, t, PlayEnabled, NotesEnabled, FullScreenEnabled}
 	return t.ExecuteTemplate(w, "root", data)
 }
 


### PR DESCRIPTION
This pull request add the -fullscreen flag to enable full screen mode (default: false).
When enabled all the slides except the current one are hidden.

Fixes golang/go#12634 and golang/go#18299

Change-Id: Id2237aa938bdc7478e2072817e7abf2b7865dea8