### PR TITLE
internal/lsp: add struct literal field snippets

### DIFF
--- a/internal/lsp/cmd/cmd_test.go
+++ b/internal/lsp/cmd/cmd_test.go
@@ -38,7 +38,7 @@ func testCommandLine(t *testing.T, exporter packagestest.Exporter) {
 	tests.Run(t, r, data)
 }
 
-func (r *runner) Completion(t *testing.T, data tests.Completions, items tests.CompletionItems) {
+func (r *runner) Completion(t *testing.T, data tests.Completions, snippets tests.CompletionSnippets, items tests.CompletionItems) {
 	//TODO: add command line completions tests when it works
 }
 

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -5,7 +5,6 @@
 package lsp
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"sort"
@@ -52,10 +51,25 @@ func toProtocolCompletionItems(candidates []source.CompletionItem, prefix string
 		if !strings.HasPrefix(candidate.Label, prefix) {
 			continue
 		}
-		insertText := labelToInsertText(candidate.Label, candidate.Kind, insertTextFormat, usePlaceholders)
+
+		insertText := candidate.Insert
+		if insertTextFormat == protocol.SnippetTextFormat {
+			if usePlaceholders && candidate.PlaceholderSnippet != nil {
+				insertText = candidate.PlaceholderSnippet.String()
+			} else if candidate.PlainSnippet != nil {
+				insertText = candidate.PlainSnippet.String()
+			}
+		}
+
 		if strings.HasPrefix(insertText, prefix) {
 			insertText = insertText[len(prefix):]
 		}
+
+		filterText := candidate.Insert
+		if strings.HasPrefix(filterText, prefix) {
+			filterText = filterText[len(prefix):]
+		}
+
 		item := protocol.CompletionItem{
 			Label:  candidate.Label,
 			Detail: candidate.Detail,
@@ -72,7 +86,7 @@ func toProtocolCompletionItems(candidates []source.CompletionItem, prefix string
 			// according to their score. This can be removed upon the resolution of
 			// https://github.com/Microsoft/language-server-protocol/issues/348.
 			SortText:   fmt.Sprintf("%05d", i),
-			FilterText: insertText,
+			FilterText: filterText,
 			Preselect:  i == 0,
 		}
 		// Trigger signature help for any function or method completion.
@@ -112,54 +126,4 @@ func toProtocolCompletionItemKind(kind source.CompletionItemKind) protocol.Compl
 	default:
 		return protocol.TextCompletion
 	}
-}
-
-func labelToInsertText(label string, kind source.CompletionItemKind, insertTextFormat protocol.InsertTextFormat, usePlaceholders bool) string {
-	switch kind {
-	case source.ConstantCompletionItem:
-		// The label for constants is of the format "<identifier> = <value>".
-		// We should not insert the " = <value>" part of the label.
-		if i := strings.Index(label, " ="); i >= 0 {
-			return label[:i]
-		}
-	case source.FunctionCompletionItem, source.MethodCompletionItem:
-		var trimmed, params string
-		if i := strings.Index(label, "("); i >= 0 {
-			trimmed = label[:i]
-			params = strings.Trim(label[i:], "()")
-		}
-		if params == "" || trimmed == "" {
-			return label
-		}
-		// Don't add parameters or parens for the plaintext insert format.
-		if insertTextFormat == protocol.PlainTextTextFormat {
-			return trimmed
-		}
-		// If we don't want to use placeholders, just add 2 parentheses with
-		// the cursor in the middle.
-		if !usePlaceholders {
-			return trimmed + "($1)"
-		}
-		// If signature help is not enabled, we should give the user parameters
-		// that they can tab through. The insert text format follows the
-		// specification defined by Microsoft for LSP. The "$", "}, and "\"
-		// characters should be escaped.
-		r := strings.NewReplacer(
-			`\`, `\\`,
-			`}`, `\}`,
-			`$`, `\$`,
-		)
-		b := bytes.NewBufferString(trimmed)
-		b.WriteByte('(')
-		for i, p := range strings.Split(params, ",") {
-			if i != 0 {
-				b.WriteString(", ")
-			}
-			fmt.Fprintf(b, "${%v:%v}", i+1, r.Replace(strings.TrimSpace(p)))
-		}
-		b.WriteByte(')')
-		return b.String()
-
-	}
-	return label
 }

--- a/internal/lsp/lsp_test.go
+++ b/internal/lsp/lsp_test.go
@@ -130,26 +130,15 @@ func summarizeDiagnostics(i int, want []source.Diagnostic, got []source.Diagnost
 	return msg.String()
 }
 
-func (r *runner) Completion(t *testing.T, data tests.Completions, items tests.CompletionItems) {
+func (r *runner) Completion(t *testing.T, data tests.Completions, snippets tests.CompletionSnippets, items tests.CompletionItems) {
 	for src, itemList := range data {
 		var want []source.CompletionItem
 		for _, pos := range itemList {
 			want = append(want, *items[pos])
 		}
-		list, err := r.server.Completion(context.Background(), &protocol.CompletionParams{
-			TextDocumentPositionParams: protocol.TextDocumentPositionParams{
-				TextDocument: protocol.TextDocumentIdentifier{
-					URI: protocol.NewURI(src.URI()),
-				},
-				Position: protocol.Position{
-					Line:      float64(src.Start().Line() - 1),
-					Character: float64(src.Start().Column() - 1),
-				},
-			},
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
+
+		list := r.runCompletion(t, src)
+
 		wantBuiltins := strings.Contains(string(src.URI()), "builtins")
 		var got []protocol.CompletionItem
 		for _, item := range list.Items {
@@ -158,30 +147,79 @@ func (r *runner) Completion(t *testing.T, data tests.Completions, items tests.Co
 			}
 			got = append(got, item)
 		}
-		if err != nil {
-			t.Fatalf("completion failed for %v: %v", src, err)
-		}
 		if diff := diffCompletionItems(t, src, want, got); diff != "" {
 			t.Errorf("%s: %s", src, diff)
 		}
 	}
 	// Make sure we don't crash completing the first position in file set.
-	firstFile := r.data.Config.Fset.Position(1).Filename
+	firstPos, err := span.NewRange(r.data.Exported.ExpectFileSet, 1, 2).Span()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = r.runCompletion(t, firstPos)
 
-	_, err := r.server.Completion(context.Background(), &protocol.CompletionParams{
+	r.checkCompletionSnippets(t, snippets, items)
+}
+
+func (r *runner) checkCompletionSnippets(t *testing.T, data tests.CompletionSnippets, items tests.CompletionItems) {
+	origPlaceHolders := r.server.usePlaceholders
+	origTextFormat := r.server.insertTextFormat
+	defer func() {
+		r.server.usePlaceholders = origPlaceHolders
+		r.server.insertTextFormat = origTextFormat
+	}()
+
+	r.server.insertTextFormat = protocol.SnippetTextFormat
+	for _, usePlaceholders := range []bool{true, false} {
+		r.server.usePlaceholders = usePlaceholders
+
+		for src, want := range data {
+			list := r.runCompletion(t, src)
+
+			wantCompletion := items[want.CompletionItem]
+			var gotItem *protocol.CompletionItem
+			for _, item := range list.Items {
+				if item.Label == wantCompletion.Label {
+					gotItem = &item
+					break
+				}
+			}
+
+			if gotItem == nil {
+				t.Fatalf("%s: couldn't find completion matching %q", src.URI(), wantCompletion.Label)
+			}
+
+			var expected string
+			if usePlaceholders {
+				expected = want.PlaceholderSnippet
+			} else {
+				expected = want.PlainSnippet
+			}
+
+			if expected != gotItem.TextEdit.NewText {
+				t.Errorf("%s: expected snippet %q, got %q", src, expected, gotItem.TextEdit.NewText)
+			}
+		}
+	}
+}
+
+func (r *runner) runCompletion(t *testing.T, src span.Span) *protocol.CompletionList {
+	t.Helper()
+	list, err := r.server.Completion(context.Background(), &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
 			TextDocument: protocol.TextDocumentIdentifier{
-				URI: protocol.NewURI(span.FileURI(firstFile)),
+				URI: protocol.NewURI(src.URI()),
 			},
 			Position: protocol.Position{
-				Line:      0,
-				Character: 0,
+				Line:      float64(src.Start().Line() - 1),
+				Character: float64(src.Start().Column() - 1),
 			},
 		},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
+	return list
 }
 
 func isBuiltin(item protocol.CompletionItem) bool {

--- a/internal/lsp/source/completion_snippet.go
+++ b/internal/lsp/source/completion_snippet.go
@@ -1,0 +1,100 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package source
+
+import (
+	"go/ast"
+
+	"golang.org/x/tools/internal/lsp/snippet"
+)
+
+// structField calculates the plain and placeholder snippets for struct literal
+// field names as in "Foo{Ba<>".
+func (c *completer) structFieldSnippet(label, detail string) (*snippet.Builder, *snippet.Builder) {
+	if !c.inCompositeLiteralField {
+		return nil, nil
+	}
+
+	cl := c.enclosingCompositeLiteral
+	kv := c.enclosingKeyValue
+
+	// If we aren't in a composite literal or are already in a key/value
+	// expression, we don't want a snippet.
+	if cl == nil || kv != nil {
+		return nil, nil
+	}
+
+	if len(cl.Elts) > 0 {
+		i := indexExprAtPos(c.pos, cl.Elts)
+		if i >= len(cl.Elts) {
+			return nil, nil
+		}
+
+		// If our expression is not an identifer, we know it isn't a
+		// struct field name.
+		if _, ok := cl.Elts[i].(*ast.Ident); !ok {
+			return nil, nil
+		}
+	}
+
+	// It is a multi-line literal if pos is not on the same line as the literal's
+	// opening brace.
+	multiLine := c.fset.Position(c.pos).Line != c.fset.Position(cl.Lbrace).Line
+
+	// Plain snippet will turn "Foo{Ba<>" into "Foo{Bar: <>"
+	plain := &snippet.Builder{}
+	plain.WriteText(label + ": ")
+	plain.WritePlaceholder(nil)
+	if multiLine {
+		plain.WriteText(",")
+	}
+
+	// Placeholder snippet will turn "Foo{Ba<>" into "Foo{Bar: *int*"
+	placeholder := &snippet.Builder{}
+	placeholder.WriteText(label + ": ")
+	placeholder.WritePlaceholder(func(b *snippet.Builder) {
+		b.WriteText(detail)
+	})
+	if multiLine {
+		placeholder.WriteText(",")
+	}
+
+	return plain, placeholder
+}
+
+// funcCall calculates the plain and placeholder snippets for function calls.
+func (c *completer) funcCallSnippet(funcName string, params []string) (*snippet.Builder, *snippet.Builder) {
+	for i := 1; i <= 2 && i < len(c.path); i++ {
+		call, ok := c.path[i].(*ast.CallExpr)
+		// If we are the left side (i.e. "Fun") part of a call expression,
+		// we don't want a snippet since there are already parens present.
+		if ok && call.Fun == c.path[i-1] {
+			return nil, nil
+		}
+	}
+
+	// Plain snippet turns "someFun<>" into "someFunc(<>)"
+	plain := &snippet.Builder{}
+	plain.WriteText(funcName + "(")
+	if len(params) > 0 {
+		plain.WritePlaceholder(nil)
+	}
+	plain.WriteText(")")
+
+	// Placeholder snippet turns "someFun<>" into "someFunc(*i int*, s string)"
+	placeholder := &snippet.Builder{}
+	placeholder.WriteText(funcName + "(")
+	for i, p := range params {
+		if i > 0 {
+			placeholder.WriteText(", ")
+		}
+		placeholder.WritePlaceholder(func(b *snippet.Builder) {
+			b.WriteText(p)
+		})
+	}
+	placeholder.WriteText(")")
+
+	return plain, placeholder
+}

--- a/internal/lsp/testdata/snippets/snippets.go
+++ b/internal/lsp/testdata/snippets/snippets.go
@@ -1,0 +1,30 @@
+package snippets
+
+func foo(i int, b bool) {} //@item(snipFoo, "foo(i int, b bool)", "", "func")
+func bar(fn func()) func()    {} //@item(snipBar, "bar(fn func())", "", "func")
+
+type Foo struct {
+	Bar int //@item(snipFieldBar, "Bar", "int", "field")
+}
+
+func (Foo) Baz() func() {} //@item(snipMethodBaz, "Baz()", "func()", "field")
+
+func _() {
+	f //@snippet(" //", snipFoo, "oo(${1})", "oo(${1:i int}, ${2:b bool})")
+
+	bar //@snippet(" //", snipBar, "(${1})", "(${1:fn func()})")
+
+	bar(nil) //@snippet("(", snipBar, "", "")
+	bar(ba) //@snippet(")", snipBar, "r(${1})", "r(${1:fn func()})")
+	var f Foo
+	bar(f.Ba) //@snippet(")", snipMethodBaz, "z()", "z()")
+
+	Foo{
+		B //@snippet(" //", snipFieldBar, "ar: ${1},", "ar: ${1:int},")
+	}
+
+	Foo{B} //@snippet("}", snipFieldBar, "ar: ${1}", "ar: ${1:int}")
+	Foo{} //@snippet("}", snipFieldBar, "Bar: ${1}", "Bar: ${1:int}")
+
+	Foo{Foo{}.B} //@snippet("} ", snipFieldBar, "ar", "ar")
+}


### PR DESCRIPTION
Now when you accept a struct literal field name completion, you will
get a snippet that includes the colon, a tab stop, and a comma if
the literal is multi-line. If you have "gopls.usePlaceholders"
enabled, you will get a placeholder with the field's type as well.

I pushed snippet generation into the "source" package so ast and type
info is available. This allows for smarter, more context aware snippet
generation. For example, this let me fix an issue with the function
snippets where "foo<>()" was completing to "foo(<>)()". Now we don't
add the function call snippet if the position is already in a CallExpr.

I also added a new "Insert" field to CompletionItem to store the plain
object name. This way, we don't have to undo label decorations when
generating the insert text for the completion response. I also changed
"filterText" to use this "Insert" field since you don't want the
filter text to include the extra label decorations.

Fixes golang/go#31556