### PR TITLE
go/analysis/internal/checker: don't clobber fact when codeFact fails

### DIFF
--- a/go/analysis/internal/checker/checker.go
+++ b/go/analysis/internal/checker/checker.go
@@ -545,11 +545,11 @@ func inheritFacts(act, dep *action) {
 		// Optionally serialize/deserialize fact
 		// to verify that it works across address spaces.
 		if serialize {
-			var err error
-			fact, err = codeFact(fact)
+			encodedFact, err := codeFact(fact)
 			if err != nil {
 				log.Panicf("internal error: encoding of %T fact failed in %v", fact, act)
 			}
+			fact = encodedFact
 		}
 
 		if false {
@@ -567,11 +567,11 @@ func inheritFacts(act, dep *action) {
 		// to verify that it works across address spaces
 		// and is deterministic.
 		if serialize {
-			var err error
-			fact, err = codeFact(fact)
+			encodedFact, err := codeFact(fact)
 			if err != nil {
 				log.Panicf("internal error: encoding of %T fact failed in %v", fact, act)
 			}
+			fact = encodedFact
 		}
 
 		if false {


### PR DESCRIPTION
`codeFact` returns `nil, err` on errors, which results in error messages like:

    panic: internal error: encoding of nil fact failed in [analyzer]

Though that and the stacktrace are often enough to identify the cause, the nil
hides the actual source of the problem.