### PR TITLE
internal/lsp: handle more expected type cases

### DIFF
--- a/internal/lsp/testdata/channel/channel.go
+++ b/internal/lsp/testdata/channel/channel.go
@@ -1,0 +1,25 @@
+package channel
+
+func _() {
+	var (
+		aa = "123" //@item(channelAA, "aa", "string", "var")
+		ab = 123   //@item(channelAB, "ab", "int", "var")
+	)
+
+	{
+		type myChan chan int
+		var mc myChan
+		mc <- a //@complete(" //", channelAB, channelAA)
+	}
+
+	{
+		var ac chan int //@item(channelAC, "ac", "chan int", "var")
+		a <- a //@complete(" <-", channelAC, channelAA, channelAB)
+	}
+
+	{
+		var foo chan int //@item(channelFoo, "foo", "chan int", "var")
+		wantsInt := func(int) {} //@item(channelWantsInt, "wantsInt", "func(int)", "var")
+		wantsInt(<-) //@complete(")", channelFoo, channelWantsInt, channelAA, channelAB)
+	}
+}

--- a/internal/lsp/testdata/func_rank/func_rank.go.in
+++ b/internal/lsp/testdata/func_rank/func_rank.go.in
@@ -26,8 +26,8 @@ func _() {
 	// no expected type
 	fnInt(func() int { s.A }) //@complete(" }", rankAA, rankAB, rankAC)
 	fnInt(s.A())              //@complete("()", rankAA, rankAB, rankAC)
-	fnInt([]int{}[s.A])       //@complete("])", rankAA, rankAB, rankAC)
-	fnInt([]int{}[:s.A])      //@complete("])", rankAA, rankAB, rankAC)
+	fnInt([]int{}[s.A])       //@complete("])", rankAA, rankAC, rankAB)
+	fnInt([]int{}[:s.A])      //@complete("])", rankAA, rankAC, rankAB)
 
 	fnInt(s.A.(int)) //@complete(".(", rankAA, rankAB, rankAC)
 

--- a/internal/lsp/testdata/index/index.go
+++ b/internal/lsp/testdata/index/index.go
@@ -1,0 +1,21 @@
+package index
+
+func _() {
+	var (
+		aa = "123" //@item(indexAA, "aa", "string", "var")
+		ab = 123   //@item(indexAB, "ab", "int", "var")
+	)
+
+	var foo [1]int
+	foo[a]  //@complete("]", indexAB, indexAA)
+	foo[:a] //@complete("]", indexAB, indexAA)
+	a[:a]   //@complete("[", indexAA, indexAB)
+	a[a]    //@complete("[", indexAA, indexAB)
+
+	var bar map[string]int
+	bar[a] //@complete("]", indexAA, indexAB)
+
+	type myMap map[string]int
+	var baz myMap
+	baz[a] //@complete("]", indexAA, indexAB)
+}

--- a/internal/lsp/testdata/rank/switch_rank.go.in
+++ b/internal/lsp/testdata/rank/switch_rank.go.in
@@ -1,0 +1,12 @@
+package rank
+
+func _() {
+	switch pear {
+	case : //@complete(":", pear, apple)
+	}
+
+	switch pear {
+	case "hi":
+		//@complete("", apple, pear)
+	}
+}

--- a/internal/lsp/testdata/rank/type_assert_rank.go.in
+++ b/internal/lsp/testdata/rank/type_assert_rank.go.in
@@ -1,0 +1,8 @@
+package rank
+
+func _() {
+	type flower int //@item(flower, "flower", "int", "type")
+	var fig string  //@item(fig, "fig", "string", "var")
+
+	_ = interface{}(nil).(f) //@complete(") //", flower, fig)
+}

--- a/internal/lsp/testdata/rank/type_switch_rank.go.in
+++ b/internal/lsp/testdata/rank/type_switch_rank.go.in
@@ -1,0 +1,11 @@
+package rank
+
+func _() {
+	type basket int   //@item(basket, "basket", "int", "type")
+	var banana string //@item(banana, "banana", "string", "var")
+
+	switch interface{}(pear).(type) {
+	case b: //@complete(":", basket, banana)
+		b //@complete(" //", banana, basket)
+	}
+}

--- a/internal/lsp/tests/tests.go
+++ b/internal/lsp/tests/tests.go
@@ -28,7 +28,7 @@ import (
 // We hardcode the expected number of test cases to ensure that all tests
 // are being executed. If a test is added, this number must be changed.
 const (
-	ExpectedCompletionsCount       = 107
+	ExpectedCompletionsCount       = 121
 	ExpectedCompletionSnippetCount = 13
 	ExpectedDiagnosticsCount       = 17
 	ExpectedFormatCount            = 5


### PR DESCRIPTION
Calculate expected type in the following cases:

- switch case statements
- index expressions (e.g. []int{}[<>] or map[string]int{}[<>])
- slice expressions (e.g. []int{}[1:<>])
- channel send statements
- channel receive expression

We now also prefer type names in type switch clauses and type asserts.