### PR TITLE
godoc: cleanup unused lines in makestatic.go

### DIFF
--- a/godoc/static/makestatic.go
+++ b/godoc/static/makestatic.go
@@ -80,11 +80,6 @@ func main() {
 }
 
 func makestatic() error {
-	f, err := os.Create("static.go")
-	if err != nil {
-		return err
-	}
-	defer f.Close()
 	buf := new(bytes.Buffer)
 	fmt.Fprintf(buf, "%v\n\n%v\n\npackage static\n\n", license, warning)
 	fmt.Fprintf(buf, "var Files = map[string]string{\n")


### PR DESCRIPTION
I was reading the implementation of godoc static assets embedding to get pointer for my project. I have noticed variable `f` was not used elsewhere within the `func`. At the end of function, `buf` bytes written into `static.go` as a whole after the format source.