### PR TITLE
godoc: skip build tag annotations when displaying examples

### DIFF
--- a/godoc/godoc.go
+++ b/godoc/godoc.go
@@ -666,6 +666,7 @@ func (p *Presentation) example_htmlFunc(info *PageInfo, funcName string) string 
 		play := ""
 		if eg.Play != nil && p.ShowPlayground {
 			var buf bytes.Buffer
+			eg.Play.Comments = filterOutBuildAnnotations(eg.Play.Comments)
 			if err := format.Node(&buf, info.FSet, eg.Play); err != nil {
 				log.Print(err)
 			} else {
@@ -692,6 +693,23 @@ func (p *Presentation) example_htmlFunc(info *PageInfo, funcName string) string 
 		}
 	}
 	return buf.String()
+}
+
+func filterOutBuildAnnotations(cg []*ast.CommentGroup) []*ast.CommentGroup {
+	if len(cg) == 0 {
+		return cg
+	}
+
+	for i := range cg {
+		if !strings.HasPrefix(cg[i].Text(), "+build ") {
+			// Found the first non-build tag, return from here until the end
+			// of the slice.
+			return cg[i:]
+		}
+	}
+
+	// There weren't any non-build tags, return an empty slice.
+	return []*ast.CommentGroup{}
 }
 
 // example_nameFunc takes an example function name and returns its display

--- a/godoc/godoc_test.go
+++ b/godoc/godoc_test.go
@@ -321,3 +321,48 @@ func TestSrcToPkgLinkFunc(t *testing.T) {
 		}
 	}
 }
+
+func TestFilterOutBuildAnnotations(t *testing.T) {
+	src := []byte(`
+// +build !foo
+// +build !anothertag
+
+// non-tag comment
+
+package foo
+
+func bar() int {
+	return 42
+}`)
+
+	fset := token.NewFileSet()
+	af, err := parser.ParseFile(fset, "foo.go", src, parser.ParseComments)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var found bool
+	for _, cg := range af.Comments {
+		if strings.HasPrefix(cg.Text(), "+build ") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("TestFilterOutBuildAnnotations is broken: missing build tag in test input")
+	}
+
+	found = false
+	for _, cg := range filterOutBuildAnnotations(af.Comments) {
+		if strings.HasPrefix(cg.Text(), "+build ") {
+			t.Errorf("filterOutBuildAnnotations failed to filter build tag")
+		}
+
+		if strings.Contains(cg.Text(), "non-tag comment") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("filterOutBuildAnnotations should not remove non-build tag comment")
+	}
+}


### PR DESCRIPTION
After moving the filepath.Walk example to a standalone example file
in CL 122237 (so it could use a standalone function), godoc includes
the build tag annotation ("// +build !windows,!plan9" in this case)
in the runnable example.  The example runs correctly, but the
annotation might be confusing for new users.

With this change, godoc skips these annotations when displaying examples.

Fixes golang/go#26490.