### PR TITLE
internal/lsp: fix composite literal completion

### DIFF
--- a/internal/lsp/testdata/bar/bar.go.in
+++ b/internal/lsp/testdata/bar/bar.go.in
@@ -23,16 +23,16 @@ func _() {
 	var Valentine int //@item(Valentine, "Valentine", "int", "var")
 
 	_ = foo.StructFoo{
-		Val       //@complete("l", Value)
+		Valu //@complete(" //", Value)
 	}
   	_ = foo.StructFoo{
-		Va        //@complete("a", Value)
+		Va        //@complete("a", Value, Valentine)
 	}
 	_ = foo.StructFoo{
 		Value: 5, //@complete("a", Value)
 	}
 	_ = foo.StructFoo{
-		//@complete("", Value)
+		//@complete("", Value, Valentine, foo, Bar, helper)
 	}
 	_ = foo.StructFoo{
 		Value: Valen //@complete("le", Valentine)

--- a/internal/lsp/testdata/complit/complit.go.in
+++ b/internal/lsp/testdata/complit/complit.go.in
@@ -32,19 +32,35 @@ func _() {
 		//@complete("", abVar, aaVar, structPosition)
 	}
 
-	_ = position{X: a} //@complete("}", abVar, aaVar)
-	_ = position{a}    //@complete("}", abVar, aaVar)
+	_ = []string{a: ""} //@complete(":", abVar, aaVar)
+	_ = [1]string{a: ""} //@complete(":", abVar, aaVar)
+
+	_ = position{X: a}   //@complete("}", abVar, aaVar)
+	_ = position{a}      //@complete("}", abVar, aaVar)
+	_ = position{a, }      //@complete("}", abVar, aaVar, structPosition)
 
 	_ = []int{a}  //@complete("a", abVar, aaVar, structPosition)
 	_ = [1]int{a} //@complete("a", abVar, aaVar, structPosition)
 
-	var s struct {
+	type myStruct struct {
 		AA int    //@item(fieldAA, "AA", "int", "field")
 		AB string //@item(fieldAB, "AB", "string", "field")
 	}
-	_ = map[int]string{1: "" + s.A} //@complete("}", fieldAB, fieldAA)
+
+	_ = myStruct{
+		AB: a, //@complete(",", aaVar, abVar)
+	}
+
+	var s myStruct
+
+	_ = map[int]string{1: "" + s.A}                                //@complete("}", fieldAB, fieldAA)
 	_ = map[int]string{1: (func(i int) string { return "" })(s.A)} //@complete(")}", fieldAA, fieldAB)
-	_ = map[int]string{1: func() string { s.A }} //@complete(" }", fieldAA, fieldAB)
+	_ = map[int]string{1: func() string { s.A }}                   //@complete(" }", fieldAA, fieldAB)
+
+	_ = position{s.A} //@complete("}", fieldAA, fieldAB)
+
+	var X int //@item(varX, "X", "int", "var")
+	_ = position{X}      //@complete("}", fieldX, varX)
 }
 
 func _() {

--- a/internal/lsp/testdata/importedcomplit/imported_complit.go
+++ b/internal/lsp/testdata/importedcomplit/imported_complit.go
@@ -1,0 +1,26 @@
+package importedcomplit
+
+import (
+	"golang.org/x/tools/internal/lsp/foo"
+)
+
+func _() {
+	var V int //@item(icVVar, "V", "int", "var")
+	_ = foo.StructFoo{V} //@complete("}", Value, icVVar)
+}
+
+func _() {
+	var (
+		aa string //@item(icAAVar, "aa", "string", "var")
+		ab int    //@item(icABVar, "ab", "int", "var")
+	)
+
+	_ = foo.StructFoo{a} //@complete("}", abVar, aaVar)
+
+	var s struct {
+		AA string //@item(icFieldAA, "AA", "string", "field")
+		AB int    //@item(icFieldAB, "AB", "int", "field")
+	}
+
+	_ = foo.StructFoo{s.} //@complete("}", icFieldAB, icFieldAA)
+}

--- a/internal/lsp/tests/tests.go
+++ b/internal/lsp/tests/tests.go
@@ -28,7 +28,7 @@ import (
 // We hardcode the expected number of test cases to ensure that all tests
 // are being executed. If a test is added, this number must be changed.
 const (
-	ExpectedCompletionsCount       = 97
+	ExpectedCompletionsCount       = 106
 	ExpectedDiagnosticsCount       = 17
 	ExpectedFormatCount            = 5
 	ExpectedDefinitionsCount       = 33


### PR DESCRIPTION
Fix the following issues:

- We were trying to complete struct literal field names for
  selector expressions (e.g. "Foo{a.B<>}"). Now we only complete field
  names in this case if the expression is an *ast.Ident.
- We weren't including lexical completions in cases where you might be
  completing a field name or a variable name (e.g. "Foo{A<>}").

I refactored composite literal logic to live mostly in one place. Now
enclosingCompositeLiteral computes all the bits of information related
to composite literals. The expected type, completion, and snippet code
make use of those precalculated facts instead of redoing the work.