### PR TITLE
go/ssa: add associated documentation to functions

### DIFF
--- a/go/ssa/create.go
+++ b/go/ssa/create.go
@@ -97,6 +97,8 @@ func memberFromObject(pkg *Package, obj types.Object, syntax ast.Node) {
 		}
 		if syntax == nil {
 			fn.Synthetic = "loaded from gc object file"
+		} else {
+			fn.Doc = syntax.(*ast.FuncDecl).Doc
 		}
 
 		pkg.values[obj] = fn

--- a/go/ssa/ssa.go
+++ b/go/ssa/ssa.go
@@ -299,6 +299,7 @@ type Function struct {
 	method    *types.Selection // info about provenance of synthetic methods
 	Signature *types.Signature
 	pos       token.Pos
+	Doc       *ast.CommentGroup
 
 	Synthetic string        // provenance of synthetic function; "" for true source functions
 	syntax    ast.Node      // *ast.Func{Decl,Lit}; replaced with simple ast.Node after build, unless debug mode


### PR DESCRIPTION
This makes it easier for clients to read compiler directives like `//go:linkname` or `//line`.

I would like to use this in my own [Go compiler project](https://github.com/aykevl/tinygo).