### PR TITLE
goimports: add Scheme and ability to order imports by std lib -> local -> 3rd party

### DIFF
--- a/cmd/goimports/goimports.go
+++ b/cmd/goimports/goimports.go
@@ -47,7 +47,8 @@ var (
 
 func init() {
 	flag.BoolVar(&options.AllErrors, "e", false, "report all errors (not just the first 10 on different lines)")
-	flag.StringVar(&imports.LocalPrefix, "local", "", "put imports beginning with this string after 3rd-party packages; comma-separated list")
+	flag.StringVar(&imports.LocalPrefix, "local", "", "put imports beginning with this string ordered by the scheme provided; comma-separated list")
+	flag.StringVar(&imports.Scheme, "scheme", "stdThirdPartyLocal", "provides scheme to ordering of imports when local prefix is provided; other option available is stdLocalThirdParty")
 }
 
 func report(err error) {

--- a/imports/fix.go
+++ b/imports/fix.go
@@ -43,12 +43,22 @@ func localPrefixes() []string {
 	return nil
 }
 
+// Scheme is the format in which imports get grouped. Two different options are supported,
+// the "stdThirdPartyLocal" and "stdLocalThirdParty" options. "stdThirdPartyLocal" will order
+// imports by std lib, third party, and finally local pkg groupings. The "stdThirdPartyLocal" is the
+// default scheme. The "stdLocalThirdParty" option will order imports by std lib, local as defined in the local
+// prefix argument above, and finally the 3rd-party packages.
+var Scheme string
+
 // importToGroup is a list of functions which map from an import path to
 // a group number.
 var importToGroup = []func(importPath string) (num int, ok bool){
 	func(importPath string) (num int, ok bool) {
 		for _, p := range localPrefixes() {
 			if strings.HasPrefix(importPath, p) || strings.TrimSuffix(p, "/") == importPath {
+				if LocalPrefix != "" && Scheme == "stdLocalThirdParty" {
+					return 1, true
+				}
 				return 3, true
 			}
 		}
@@ -62,6 +72,9 @@ var importToGroup = []func(importPath string) (num int, ok bool){
 	},
 	func(importPath string) (num int, ok bool) {
 		if strings.Contains(importPath, ".") {
+			if LocalPrefix != "" && Scheme == "stdLocalThirdParty" {
+				return 3, true
+			}
 			return 1, true
 		}
 		return


### PR DESCRIPTION
The problem I am solving for is having options available to those who do not want to force the local pkgs to the bottom of the import groupings. Only one option available at this time, providing the ability to group by std lib -> local -> 3rd party. This does not change default behavior when LocalPrefix is set and Scheme is not. Will default back to the local being last in that case.