### PR TITLE
cmd/gopls/forward: use select instead of empty for

### DIFF
--- a/cmd/gopls/forward/main.go
+++ b/cmd/gopls/forward/main.go
@@ -54,6 +54,6 @@ func (a *app) Run(ctx context.Context, args ...string) error {
 		}
 	}(conn)
 
-	for {
+	select {
 	}
 }


### PR DESCRIPTION
An empty for loop body results in a CPU spinning at 100% CPU.

`select {}` is more friendly to battery life.

/cc @stamblerre 