### PR TITLE
lostcancel: do not analyze cancel variable which defined outside current function scope

### DIFF
--- a/go/analysis/passes/lostcancel/lostcancel.go
+++ b/go/analysis/passes/lostcancel/lostcancel.go
@@ -45,6 +45,8 @@ var contextPackage = "context"
 // control-flow path from the call to a return statement and that path
 // does not "use" the cancel function.  Any reference to the variable
 // counts as a use, even within a nested function literal.
+// If the variable's scope is larger than the function
+// containing the assignment, we assume that other uses exist.
 //
 // checkLostCancel analyzes a single named or literal function.
 func run(pass *analysis.Pass) (interface{}, error) {
@@ -66,7 +68,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 }
 
 func runFunc(pass *analysis.Pass, node ast.Node) {
-	// Try to find scope of function node
+	// Find scope of function node
 	var funcScope *types.Scope
 	switch v := node.(type) {
 	case *ast.FuncLit:
@@ -125,7 +127,7 @@ func runFunc(pass *analysis.Pass, node ast.Node) {
 			} else if v, ok := pass.TypesInfo.Uses[id].(*types.Var); ok {
 				// If the cancel variable is defined outside function scope,
 				// do not analyze it.
-				if funcScope == nil || funcScope.Contains(v.Pos()) {
+				if funcScope.Contains(v.Pos()) {
 					cancelvars[v] = stmt
 				}
 			} else if v, ok := pass.TypesInfo.Defs[id].(*types.Var); ok {

--- a/go/analysis/passes/lostcancel/testdata/src/a/a.go
+++ b/go/analysis/passes/lostcancel/testdata/src/a/a.go
@@ -171,3 +171,14 @@ var _ = func() (ctx context.Context, cancel func()) {
 	ctx, cancel = context.WithCancel(bg)
 	return
 }
+
+// Test for Go issue 31856.
+func _() {
+	var cancel func()
+
+	func() {
+		_, cancel = context.WithCancel(bg)
+	}()
+
+	cancel()
+}

--- a/go/analysis/passes/lostcancel/testdata/src/a/a.go
+++ b/go/analysis/passes/lostcancel/testdata/src/a/a.go
@@ -182,3 +182,11 @@ func _() {
 
 	cancel()
 }
+
+var cancel1 func()
+
+// Same as above, but for package-level cancel variable.
+func _() {
+	// We assume that other uses of cancel1 exist.
+	_, cancel1 = context.WithCancel(bg)
+}


### PR DESCRIPTION
See golang/go#31856.