### PR TITLE
cmd/guru: fix guessImportPath for Windows

### DIFF
--- a/cmd/guru/what.go
+++ b/cmd/guru/what.go
@@ -10,6 +10,7 @@ import (
 	"go/build"
 	"go/token"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -202,7 +203,7 @@ func guessImportPath(filename string, buildContext *build.Context) (srcdir, impo
 		if d >= 0 && d < minD {
 			minD = d
 			srcdir = gopathDir
-			importPath = strings.Join(segmentedAbsFileDir[len(segmentedAbsFileDir)-minD:], string(os.PathSeparator))
+			importPath = path.Join(segmentedAbsFileDir[len(segmentedAbsFileDir)-minD:]...)
 		}
 	}
 	if srcdir == "" {


### PR DESCRIPTION
Import paths in Go use forward slashes, not the operating system's path separator.

Fixes golang/go#24699.
Fixes golang/go#23318.