### PR TITLE
go/packages: use GOROOT to determine go binary

### DIFF
--- a/go/packages/golist.go
+++ b/go/packages/golist.go
@@ -290,7 +290,10 @@ func golist(cfg *Config, args []string) (*bytes.Buffer, error) {
 	goBin := "go"
 	for _, e := range cfg.Env {
 		if strings.HasPrefix(e, "GOCMD=") && len(e) > 7 {
-			goBin = filepath.Join(e[7:], "bin", "go")
+			goBin = e[7:]
+			if len(goBin) == 0 {
+				return nil, fmt.Errorf("GOCMD environment variable should not be empty")
+			}
 		}
 	}
 	out := new(bytes.Buffer)

--- a/go/packages/golist.go
+++ b/go/packages/golist.go
@@ -287,8 +287,14 @@ func golistargs(cfg *Config, words []string) []string {
 
 // golist returns the JSON-encoded result of a "go list args..." query.
 func golist(cfg *Config, args []string) (*bytes.Buffer, error) {
+	goBin := "go"
+	for _, e := range cfg.Env {
+		if strings.HasPrefix(e, "GOCMD=") && len(e) > 7 {
+			goBin = filepath.Join(e[7:], "bin", "go")
+		}
+	}
 	out := new(bytes.Buffer)
-	cmd := exec.CommandContext(cfg.Context, "go", args...)
+	cmd := exec.CommandContext(cfg.Context, goBin, args...)
 	cmd.Env = cfg.Env
 	cmd.Dir = cfg.Dir
 	cmd.Stdout = out

--- a/go/packages/golist.go
+++ b/go/packages/golist.go
@@ -289,11 +289,8 @@ func golistargs(cfg *Config, words []string) []string {
 func golist(cfg *Config, args []string) (*bytes.Buffer, error) {
 	goBin := "go"
 	for _, e := range cfg.Env {
-		if strings.HasPrefix(e, "GOCMD=") && len(e) > 7 {
-			goBin = e[7:]
-			if len(goBin) == 0 {
-				return nil, fmt.Errorf("GOCMD environment variable should not be empty")
-			}
+		if strings.HasPrefix(e, "GOCMD=") && len(e) > 6 {
+			goBin = e[6:]
 		}
 	}
 	out := new(bytes.Buffer)


### PR DESCRIPTION
This change allows users with multiple Go distributions
installed on their machine to use whichever go binary they prefer
by looking at the runtime GOROOT and executing the bin/go inside of it.
If the binary is not found, it will fallback to using "go" which is
whatever version is set in the user's PATH.

Fixes https://github.com/golang/go/issues/26845