### PR TITLE
internal/lsp: provide deep completion candidates

### DIFF
--- a/internal/lsp/general.go
+++ b/internal/lsp/general.go
@@ -201,6 +201,10 @@ func (s *Server) processConfig(view source.View, config interface{}) error {
 			}
 		}
 	}
+	// Check if deep completions are enabled.
+	if useDeepCompletions, ok := c["useDeepCompletions"].(bool); ok {
+		s.useDeepCompletions = useDeepCompletions
+	}
 	return nil
 }
 

--- a/internal/lsp/lsp_test.go
+++ b/internal/lsp/lsp_test.go
@@ -145,11 +145,15 @@ func summarizeDiagnostics(i int, want []source.Diagnostic, got []source.Diagnost
 }
 
 func (r *runner) Completion(t *testing.T, data tests.Completions, snippets tests.CompletionSnippets, items tests.CompletionItems) {
+	defer func() { r.server.useDeepCompletions = false }()
+
 	for src, itemList := range data {
 		var want []source.CompletionItem
 		for _, pos := range itemList {
 			want = append(want, *items[pos])
 		}
+
+		r.server.useDeepCompletions = strings.Contains(string(src.URI()), "deepcomplete")
 
 		list := r.runCompletion(t, src)
 
@@ -178,6 +182,8 @@ func (r *runner) Completion(t *testing.T, data tests.Completions, snippets tests
 		r.server.usePlaceholders = usePlaceholders
 
 		for src, want := range snippets {
+			r.server.useDeepCompletions = strings.Contains(string(src.URI()), "deepcomplete")
+
 			list := r.runCompletion(t, src)
 
 			wantItem := items[want.CompletionItem]

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -72,6 +72,7 @@ type Server struct {
 	// TODO(rstambler): Separate these into their own struct?
 	usePlaceholders               bool
 	noDocsOnHover                 bool
+	useDeepCompletions            bool
 	insertTextFormat              protocol.InsertTextFormat
 	configurationSupported        bool
 	dynamicConfigurationSupported bool

--- a/internal/lsp/source/completion_format.go
+++ b/internal/lsp/source/completion_format.go
@@ -26,7 +26,7 @@ func (c *completer) item(cand candidate) CompletionItem {
 	}
 
 	var (
-		label              = obj.Name()
+		label              = c.deepState.chainString(obj.Name())
 		detail             = types.TypeString(obj.Type(), c.qf)
 		insert             = label
 		kind               CompletionItemKind
@@ -38,9 +38,9 @@ func (c *completer) item(cand candidate) CompletionItem {
 	// to that of an invocation of sig.
 	expandFuncCall := func(sig *types.Signature) {
 		params := formatParams(sig.Params(), sig.Variadic(), c.qf)
+		plainSnippet, placeholderSnippet = c.functionCallSnippets(label, params)
 		results, writeParens := formatResults(sig.Results(), c.qf)
-		label, detail = formatFunction(obj.Name(), params, results, writeParens)
-		plainSnippet, placeholderSnippet = c.functionCallSnippets(obj.Name(), params)
+		label, detail = formatFunction(label, params, results, writeParens)
 	}
 
 	switch obj := obj.(type) {
@@ -69,7 +69,6 @@ func (c *completer) item(cand candidate) CompletionItem {
 		if !ok {
 			break
 		}
-
 		kind = FunctionCompletionItem
 		if sig != nil && sig.Recv() != nil {
 			kind = MethodCompletionItem
@@ -91,6 +90,7 @@ func (c *completer) item(cand candidate) CompletionItem {
 		Detail:             detail,
 		Kind:               kind,
 		Score:              cand.score,
+		Depth:              len(c.deepState.chain),
 		plainSnippet:       plainSnippet,
 		placeholderSnippet: placeholderSnippet,
 	}

--- a/internal/lsp/source/completion_snippet.go
+++ b/internal/lsp/source/completion_snippet.go
@@ -13,21 +13,21 @@ import (
 
 // structFieldSnippets calculates the plain and placeholder snippets for struct literal field names.
 func (c *completer) structFieldSnippets(label, detail string) (*snippet.Builder, *snippet.Builder) {
-	clInfo := c.enclosingCompositeLiteral
-
-	if clInfo == nil || !clInfo.isStruct() {
+	if !c.wantStructFieldCompletions() {
 		return nil, nil
 	}
+
+	// If we are in a deep completion then we can't be completing a field
+	// name (e.g. "Foo{f<>}" completing to "Foo{f.Bar}" should not generate
+	// a snippet).
+	if c.inDeepCompletion() {
+		return nil, nil
+	}
+
+	clInfo := c.enclosingCompositeLiteral
 
 	// If we are already in a key-value expression, we don't want a snippet.
 	if clInfo.kv != nil {
-		return nil, nil
-	}
-
-	// We don't want snippet unless we are completing a field name. maybeInFieldName
-	// means we _might_ not be a struct field name, but this method is only called for
-	// struct fields, so we can ignore that possibility.
-	if !clInfo.inKey && !clInfo.maybeInFieldName {
 		return nil, nil
 	}
 

--- a/internal/lsp/source/deep_completion.go
+++ b/internal/lsp/source/deep_completion.go
@@ -1,0 +1,84 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package source
+
+import (
+	"go/types"
+	"strings"
+)
+
+// deepCompletionState stores our state as we search for deep completions.
+// "deep completion" refers to searching into objects' fields and methods to
+// find more completion candidates.
+type deepCompletionState struct {
+	// enabled is true if deep completions are enabled.
+	enabled bool
+
+	// chain holds the traversal path as we do a depth-first search through
+	// objects' members looking for exact type matches.
+	chain []types.Object
+
+	// chainNames holds the names of the chain objects. This allows us to
+	// save allocations as we build many deep completion items.
+	chainNames []string
+}
+
+// push pushes obj onto our search stack.
+func (s *deepCompletionState) push(obj types.Object) {
+	s.chain = append(s.chain, obj)
+	s.chainNames = append(s.chainNames, obj.Name())
+}
+
+// pop pops the last object off our search stack.
+func (s *deepCompletionState) pop() {
+	s.chain = s.chain[:len(s.chain)-1]
+	s.chainNames = s.chainNames[:len(s.chainNames)-1]
+}
+
+// chainString joins the chain of objects' names together on ".".
+func (s *deepCompletionState) chainString(finalName string) string {
+	s.chainNames = append(s.chainNames, finalName)
+	chainStr := strings.Join(s.chainNames, ".")
+	s.chainNames = s.chainNames[:len(s.chainNames)-1]
+	return chainStr
+}
+
+func (c *completer) inDeepCompletion() bool {
+	return len(c.deepState.chain) > 0
+}
+
+// deepSearch searches through obj's subordinate objects for more
+// completion items.
+func (c *completer) deepSearch(obj types.Object) {
+	if !c.deepState.enabled {
+		return
+	}
+
+	// Don't search into type names.
+	if isTypeName(obj) {
+		return
+	}
+
+	// Don't search embedded fields because they were already included in their
+	// parent's fields.
+	if v, ok := obj.(*types.Var); ok && v.Embedded() {
+		return
+	}
+
+	// Push this object onto our search stack.
+	c.deepState.push(obj)
+
+	switch obj := obj.(type) {
+	case *types.PkgName:
+		c.packageMembers(obj)
+	default:
+		// For now it is okay to assume obj is addressable since we don't search beyond
+		// function calls.
+		c.methodsAndFields(obj.Type(), true)
+	}
+
+	// Pop the object off our search stack.
+	c.deepState.pop()
+}

--- a/internal/lsp/source/util.go
+++ b/internal/lsp/source/util.go
@@ -38,18 +38,20 @@ func fieldSelections(T types.Type) (fields []*types.Var) {
 	// selections that match more than one field/method.
 	// types.NewSelectionSet should do that for us.
 
-	seen := make(map[types.Type]bool) // for termination on recursive types
+	seen := make(map[*types.Var]bool) // for termination on recursive types
+
 	var visit func(T types.Type)
 	visit = func(T types.Type) {
-		if !seen[T] {
-			seen[T] = true
-			if T, ok := deref(T).Underlying().(*types.Struct); ok {
-				for i := 0; i < T.NumFields(); i++ {
-					f := T.Field(i)
-					fields = append(fields, f)
-					if f.Anonymous() {
-						visit(f.Type())
-					}
+		if T, ok := deref(T).Underlying().(*types.Struct); ok {
+			for i := 0; i < T.NumFields(); i++ {
+				f := T.Field(i)
+				if seen[f] {
+					continue
+				}
+				seen[f] = true
+				fields = append(fields, f)
+				if f.Anonymous() {
+					visit(f.Type())
 				}
 			}
 		}

--- a/internal/lsp/testdata/deepcomplete/deep_complete.go
+++ b/internal/lsp/testdata/deepcomplete/deep_complete.go
@@ -1,0 +1,61 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package deepcomplete
+
+import "context" //@item(ctxPackage, "context", "\"context\"", "package")
+
+type deepA struct {
+	b deepB //@item(deepBField, "b", "deepB", "field")
+}
+
+type deepB struct {
+}
+
+func wantsDeepB(deepB) {}
+
+func _() {
+	var a deepA   //@item(deepAVar, "a", "deepA", "var")
+	a.b           //@item(deepABField, "a.b", "deepB", "field")
+	wantsDeepB(a) //@complete(")", deepABField, deepAVar)
+
+	deepA{a} //@snippet("}", deepABField, "a.b", "a.b")
+}
+
+func wantsContext(context.Context) {}
+
+func _() {
+	context.Background() //@item(ctxBackground, "context.Background()", "context.Context", "func")
+	context.TODO()       //@item(ctxTODO, "context.TODO()", "context.Context", "func")
+	/* context.WithValue(parent context.Context, key interface{}, val interface{}) */ //@item(ctxWithValue, "context.WithValue(parent context.Context, key interface{}, val interface{})", "context.Context", "func")
+
+	wantsContext(c) //@complete(")", ctxBackground, ctxTODO, ctxWithValue, ctxPackage)
+}
+
+func _() {
+	type deepCircle struct {
+		*deepCircle
+	}
+	var circle deepCircle //@item(deepCircle, "circle", "deepCircle", "var")
+	circle.deepCircle     //@item(deepCircleField, "circle.deepCircle", "*deepCircle", "field")
+	var _ deepCircle = ci //@complete(" //", deepCircle, deepCircleField)
+}
+
+func _() {
+	type deepEmbedC struct {
+	}
+	type deepEmbedB struct {
+		deepEmbedC
+	}
+	type deepEmbedA struct {
+		deepEmbedB
+	}
+
+	wantsC := func(deepEmbedC) {}
+
+	var a deepEmbedA //@item(deepEmbedA, "a", "deepEmbedA", "var")
+	a.deepEmbedB     //@item(deepEmbedB, "a.deepEmbedB", "deepEmbedB", "field")
+	a.deepEmbedC     //@item(deepEmbedC, "a.deepEmbedC", "deepEmbedC", "field")
+	wantsC(a)        //@complete(")", deepEmbedC, deepEmbedA, deepEmbedB)
+}

--- a/internal/lsp/tests/tests.go
+++ b/internal/lsp/tests/tests.go
@@ -25,8 +25,8 @@ import (
 // We hardcode the expected number of test cases to ensure that all tests
 // are being executed. If a test is added, this number must be changed.
 const (
-	ExpectedCompletionsCount       = 132
-	ExpectedCompletionSnippetCount = 14
+	ExpectedCompletionsCount       = 136
+	ExpectedCompletionSnippetCount = 15
 	ExpectedDiagnosticsCount       = 17
 	ExpectedFormatCount            = 5
 	ExpectedImportCount            = 2


### PR DESCRIPTION
Deep completion refers to searching through an object's fields and
methods for more completion candidates. For example:

func wantsInt(int) { }
var s struct { i int }
wantsInt(<>)

Will now give a candidate for "s.i" since its type matches the
expected type.

We limit to three deep completion results. In some cases there are
many useless deep completion matches. Showing too many options defeats
the purpose of "smart" completions. We also lower a completion item's
score according to its depth so that we favor shallower options. For
now we do not continue searching past function calls to limit our
search scope. In other words, we are not able to suggest results with
any chained fields/methods after the first method call.

Deep completions are behind the "useDeepCompletions" LSP config flag
for now.