### PR TITLE
godoc: correctly parse packages with digits in the package name

### DIFF
--- a/godoc/versions.go
+++ b/godoc/versions.go
@@ -132,7 +132,7 @@ func parseRow(s string) (vr versionedRow, ok bool) {
 		return
 	}
 	rest := s[len("pkg "):]
-	endPkg := strings.IndexFunc(rest, func(r rune) bool { return !(unicode.IsLetter(r) || r == '/') })
+	endPkg := strings.IndexFunc(rest, func(r rune) bool { return !(unicode.IsLetter(r) || r == '/' || unicode.IsDigit(r)) })
 	if endPkg == -1 {
 		return
 	}

--- a/godoc/versions_test.go
+++ b/godoc/versions_test.go
@@ -51,6 +51,15 @@ func TestParseVersionRow(t *testing.T) {
 				name: "FileInfoHeader",
 			},
 		},
+		{
+			row: "pkg encoding/base32, method (Encoding) WithPadding(int32) *Encoding",
+			want: versionedRow{
+				pkg:  "encoding/base32",
+				kind: "method",
+				name: "WithPadding",
+				recv: "Encoding",
+			},
+		},
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
Fixes golang/go#26514