### PR TITLE
go/analysis/internal/checker: don't clobber error when packages.Load fails

### DIFF
--- a/go/analysis/internal/checker/checker.go
+++ b/go/analysis/internal/checker/checker.go
@@ -141,11 +141,11 @@ func load(patterns []string, allSyntax bool) ([]*packages.Package, error) {
 			err = fmt.Errorf("%d errors during loading", n)
 		} else if n == 1 {
 			err = fmt.Errorf("error during loading")
+		} else if len(initial) == 0 {
+			err = fmt.Errorf("%s matched no packages", strings.Join(patterns, " "))
 		}
 	}
-	if len(initial) == 0 {
-		err = fmt.Errorf("%s matched no packages", strings.Join(patterns, " "))
-	}
+
 	return initial, err
 }
 


### PR DESCRIPTION
Previously, if `packages.Load` failed, it would (sometimes? always?) return an error + no initial packages.
The moved `len(initial)` check was overriding the actual err with a much less useful one.

Example output before:
```
13:03:17.856866 load [./...]
13:03:28.403532 ./... matched no packages
```
And after:
```
13:03:30.942191 load [./...]
13:03:36.999506 go list repeated package [an internal package] with different values
```