### PR TITLE
godoc: skip build tag annotations when displaying examples

### DIFF
--- a/godoc/godoc.go
+++ b/godoc/godoc.go
@@ -666,6 +666,7 @@ func (p *Presentation) example_htmlFunc(info *PageInfo, funcName string) string 
 		play := ""
 		if eg.Play != nil && p.ShowPlayground {
 			var buf bytes.Buffer
+			eg.Play.Comments = filterOutBuildAnnotations(eg.Play.Comments)
 			if err := format.Node(&buf, info.FSet, eg.Play); err != nil {
 				log.Print(err)
 			} else {
@@ -692,6 +693,23 @@ func (p *Presentation) example_htmlFunc(info *PageInfo, funcName string) string 
 		}
 	}
 	return buf.String()
+}
+
+func filterOutBuildAnnotations(cg []*ast.CommentGroup) []*ast.CommentGroup {
+	if len(cg) == 0 {
+		return cg
+	}
+
+	for i := range cg {
+		if !strings.HasPrefix(cg[i].Text(), "+build ") {
+			// Found the first non-build tag, return from here until the end
+			// of the slice.
+			return cg[i:]
+		}
+	}
+
+	// There weren't any non-build tags, return an empty slice.
+	return []*ast.CommentGroup{}
 }
 
 // example_nameFunc takes an example function name and returns its display


### PR DESCRIPTION
After moving the filepath.Walk example to a standalone example file
in CL 122237 (so it could use a standalone function), godoc includes
the build tag annotation ("// +build !windows,!plan9" in this case)
in the runnable example.  The example runs correctly, but the
annotation might be confusing for new users.

Change the behavior so that godoc skips these annotations when
displaying examples.

To avoid false positives in older versions of "go vet", which are still used
on the build dashboard, we avoid using a multiline string in the test.

Fixes golang/go#26490.