### PR TITLE
godoc/static: inherit textarea color to avoid illegible text

### DIFF
--- a/godoc/static/style.css
+++ b/godoc/static/style.css
@@ -7,9 +7,9 @@ body {
 	color: #222;
 }
 textarea {
-  /* Inherit text color from body avoiding illegible text in the case where the
-   * user has inverted the browsers custom text and background colors. */
-  color: inherit;
+	/* Inherit text color from body avoiding illegible text in the case where the
+ 	* user has inverted the browsers custom text and background colors. */
+	color: inherit;
 }
 pre,
 code {

--- a/godoc/static/style.css
+++ b/godoc/static/style.css
@@ -6,6 +6,11 @@ body {
 	text-align: center;
 	color: #222;
 }
+textarea {
+  /* Inherit text color from body avoiding illegible text in the case where the
+   * user has inverted the browsers custom text and background colors. */
+  color: inherit;
+}
 pre,
 code {
 	font-family: Menlo, monospace;


### PR DESCRIPTION
The cascading sylesheet from the users UI can be inverted.
If the background color is altered in the textarea and the text
style is left unchanged the text may become illegible.
The default value of the textarea color is that of the users UI
styling and is not the same as that of the document body.
Setting color: inherit; resolves this.

Fixes golang/go#29482