### PR TITLE
go/analysis/internal/checker: fix debug flag docs

### DIFF
--- a/go/analysis/internal/checker/checker.go
+++ b/go/analysis/internal/checker/checker.go
@@ -47,7 +47,7 @@ func RegisterFlags() {
 	// When adding flags here, remember to update
 	// the list of suppressed flags in analysisflags.
 
-	flag.StringVar(&Debug, "debug", Debug, `debug flags, any subset of "lpsv"`)
+	flag.StringVar(&Debug, "debug", Debug, `debug flags, any subset of "fpstv"`)
 
 	flag.StringVar(&CPUProfile, "cpuprofile", "", "write CPU profile to this file")
 	flag.StringVar(&MemProfile, "memprofile", "", "write memory profile to this file")


### PR DESCRIPTION
The list of recognized values for the `-debug` flag was old / incorrect.