### PR TITLE
internal/lsp: improve signatureHelp in various cases

### DIFF
--- a/internal/lsp/lsp_test.go
+++ b/internal/lsp/lsp_test.go
@@ -44,6 +44,7 @@ func testLSP(t *testing.T, exporter packagestest.Exporter) {
 	const expectedTypeDefinitionsCount = 2
 	const expectedHighlightsCount = 2
 	const expectedSymbolsCount = 1
+	const expectedSignaturesCount = 19
 
 	files := packagestest.MustCopyFileTree(dir)
 	for fragment, operation := range files {
@@ -73,6 +74,7 @@ func testLSP(t *testing.T, exporter packagestest.Exporter) {
 	s := &Server{
 		views:       []*cache.View{cache.NewView(ctx, log, "lsp_test", span.FileURI(cfg.Dir), &cfg)},
 		undelivered: make(map[span.URI][]source.Diagnostic),
+		log:         log,
 	}
 	// Do a first pass to collect special markers for completion.
 	if err := exported.Expect(map[string]interface{}{
@@ -94,6 +96,7 @@ func testLSP(t *testing.T, exporter packagestest.Exporter) {
 		m:        make(map[span.URI][]protocol.DocumentSymbol),
 		children: make(map[string][]protocol.DocumentSymbol),
 	}
+	expectedSignatures := make(signatures)
 
 	// Collect any data that needs to be used by subsequent tests.
 	if err := exported.Expect(map[string]interface{}{
@@ -105,6 +108,7 @@ func testLSP(t *testing.T, exporter packagestest.Exporter) {
 		"typdef":    expectedTypeDefinitions.collect,
 		"highlight": expectedHighlights.collect,
 		"symbol":    expectedSymbols.collect,
+		"signature": expectedSignatures.collect,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -172,6 +176,14 @@ func testLSP(t *testing.T, exporter packagestest.Exporter) {
 		}
 		expectedSymbols.test(t, s)
 	})
+
+	t.Run("Signatures", func(t *testing.T) {
+		t.Helper()
+		if len(expectedSignatures) != expectedSignaturesCount {
+			t.Errorf("got %v signatures expected %v", len(expectedSignatures), expectedSignaturesCount)
+		}
+		expectedSignatures.test(t, s)
+	})
 }
 
 type diagnostics map[span.URI][]protocol.Diagnostic
@@ -184,6 +196,7 @@ type symbols struct {
 	m        map[span.URI][]protocol.DocumentSymbol
 	children map[string][]protocol.DocumentSymbol
 }
+type signatures map[token.Position]*protocol.SignatureHelp
 
 func (d diagnostics) test(t *testing.T, v source.View) int {
 	count := 0
@@ -603,6 +616,72 @@ func (s symbols) test(t *testing.T, server *Server) {
 			expectedSymbols[i].Children = children
 		}
 		if diff := diffSymbols(uri, expectedSymbols, symbols); diff != "" {
+			t.Error(diff)
+		}
+	}
+}
+
+func (s signatures) collect(src token.Position, signature string, activeParam int64) {
+	s[src] = &protocol.SignatureHelp{
+		Signatures:      []protocol.SignatureInformation{{Label: signature}},
+		ActiveSignature: 0,
+		ActiveParameter: float64(activeParam),
+	}
+}
+
+func diffSignatures(src token.Position, want, got *protocol.SignatureHelp) string {
+	decorate := func(f string, args ...interface{}) string {
+		return fmt.Sprintf("Invalid signature at %s: %s", src, fmt.Sprintf(f, args...))
+	}
+
+	if lw, lg := len(want.Signatures), len(got.Signatures); lw != lg {
+		return decorate("wanted %d signatures, got %d", lw, lg)
+	}
+
+	if want.ActiveSignature != got.ActiveSignature {
+		return decorate("wanted active signature of %f, got %f", want.ActiveSignature, got.ActiveSignature)
+	}
+
+	if want.ActiveParameter != got.ActiveParameter {
+		return decorate("wanted active parameter of %f, got %f", want.ActiveParameter, got.ActiveParameter)
+	}
+
+	for i := range want.Signatures {
+		wantSig, gotSig := want.Signatures[i], got.Signatures[i]
+
+		if wantSig.Label != gotSig.Label {
+			return decorate("wanted label %q, got %q", wantSig.Label, gotSig.Label)
+		}
+
+		var paramParts []string
+		for _, p := range gotSig.Parameters {
+			paramParts = append(paramParts, p.Label)
+		}
+		paramsStr := strings.Join(paramParts, ", ")
+		if !strings.Contains(gotSig.Label, paramsStr) {
+			return decorate("expected signature %q to contain params %q", gotSig.Label, paramsStr)
+		}
+	}
+
+	return ""
+}
+
+func (s signatures) test(t *testing.T, server *Server) {
+	for src, expectedSignatures := range s {
+		gotSignatures, err := server.SignatureHelp(context.Background(), &protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{
+				URI: protocol.NewURI(span.FileURI(src.Filename)),
+			},
+			Position: protocol.Position{
+				Line:      float64(src.Line - 1),
+				Character: float64(src.Column - 1),
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if diff := diffSignatures(src, expectedSignatures, gotSignatures); diff != "" {
 			t.Error(diff)
 		}
 	}

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -395,7 +395,7 @@ func (s *Server) SignatureHelp(ctx context.Context, params *protocol.TextDocumen
 	}
 	info, err := source.SignatureHelp(ctx, f, rng.Start)
 	if err != nil {
-		s.log.Infof(ctx, "no signature help for %s:%v:%v", uri, int(params.Position.Line), int(params.Position.Character))
+		s.log.Infof(ctx, "no signature help for %s:%v:%v : %s", uri, int(params.Position.Line), int(params.Position.Character), err)
 	}
 	return toProtocolSignatureHelp(info), nil
 }

--- a/internal/lsp/source/completion.go
+++ b/internal/lsp/source/completion.go
@@ -508,7 +508,11 @@ func formatParams(t *types.Tuple, variadic bool, qualifier types.Qualifier) stri
 		if variadic && i == t.Len()-1 {
 			typ = strings.Replace(typ, "[]", "...", 1)
 		}
-		fmt.Fprintf(&b, "%v %v", el.Name(), typ)
+		if el.Name() == "" {
+			fmt.Fprintf(&b, "%v", typ)
+		} else {
+			fmt.Fprintf(&b, "%v %v", el.Name(), typ)
+		}
 	}
 	b.WriteByte(')')
 	return b.String()

--- a/internal/lsp/testdata/signature/signature.go
+++ b/internal/lsp/testdata/signature/signature.go
@@ -1,0 +1,61 @@
+package signature
+
+import (
+	"bytes"
+	"encoding/json"
+	"math/big"
+)
+
+func Foo(a string, b int) (c bool) {
+	return
+}
+
+func Bar(float64, ...byte) {
+}
+
+type myStruct struct{}
+
+func (*myStruct) foo(e *json.Decoder) (*big.Int, error) {
+	return nil, nil
+}
+
+type MyFunc func(foo int) string
+
+func Qux() {
+	Foo("foo", 123) //@signature("(", "Foo(a string, b int) (c bool)", 2)
+	Foo("foo", 123) //@signature("123", "Foo(a string, b int) (c bool)", 1)
+	Foo("foo", 123) //@signature(",", "Foo(a string, b int) (c bool)", 0)
+	Foo("foo", 123) //@signature(" 1", "Foo(a string, b int) (c bool)", 1)
+	Foo("foo", 123) //@signature(")", "Foo(a string, b int) (c bool)", 1)
+
+	Bar(13.37, 0x1337)     //@signature("13.37", "Bar(float64, ...byte)", 0)
+	Bar(13.37, 0x1337)     //@signature("0x1337", "Bar(float64, ...byte)", 1)
+	Bar(13.37, 1, 2, 3, 4) //@signature("4", "Bar(float64, ...byte)", 1)
+
+	fn := func(hi, there string) func(i int) rune {
+		return 0
+	}
+
+	fn("hi", "there")    //@signature("hi", "fn(hi string, there string) func(i int) rune", 0)
+	fn("hi", "there")(1) //@signature("1", "func(i int) rune", 0)
+
+	fnPtr := &fn
+	(*fnPtr)("hi", "there") //@signature("hi", "func(hi string, there string) func(i int) rune", 0)
+
+	var fnIntf interface{} = Foo
+	fnIntf.(func(string, int) bool)("hi", 123) //@signature("123", "func(string, int) bool", 1)
+
+	(&bytes.Buffer{}).Next(2) //@signature("2", "Next(n int) []byte", 0)
+
+	myFunc := MyFunc(func(n int) string { return "" })
+	myFunc(123) //@signature("123", "myFunc(foo int) string", 0)
+
+	var ms myStruct
+	ms.foo(nil) //@signature("nil", "foo(e *json.Decoder) (*big.Int, error)", 0)
+
+	panic("oops!")    //@signature("oops", "panic(interface{})", 0)
+	make([]int, 1, 2) //@signature("2", "make([]int, int, int) []int", 2)
+
+	Foo(myFunc(123), 456) //@signature("myFunc", "Foo(a string, b int) (c bool)", 0)
+	Foo(myFunc(123), 456) //@signature("123", "myFunc(foo int) string", 0)
+}

--- a/internal/span/token.go
+++ b/internal/span/token.go
@@ -19,8 +19,8 @@ type Range struct {
 }
 
 // TokenConverter is a Converter backed by a token file set and file.
-// It uses the file set methods to work out determine the conversions which
-// make if fast and do not require the file contents.
+// It uses the file set methods to work out the conversions, which
+// makes it fast and does not require the file contents.
 type TokenConverter struct {
 	fset *token.FileSet
 	file *token.File


### PR DESCRIPTION
- show signature for function calls whose function expression is not
  an object (e.g. the second call in foo()()). since the function name
  is not available, we use the generic "func"
- only provide signature help when the position is on or within the
  call expression parens. this is consistent with the one other lsp
  server i tried (java). this improves the gopls experience in emacs
  where lsp-mode is constantly calling "hover" and
  "signatureHelp" ("hover" should be preferred unless you are inside
  the function params list)
- use the entire signature type string as the label since that includes
  the return values, which are useful to see
- don't qualify the function name with its package. it looks funny to
  see "bytes.Cap()" as the help when you are in a call
  to (*bytes.Buffer).Cap(). it could be useful to include invocant
  type info, but leave it out for now since signature help is meant to
  focus on the function parameters.
- don't turn variadic args "foo ...int" into "foo []int" for the
  parameter information (i.e. maintain it as "foo ...int")
- when determining active parameter, count the space before a
  parameter name as being part of that parameter (e.g. the space
  before "b" in "func(a int, b int)")
- handle variadic params when determining the active param (i.e.
  highlight "foo(a int, *b ...string*)" on signature help for final
  param in `foo(123, "a", "b", "c")`
- don't generate an extra space in formatParams() for unnamed
  arguments

I also tweaked the signatureHelp server log message to include the
error message itself, and populated the server's logger in lsp_test.go
to aid in development.

Fixes golang/go#31448