### PR TITLE
go/packages: stop parsing files if the context is canceled

### DIFF
--- a/go/packages/packages.go
+++ b/go/packages/packages.go
@@ -768,17 +768,15 @@ var ioLimit = make(chan bool, 20)
 // positions of the resulting ast.Files are not ordered.
 //
 func (ld *loader) parseFiles(filenames []string) ([]*ast.File, []error) {
-	ctx := ld.Config.Context
-	if ctx == nil {
-		ctx = context.Background()
-	}
 	var wg sync.WaitGroup
 	n := len(filenames)
 	parsed := make([]*ast.File, n)
 	errors := make([]error, n)
 	for i, file := range filenames {
-		if ctx.Err() == context.Canceled {
-			break
+		if ld.Config.Context.Err() != nil {
+			parsed[i] = nil
+			errors[i] = ld.Config.Context.Err()
+			continue
 		}
 		wg.Add(1)
 		go func(i int, filename string) {

--- a/go/packages/packages.go
+++ b/go/packages/packages.go
@@ -768,11 +768,18 @@ var ioLimit = make(chan bool, 20)
 // positions of the resulting ast.Files are not ordered.
 //
 func (ld *loader) parseFiles(filenames []string) ([]*ast.File, []error) {
+	ctx := ld.Config.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	var wg sync.WaitGroup
 	n := len(filenames)
 	parsed := make([]*ast.File, n)
 	errors := make([]error, n)
 	for i, file := range filenames {
+		if ctx.Err() == context.Canceled {
+			break
+		}
 		wg.Add(1)
 		go func(i int, filename string) {
 			ioLimit <- true // wait


### PR DESCRIPTION
`stamblerre/gocode`, which is the fork of `mdempsky/gocode` that supports Go 1.11 modules, uses `packages.Load` to load all of the Go code for, among other things, IDE autocomplete support.  A common aspect to IDE autocomplete is asking for suggestions very frequently (perhaps at every character typed).  Once the user has typed another character, the previous request for autocomplete is invalid and can be canceled.
    
`packages.Load` already stops its `go list` component if the context is canceled, but if the context is canceled afterward, then it will parse all of the files that it found.  This change stops the parsing of Go files once it detects that the context has been canceled.  When a file has not been processed due to cancelation, its error will be set to that of the context.
    
This change dramatically improves the performance of the `stamblerre/gocode` fork when requests have been canceled.