### PR TITLE
all: fix typos in comments

### DIFF
--- a/cmd/digraph/digraph.go
+++ b/cmd/digraph/digraph.go
@@ -8,7 +8,7 @@
 //
 // TODO(adonovan):
 // - support input files other than stdin
-// - suport alternative formats (AT&T GraphViz, CSV, etc),
+// - support alternative formats (AT&T GraphViz, CSV, etc),
 //   a comment syntax, etc.
 // - allow queries to nest, like Blaze query language.
 //

--- a/cmd/godoc/setup-godoc-app.bash
+++ b/cmd/godoc/setup-godoc-app.bash
@@ -14,7 +14,7 @@
 # is consulted to find the $GOROOT.
 #
 # The script creates a .zip file representing the $GOROOT file system
-# and computes the correspondig search index files. These files are then
+# and computes the corresponding search index files. These files are then
 # copied to $APPDIR. A corresponding godoc configuration file is created
 # in $APPDIR/appconfig.go.
 

--- a/go/packages/doc.go
+++ b/go/packages/doc.go
@@ -223,7 +223,7 @@ Questions & Tasks
   GOOS and GOARCH seem important enough to warrant a dedicated option.
 
 - How should we handle partial failures such as a mixture of good and
-  malformed patterns, existing and non-existent packages, succesful and
+  malformed patterns, existing and non-existent packages, successful and
   failed builds, import failures, import cycles, and so on, in a call to
   Load?
 

--- a/go/packages/packages_test.go
+++ b/go/packages/packages_test.go
@@ -570,7 +570,7 @@ func TestLoadSyntaxOK(t *testing.T) {
 
 	// TODO(matloob): The legacy go list based support loads everything from source
 	// because it doesn't do a build and the .a files don't exist.
-	// Can we simulate its existance?
+	// Can we simulate its existence?
 
 	for _, test := range []struct {
 		id         string

--- a/godoc/analysis/README
+++ b/godoc/analysis/README
@@ -49,7 +49,7 @@ CALLEES:
 
 Type info:
 - In the source viewer's lower pane, use a toggle div around the
-  IMPLEMENTS and METHODSETS lists, like we do in the pacakge view.
+  IMPLEMENTS and METHODSETS lists, like we do in the package view.
   Only expand them initially if short.
 - Include IMPLEMENTS and METHOD SETS information in search index.
 - URLs in IMPLEMENTS/METHOD SETS always link to source, even from the

--- a/godoc/index.go
+++ b/godoc/index.go
@@ -82,7 +82,7 @@ type interfaceSlice struct {
 
 // A RunList is a list of entries that can be sorted according to some
 // criteria. A RunList may be compressed by grouping "runs" of entries
-// which are equal (according to the sort critera) into a new RunList of
+// which are equal (according to the sort criteria) into a new RunList of
 // runs. For instance, a RunList containing pairs (x, y) may be compressed
 // into a RunList containing pair runs (x, {y}) where each run consists of
 // a list of y's with the same x.

--- a/imports/fix.go
+++ b/imports/fix.go
@@ -1004,7 +1004,7 @@ func pkgIsCandidate(filename, pkgIdent string, pkg *pkg) bool {
 	// permit a directory "foo" to be package
 	// "bar", which is strongly discouraged
 	// anyway. There's no reason goimports needs
-	// to be slow just to accomodate that.
+	// to be slow just to accommodate that.
 	lastTwo := lastTwoComponents(pkg.importPathShort)
 	if strings.Contains(lastTwo, pkgIdent) {
 		return true

--- a/playground/common.go
+++ b/playground/common.go
@@ -49,7 +49,7 @@ func passThru(w io.Writer, req *http.Request) error {
 	return nil
 }
 
-var onAppengine = false // will be overriden by appengine.go and appenginevm.go
+var onAppengine = false // will be overridden by appengine.go and appenginevm.go
 
 func allowShare(r *http.Request) bool {
 	if !onAppengine {

--- a/present/doc.go
+++ b/present/doc.go
@@ -224,7 +224,7 @@ html:
 The function html includes the contents of the specified file as
 unescaped HTML. This is useful for including custom HTML elements
 that cannot be created using only the slide format.
-It is your responsibilty to make sure the included HTML is valid and safe.
+It is your responsibility to make sure the included HTML is valid and safe.
 
 	.html file.html
 

--- a/refactor/eg/eg.go
+++ b/refactor/eg/eg.go
@@ -322,7 +322,7 @@ func soleExpr(fn *ast.FuncDecl) (ast.Expr, error) {
 	return nil, fmt.Errorf("must contain a single return or expression statement")
 }
 
-// stmtAndExpr returns the expression in the last return statement as well as the preceeding lines.
+// stmtAndExpr returns the expression in the last return statement as well as the preceding lines.
 func stmtAndExpr(fn *ast.FuncDecl) ([]ast.Stmt, ast.Expr, error) {
 	if fn.Body == nil {
 		return nil, nil, fmt.Errorf("no body")

--- a/refactor/eg/rewrite.go
+++ b/refactor/eg/rewrite.go
@@ -202,7 +202,7 @@ func (tr *Transformer) apply(f func(reflect.Value) (reflect.Value, bool, map[str
 				if localchanged {
 					changed = true
 					// we clobber envp here,
-					// which means if we have two sucessive
+					// which means if we have two successive
 					// replacements inside the same statement
 					// we will only generate the setup for one of them.
 					envp = env


### PR DESCRIPTION
This pull request fixes several typos in comments. I believe that they're safe enough.