### PR TITLE
internal/lsp: get the correct symbol kind for the type alias and type definition

### DIFF
--- a/internal/lsp/symbols.go
+++ b/internal/lsp/symbols.go
@@ -31,20 +31,28 @@ func toProtocolDocumentSymbols(m *protocol.ColumnMapper, symbols []source.Symbol
 
 func toProtocolSymbolKind(kind source.SymbolKind) protocol.SymbolKind {
 	switch kind {
-	case source.StructSymbol:
-		return protocol.Struct
 	case source.PackageSymbol:
 		return protocol.Package
-	case source.VariableSymbol:
-		return protocol.Variable
-	case source.ConstantSymbol:
-		return protocol.Constant
-	case source.FunctionSymbol:
-		return protocol.Function
 	case source.MethodSymbol:
 		return protocol.Method
 	case source.InterfaceSymbol:
 		return protocol.Interface
+	case source.VariableSymbol:
+		return protocol.Variable
+	case source.ConstantSymbol:
+		return protocol.Constant
+	case source.StringSymbol:
+		return protocol.String
+	case source.NumberSymbol:
+		return protocol.Number
+	case source.BooleanSymbol:
+		return protocol.Boolean
+	case source.ArraySymbol:
+		return protocol.Array
+	case source.FunctionSymbol:
+		return protocol.Function
+	case source.StructSymbol:
+		return protocol.Struct
 	default:
 		return 0
 	}

--- a/internal/lsp/testdata/symbols/main.go
+++ b/internal/lsp/testdata/symbols/main.go
@@ -25,3 +25,33 @@ func main() { //@symbol("main", "main", 12)
 type Stringer interface { //@symbol("Stringer", "Stringer", 11)
 	String() string
 }
+
+type struct_alias = Foo //@symbol("struct_alias", "struct_alias", 23)
+type struct_tydef Foo   //@symbol("struct_tydef", "struct_tydef", 23)
+
+type interface_alias = Stringer //@symbol("interface_alias", "interface_alias", 11)
+type interface_tydef Stringer   //@symbol("interface_tydef", "interface_tydef", 11)
+
+type int_basic_alias = int //@symbol("int_basic_alias", "int_basic_alias", 16)
+type int_tydef int         //@symbol("int_tydef", "int_tydef", 16)
+
+type float_basic_alias = float64 //@symbol("float_basic_alias", "float_basic_alias", 16)
+type float_basic_tydef float64   //@symbol("float_basic_tydef", "float_basic_tydef", 16)
+
+type bool_basic_alias = bool //@symbol("bool_basic_alias", "bool_basic_alias", 17)
+type bool_basic_tydef bool   //@symbol("bool_basic_tydef", "bool_basic_tydef", 17)
+
+type string_basic_alias = string //@symbol("string_basic_alias", "string_basic_alias", 15)
+type string_basic_tydef string   //@symbol("string_basic_tydef", "string_basic_tydef", 15)
+
+type int_slice_alias = []int //@symbol("int_slice_alias", "int_slice_alias", 18)
+type int_slice_tydef = []int //@symbol("int_slice_tydef", "int_slice_tydef", 18)
+
+type string_slice_alias = []string //@symbol("string_slice_alias", "string_slice_alias", 18)
+type string_slice_tydef = []string //@symbol("string_slice_tydef", "string_slice_tydef", 18)
+
+type int_array_alias = []int //@symbol("int_array_alias", "int_array_alias", 18)
+type int_array_tydef = []int //@symbol("int_array_tydef", "int_array_tydef", 18)
+
+type string_array_alias = []string //@symbol("string_array_alias", "string_array_alias", 18)
+type string_array_tydef = []string //@symbol("string_array_tydef", "string_array_tydef", 18)


### PR DESCRIPTION
For the original implementation, there are just two symbol
kinds, `StructSymbol` and `InterfaceSymbol`. And it won't 
take the essential type into account. Like the code bellow, 
the symbol kind of `alias` will be `StructSymbol`, that's not 
correct. BTW, there is no corresponding symbol kind to the 
type alias.
```go
type Node interface{}

type alias = Node
```

This patch consider the essential type to give a more precise 
result of the symbol kind.