### PR TITLE
internal/lsp: fix query cmd usage

### DIFF
--- a/internal/lsp/cmd/query.go
+++ b/internal/lsp/cmd/query.go
@@ -30,7 +30,7 @@ type query struct {
 }
 
 func (q *query) Name() string  { return "query" }
-func (q *query) Usage() string { return "query [flags] <mode> <mode args>" }
+func (q *query) Usage() string { return "<mode> <mode args>" }
 func (q *query) ShortHelp() string {
 	return "answer queries about go source code"
 }


### PR DESCRIPTION
`query` usage has the following duplicated description.

```
Usage: query [flags] query [flags] <mode> <mode args>
```

```
$ gopls query
query: query must be supplied a mode
answer queries about go source code

Usage: query [flags] query [flags] <mode> <mode args>

The mode argument determines the query to perform:
  definition : show declaration of selected identifier

query flags are:
  -emulate string
        compatibility mode, causes gopls to emulate another tool.
        values depend on the operation being performed
  -json
        emit output in JSON format
```