### PR TITLE
present: add footer template

### DIFF
--- a/cmd/present/static/styles.css
+++ b/cmd/present/static/styles.css
@@ -415,12 +415,32 @@ p.link {
   margin-left: 20px;
 }
 
-.pagenumber {
+.footer {
   color: #8c8c8c;
   font-size: 75%;
   position: absolute;
-  bottom: 0px;
-  right: 10px;
+  bottom: 5px;
+  left: 15px;
+  right: 15px; 
+  height: 50px;
+  line-height:50px;
+}
+.footer .segment-0 {
+  min-width:33%;
+  float: left;
+  min-height: 1px;
+}
+.footer .segment-1 {
+  min-width:33%;
+  float: left;
+  text-align: center;
+  min-height: 1px;
+}
+.footer .segment-2 {
+  min-width: 33%;
+  float: right;
+  text-align: right;
+  min-height: 1px;
 }
 
 /* Code */

--- a/cmd/present/templates/slides.tmpl
+++ b/cmd/present/templates/slides.tmpl
@@ -50,7 +50,7 @@
           <div class="presenter">
             {{range .TextElem}}{{elem $.Template .}}{{end}}
           </div>
-        {{end}}
+        {{end}}        
       </article>
 
   {{range $i, $s := .Sections}}
@@ -62,7 +62,7 @@
       {{else}}
         <h2>{{$s.Title}}</h2>
       {{end}}
-      <span class="pagenumber">{{pagenum $s 1}}</span>
+      {{footer $.Template $s $.Footer 1}}
       </article>
   <!-- end of slide {{$s.Number}} -->
   {{end}}{{/* of Slide block */}}
@@ -104,4 +104,16 @@
 
 {{define "newline"}}
 <br>
+{{end}}
+
+{{define "footer"}}
+{{if $.Footer.Enabled}}
+<div class="footer">
+    {{range $i, $el := $.Footer.Elem}}
+      <div class="segment-{{$i}}">
+          {{elem $.Template $el}}
+      </div>
+    {{end}}
+</div>
+{{end}}
 {{end}}

--- a/present/doc.go
+++ b/present/doc.go
@@ -12,6 +12,8 @@ line is the title, so the header looks like
 	Subtitle of document
 	15:04 2 Jan 2006
 	Tags: foo, bar, baz
+	Footer: Go Rules! | .image image.png | [#]
+	FooterOmit: 3, 7
 	<blank line>
 	Author Name
 	Job title, Company
@@ -19,7 +21,7 @@ line is the title, so the header looks like
 	http://url/
 	@twitter_name
 
-The subtitle, date, and tags lines are optional.
+The subtitle, date, tags and footer lines are optional.
 
 The date line may be written without a time:
 	2 Jan 2006
@@ -27,6 +29,13 @@ In this case, the time will be interpreted as 10am UTC on that date.
 
 The tags line is a comma-separated list of tags that may be used to categorize
 the document.
+
+The footer line is a pipe (|) list of three segments that can be used to add a footer
+for each slide. The justifications are left, center, and right.
+Use [#] to denote the slide number and .image to add an image.
+
+The footer omit line is a comma-separated list of slide numbers that can be used
+to turn off the footer for a specific slide.
 
 The author section may contain a mixture of text, twitter names, and links.
 For slide presentations, only the plain text lines will be displayed on the


### PR DESCRIPTION
This commit add the possibily to define a footer template using two lines in the header section.

The footer line is a pipe (|) list of three segments that can be used to add a footer
for each slide. The justifications are left, center, and right.
Use [#] to denote the slide number and .image to add an image.

The footer omit line is a comma-separated list of slide numbers that can be used
to turn off the footer for a specific slide.

Fixes golang/go#20946