### PR TITLE
internal/lsp: suppress more completions in comments and literals

### DIFF
--- a/internal/lsp/testdata/bar/bar.go.in
+++ b/internal/lsp/testdata/bar/bar.go.in
@@ -38,7 +38,7 @@ func _() {
 		Value: Valen //@complete("le", Valentine)
 	}
 	_ = foo.StructFoo{
-		Value:       //@complete(re"$", Valentine, foo, Bar, helper)
+		Value:       //@complete(" //", Valentine, foo, Bar, helper)
 	}
 	_ = foo.StructFoo{
 		Value:       //@complete(" ", Valentine, foo, Bar, helper)

--- a/internal/lsp/testdata/basiclit/basiclit.go
+++ b/internal/lsp/testdata/basiclit/basiclit.go
@@ -1,0 +1,13 @@
+package basiclit
+
+func _() {
+	var a int // something for lexical completions
+
+	_ = "hello." //@complete(".")
+
+	_ = 1 //@complete(" //")
+
+	_ = 1. //@complete(".")
+
+	_ = 'a' //@complete("' ")
+}

--- a/internal/lsp/testdata/baz/baz.go.in
+++ b/internal/lsp/testdata/baz/baz.go.in
@@ -18,10 +18,10 @@ func Baz() {
 
 func _() {
 	bob := f.StructFoo{Value: 5}
-	if x := bob.           //@complete(re"$", Value)
+	if x := bob.           //@complete(" //", Value)
 	switch true == false {
 		case true:
-			if x := bob.   //@complete(re"$", Value)
+			if x := bob.   //@complete(" //", Value)
 		case false:
 	}
 	if x := bob.Va         //@complete("a", Value)

--- a/internal/lsp/testdata/comments/comments.go
+++ b/internal/lsp/testdata/comments/comments.go
@@ -1,0 +1,27 @@
+package comments
+
+var p bool
+
+//@complete(re"$")
+
+func _() {
+	var a int
+
+	switch a {
+	case 1:
+		//@complete(re"$")
+		_ = a
+	}
+
+	var b chan int
+	select {
+	case <-b:
+		//@complete(re"$")
+		_ = b
+	}
+
+	var (
+		//@complete(re"$")
+		_ = a
+	)
+}

--- a/internal/lsp/testdata/stringlit/stringlit.go.in
+++ b/internal/lsp/testdata/stringlit/stringlit.go.in
@@ -1,5 +1,0 @@
-package stringlit
-
-func _() {
-	_ := "hello." //@complete(".")
-}

--- a/internal/lsp/tests/tests.go
+++ b/internal/lsp/tests/tests.go
@@ -27,7 +27,7 @@ import (
 // We hardcode the expected number of test cases to ensure that all tests
 // are being executed. If a test is added, this number must be changed.
 const (
-	ExpectedCompletionsCount     = 75
+	ExpectedCompletionsCount     = 82
 	ExpectedDiagnosticsCount     = 16
 	ExpectedFormatCount          = 4
 	ExpectedDefinitionsCount     = 21


### PR DESCRIPTION
Completion suppression in comments wasn't working for comments in
switch case statements, select case statements, and decl statements.
Rather than adding those to the list of leaf ast.Node types to look
for, we now always check if the position is in a comment. This fix
broke some completion tests that were using re"$" since "$" matches
after the comment "//" characters.

We now also don't complete within any literal values. Previously we
only excluded string literals.