### PR TITLE
Add support for %param

### DIFF
--- a/cmd/goyacc/doc.go
+++ b/cmd/goyacc/doc.go
@@ -52,6 +52,12 @@ returns a yyParser conforming to the following interface:
 Parse runs the parser; the top-level call yyParse(yylex) is equivalent
 to yyNewParser().Parse(yylex).
 
+The receiver for Parse(yylex) is of type yyParserImpl. It is possible
+to add fields to this struct by use of the "%param" command, each
+invocation adding a single field (thus performing an idiomatic
+equivalent of Bison's %param command). The receiver can be referenced
+within the parser as yyrcvr.
+
 Lookahead can be called during grammar actions to read (but not consume)
 the value of the current lookahead token, as returned by yylex.Lex.
 If there is no current lookahead token (because the parser has not called Lex


### PR DESCRIPTION
This pull request adds support for a `%param` directive to `goyacc`.

Per [this StackExchange](https://stackoverflow.com/questions/55897562/goyacc-getting-context-to-the-yacc-parser-no-param) question, it's currently hard to pars some form of context to the `yacc` parser in [`goyacc`][1], i.e. emulate the [`%param`][2] command in traditional `yacc`. A typical use case would be to parse the `.Parse` function to context as to where to build its parse tree.

This patch attempts to remedy this in an idiomatic manner by adding the facility to add multiple fields to the `$$ParserImpl` struct, as specified in a `%param` directive. IE

    `%param foo bar`

adds the line `foo bar` to the `$$ParserImpl` struct, which can be referred to as `$$rcvr`.

The `goyacc` `.Parse` function is [declared][3]
    
    func ($$rcvr *$$ParserImpl) Parse($$lex $$Lexer) int {

Things I've thought of other than this patch:

* `$$ParserImpl` [cannot be changed][4] by the `.y` file, so the obvious solution (to add fields to it) is (before this patch) right out, which is a pity.
* As `$$Lexer` is an interface, I could stuff the parser context into the Lexer implementation, then force type convert `$$lex` to that implementation (assuming my parser always used the same lexer), but this seems pretty disgusting (for which read non-idiomatic). Moreover there is (seemingly) no way to put a user-generated line at the top of the `Parse` function like `c := yylex.(*lexer).c`, so in the many tens of places I want to refer to this variable, I have to use the rather ugly form `yylex.(*lexer).c` rather than just `c`.
*  Normally I'd use [`%param`][2] in normal `yacc` / C (well, `bison` anyway), but that doesn't exist in `goyacc` (before this patch).
* I'd like to avoid postprocessing my generated `.go` file with `sed` or `perl` for what are hopefully obvious reasons.
*  I want to be able to (go)yacc parse more than one file at once, so a global variable is not possible (and global variables are hardly idiomatic).

  [1]: https://godoc.org/golang.org/x/tools/cmd/goyacc
  [2]: https://www.gnu.org/software/bison/manual/html_node/Pure-Calling.html
  [3]: https://github.com/golang/tools/blob/master/cmd/goyacc/yacc.go#L3416
  [4]: https://github.com/golang/tools/blob/master/cmd/goyacc/yacc.go#L3279

(commit message follows)

Add support for a %param option similar to Bison's in a golang idiomatic
manner. Each %param option specified adds a field to the ParserImpl
struct. If none are specified, output is byte-for-byte identical to
goyacc's output before this commit.

Signed-off-by: Alex Bligh <alex@alex.org.uk>