### PR TITLE
godoc: add 'shallow' PageInfoMode to only show top-level directories in subdirectory listings

### DIFF
--- a/godoc/dirtrees.go
+++ b/godoc/dirtrees.go
@@ -332,7 +332,7 @@ func hasThirdParty(list []DirEntry) bool {
 // If filter is set, only the directory entries whose paths match the filter
 // are included.
 //
-func (root *Directory) listing(skipRoot bool, filter func(string) bool) *DirList {
+func (root *Directory) listing(mode PageInfoMode, skipRoot bool, filter func(string) bool) *DirList {
 	if root == nil {
 		return nil
 	}
@@ -362,8 +362,12 @@ func (root *Directory) listing(skipRoot bool, filter func(string) bool) *DirList
 		if filter != nil && !filter(d.Path) {
 			continue
 		}
+		depth := d.Depth - minDepth
+		if mode&Shallow != 0 && depth > 0 {
+			continue
+		}
 		var p DirEntry
-		p.Depth = d.Depth - minDepth
+		p.Depth = depth
 		p.Height = maxHeight - p.Depth
 		// the path is relative to root.Path - remove the root.Path
 		// prefix (the prefix should always be present but avoid

--- a/godoc/server.go
+++ b/godoc/server.go
@@ -216,7 +216,7 @@ func (h *handlerServer) GetPageInfo(abspath, relpath string, mode PageInfoMode, 
 		dir = h.c.newDirectory(abspath, 2)
 		timestamp = time.Now()
 	}
-	info.Dirs = dir.listing(true, func(path string) bool { return h.includePath(path, mode) })
+	info.Dirs = dir.listing(mode, true, func(path string) bool { return h.includePath(path, mode) })
 
 	info.DirTime = timestamp
 	info.DirFlat = mode&FlatDir != 0
@@ -361,6 +361,7 @@ const (
 	NoHTML                               // show result in textual form, do not generate HTML
 	FlatDir                              // show directory in a flat (non-indented) manner
 	NoTypeAssoc                          // don't associate consts, vars, and factory functions with types
+	Shallow                              // don't show directories under subdirectories.
 )
 
 // modeNames defines names for each PageInfoMode flag.
@@ -370,6 +371,7 @@ var modeNames = map[string]PageInfoMode{
 	"src":     ShowSource,
 	"text":    NoHTML,
 	"flat":    FlatDir,
+	"shallow": Shallow,
 }
 
 // generate a query string for persisting PageInfoMode between pages.


### PR DESCRIPTION
Solves golang/go#27666. I'm not sure if this is the preferred method of implementing something like this, but it does the job!