### PR TITLE
internal/lsp: do not complete inside comments in functions

### DIFF
--- a/internal/lsp/source/completion.go
+++ b/internal/lsp/source/completion.go
@@ -73,8 +73,11 @@ func Completion(ctx context.Context, f File, pos token.Pos) (items []CompletionI
 	}
 
 	// Skip completion inside comment blocks.
-	if p, ok := path[0].(*ast.File); ok && isCommentNode(p, pos) {
-		return items, prefix, nil
+	switch path[0].(type) {
+	case *ast.File, *ast.BlockStmt:
+		if isCompletionInsideComment(file.Comments, pos) {
+			return items, prefix, nil
+		}
 	}
 
 	// Save certain facts about the query position, including the expected type
@@ -252,22 +255,16 @@ func lexical(path []ast.Node, pos token.Pos, pkg *types.Package, info *types.Inf
 	return items
 }
 
-// isCommentNode checks if given token position is inside ast.Comment node.
-func isCommentNode(root ast.Node, pos token.Pos) bool {
-	var found bool
-	ast.Inspect(root, func(n ast.Node) bool {
-		if n == nil {
-			return false
-		}
-		if n.Pos() <= pos && pos <= n.End() {
-			if _, ok := n.(*ast.Comment); ok {
-				found = true
-				return false
+// isCompletionInsideComment checks if given token position is inside ast.Comment node.
+func isCompletionInsideComment(commentGroups []*ast.CommentGroup, pos token.Pos) bool {
+	for _, g := range commentGroups {
+		for _, c := range g.List {
+			if c.Pos() <= pos && pos <= c.End() {
+				return true
 			}
 		}
-		return true
-	})
-	return found
+	}
+	return false
 }
 
 // complit finds completions for field names inside a composite literal.

--- a/internal/lsp/source/completion.go
+++ b/internal/lsp/source/completion.go
@@ -75,7 +75,7 @@ func Completion(ctx context.Context, f File, pos token.Pos) (items []CompletionI
 	// Skip completion inside comment blocks.
 	switch path[0].(type) {
 	case *ast.File, *ast.BlockStmt:
-		if isCompletionInsideComment(file.Comments, pos) {
+		if inComment(pos, file.Comments) {
 			return items, prefix, nil
 		}
 	}
@@ -255,8 +255,8 @@ func lexical(path []ast.Node, pos token.Pos, pkg *types.Package, info *types.Inf
 	return items
 }
 
-// isCompletionInsideComment checks if given token position is inside ast.Comment node.
-func isCompletionInsideComment(commentGroups []*ast.CommentGroup, pos token.Pos) bool {
+// inComment checks if given token position is inside ast.Comment node.
+func inComment(pos token.Pos, commentGroups []*ast.CommentGroup) bool {
 	for _, g := range commentGroups {
 		for _, c := range g.List {
 			if c.Pos() <= pos && pos <= c.End() {

--- a/internal/lsp/testdata/foo/foo.go
+++ b/internal/lsp/testdata/foo/foo.go
@@ -19,6 +19,4 @@ func _() {
 	}
 }
 
-//@complete("", Foo, IntFoo, StructFoo)
-
-type IntFoo int //@item(IntFoo, "IntFoo", "int", "type")
+type IntFoo int //@item(IntFoo, "IntFoo", "int", "type"),complete("", Foo, IntFoo, StructFoo)


### PR DESCRIPTION
The previous change (https://go-review.googlesource.com/c/tools/+/157678) only stopped completion in comments in global scope. This change prevents completions results from being sent for comments inside of functions.

Fixes golang/go#29370