### PR TITLE
internal/lsp: improve expected type determination

### DIFF
--- a/internal/lsp/testdata/complit/complit.go.in
+++ b/internal/lsp/testdata/complit/complit.go.in
@@ -44,6 +44,7 @@ func _() {
 	}
 	_ = map[int]string{1: "" + s.A} //@complete("}", fieldAB, fieldAA)
 	_ = map[int]string{1: (func(i int) string { return "" })(s.A)} //@complete(")}", fieldAA, fieldAB)
+	_ = map[int]string{1: func() string { s.A }} //@complete(" }", fieldAA, fieldAB)
 }
 
 func _() {

--- a/internal/lsp/testdata/func_rank/func_rank.go.in
+++ b/internal/lsp/testdata/func_rank/func_rank.go.in
@@ -1,8 +1,8 @@
 package func_rank
 
-var stringAVar = "var" //@item(stringAVar, "stringAVar", "string", "var")
+var stringAVar = "var"    //@item(stringAVar, "stringAVar", "string", "var")
 func stringBFunc() string { return "str" } //@item(stringBFunc, "stringBFunc()", "string", "func")
-type stringer struct{}   //@item(stringer, "stringer", "struct{...}", "struct")
+type stringer struct{}    //@item(stringer, "stringer", "struct{...}", "struct")
 
 func _() stringer //@complete("tr", stringer, stringAVar, stringBFunc)
 
@@ -10,3 +10,35 @@ func _(val stringer) {} //@complete("tr", stringer, stringAVar, stringBFunc)
 
 func (stringer) _() {} //@complete("tr", stringer, stringAVar, stringBFunc)
 
+func _() {
+	var s struct {
+		AA int    //@item(rankAA, "AA", "int", "field")
+		AB string //@item(rankAB, "AB", "string", "field")
+		AC int    //@item(rankAC, "AC", "int", "field")
+	}
+	fnStr := func(string) {}
+	fnStr(s.A)      //@complete(")", rankAB, rankAA, rankAC)
+	fnStr("" + s.A) //@complete(")", rankAB, rankAA, rankAC)
+
+	fnInt := func(int) {}
+	fnInt(-s.A) //@complete(")", rankAA, rankAC, rankAB)
+
+	// no expected type
+	fnInt(func() int { s.A }) //@complete(" }", rankAA, rankAB, rankAC)
+	fnInt(s.A())              //@complete("()", rankAA, rankAB, rankAC)
+	fnInt([]int{}[s.A])       //@complete("])", rankAA, rankAB, rankAC)
+	fnInt([]int{}[:s.A])      //@complete("])", rankAA, rankAB, rankAC)
+
+	fnInt(s.A.(int)) //@complete(".(", rankAA, rankAB, rankAC)
+
+	fnPtr := func(*string) {}
+	fnPtr(&s.A) //@complete(")", rankAB, rankAA, rankAC)
+
+	var aaPtr *string //@item(rankAAPtr, "aaPtr", "*string", "var")
+	var abPtr *int    //@item(rankABPtr, "abPtr", "*int", "var")
+	fnInt(*a)         //@complete(")", rankABPtr, rankAAPtr)
+
+	_ = func() string {
+		return s.A //@complete(" //", rankAB, rankAA, rankAC)
+	}
+}

--- a/internal/lsp/tests/tests.go
+++ b/internal/lsp/tests/tests.go
@@ -28,7 +28,7 @@ import (
 // We hardcode the expected number of test cases to ensure that all tests
 // are being executed. If a test is added, this number must be changed.
 const (
-	ExpectedCompletionsCount       = 85
+	ExpectedCompletionsCount       = 97
 	ExpectedDiagnosticsCount       = 17
 	ExpectedFormatCount            = 5
 	ExpectedDefinitionsCount       = 21


### PR DESCRIPTION
Improve expected type determination for the following cases:

- search back further through ast path to handle cases where the
  position's node is more than two nodes from the ancestor node with
  type information
- generate expected type for return statements
- wrap and unwrap pointerness from expected type when position is
  preceded by "*" (dereference) or "&" (reference) operators,
  respectively
- fix some false positive expected types when completing the "Fun"
  (left) side of a CallExpr