### PR TITLE
cmd/goimports: update Emacs install instructions

### DIFF
--- a/cmd/goimports/doc.go
+++ b/cmd/goimports/doc.go
@@ -13,8 +13,6 @@ For emacs, make sure you have the latest go-mode.el:
    https://github.com/dominikh/go-mode.el
 Then in your .emacs file:
    (setq gofmt-command "goimports")
-   (add-to-list 'load-path "/home/you/somewhere/emacs/")
-   (require 'go-mode-autoloads)
    (add-hook 'before-save-hook 'gofmt-before-save)
 
 For vim, set "gofmt_command" to "goimports":


### PR DESCRIPTION
When I tried to use the Emacs instructions, I found there was no go-mode-autoloads available. Searching, I found: https://github.com/dominikh/go-mode.el/issues/222

Removing the (require) line solved my problem.

I don't know what the add-to-list invocation was supposed to do, so I propose removing it too.