### PR TITLE
imports: collect package name instead of the last element of path

### DIFF
--- a/imports/fix.go
+++ b/imports/fix.go
@@ -143,7 +143,7 @@ func dirPackageInfoFile(pkgName, srcDir, filename string) (*packageInfo, error) 
 
 		for _, imp := range root.Imports {
 			impInfo := importInfo{Path: strings.Trim(imp.Path.Value, `"`)}
-			name := path.Base(impInfo.Path)
+			name := importPathToName(impInfo.Path, srcDir)
 			if imp.Name != nil {
 				name = strings.Trim(imp.Name.Name, `"`)
 				impInfo.Alias = name


### PR DESCRIPTION
If the package name and the last element of import path are different, sibling will not be hit.
https://github.com/golang/tools/blob/master/imports/fix.go#L315