### PR TITLE
internal/lsp: add fuzzy matching algorithm

### DIFF
--- a/internal/lsp/fuzzymatch/fuzzy_match.go
+++ b/internal/lsp/fuzzymatch/fuzzy_match.go
@@ -1,0 +1,163 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// fuzzymatch implements fuzzy string matching suitable for matching a user's
+// query against Go identifiers. See Match documentation for more details.
+package fuzzymatch
+
+import (
+	"unicode"
+	"unicode/utf8"
+)
+
+const (
+	// fuzzyStartMatch is a bonus for matching the first rune of an identifier.
+	// This includes "b" against "bar" and "foo.bar".
+	fuzzyStartMatch = 2
+
+	// fuzzyWordMatch is a bonus for matching the first rune of a non-initial
+	// word. This includes "b" against "foo_bar" and "fooBar".
+	fuzzyWordMatch = 1
+
+	// fuzzyConsecMatch is a bonus for each consecutively matched rune after the
+	// first. This includes "ba" against "fooBar".
+	fuzzyConsecMatch = 1
+
+	// fuzzyPrefixMatch is like fuzzyConsecMatch but only for matches anchored at
+	// the start of an identifier. This includes "ba" against "bar".
+	fuzzyPrefixMatch = 1
+)
+
+// Match matches the user input against a target string. It returns
+// whether the target matches the input string, and if so, a score (higher
+// meaning a better match). See the above constants for more detail on
+// the scoring.
+//
+// In order to match, each input rune must appear in order in the target string.
+// Uppercase input runes must match exactly with target runes, but lowercase
+// input runes match case insensitively. Matching is greedy, so the first target
+// rune that matches an input rune is always taken.
+func Match(input, target string) (bool, int) {
+	if len(input) == 0 {
+		return true, 0
+	}
+
+	if len(input) > len(target) {
+		return false, 0
+	}
+
+	var (
+		score               int
+		prevTargetRune      rune
+		previousRuneMatched bool // did the previous target rune match an input rune
+		prefixStreak        bool // do we match consecutively from start of identifier
+		inputRune           rune // current rune from input string
+	)
+
+	for targetByteIdx, targetRune := range target {
+		// If this is the first iteration or if previous iteration matched, advance
+		// to the next rune in the input string.
+		if targetByteIdx == 0 || previousRuneMatched {
+			var inputRuneSize int
+			inputRune, inputRuneSize = utf8.DecodeRuneInString(input)
+			if inputRune == utf8.RuneError {
+				return false, 0
+			}
+			input = input[inputRuneSize:]
+		}
+
+		// startOfIdentifier is true if we are at the first rune of target, or
+		// the first rune after a period.
+		startOfIdentifier := targetByteIdx == 0 || prevTargetRune == '.'
+
+		// At the start of an identifier we begin a prefix streak.
+		if startOfIdentifier {
+			prefixStreak = true
+		}
+
+		var match bool
+		// Uppercase input runes must match exactly. This allows somewhat for
+		// overriding a greedy lowercase match by using uppercase input. For
+		// example, searching "abar" against "abcBart" will match "<ab>cB<ar>t",
+		// but "aBar" will match "<a>bc<Bar>t".
+		if unicode.IsUpper(inputRune) {
+			match = inputRune == targetRune
+		} else {
+			match = runesEqualFold(inputRune, targetRune)
+		}
+
+		if match {
+			// Matches the start of an identifer.
+			if startOfIdentifier {
+				score += fuzzyStartMatch
+			}
+
+			// Check if we match the start of a word within an identifer.
+			if targetByteIdx > 0 {
+				switch {
+				case prevTargetRune == '_' && !previousRuneMatched:
+					// Matches the start of a word starting after an underscore.
+					score += fuzzyWordMatch
+				case unicode.IsUpper(targetRune) && unicode.IsLower(prevTargetRune):
+					// Matches the start of camel case word.
+					score += fuzzyWordMatch
+				}
+			}
+
+			// Consecutive match.
+			if previousRuneMatched {
+				score += fuzzyConsecMatch
+				// Consecutive match from the start of an identifier.
+				if prefixStreak {
+					score += fuzzyPrefixMatch
+				}
+			}
+
+			previousRuneMatched = true
+
+			if len(input) == 0 {
+				return true, score
+			}
+		} else {
+			previousRuneMatched = false
+			prefixStreak = false
+		}
+
+		prevTargetRune = targetRune
+	}
+
+	return false, 0
+}
+
+// runesEqualFold returns whether tr and sr are equivalent taking into
+// account unicode case folding.
+func runesEqualFold(tr, sr rune) bool {
+	// Adapted directly from the loop in strings.EqualFold().
+
+	// Easy case.
+	if tr == sr {
+		return true
+	}
+
+	// Make sr < tr to simplify what follows.
+	if tr < sr {
+		tr, sr = sr, tr
+	}
+	// Fast check for ASCII.
+	if tr < utf8.RuneSelf {
+		// ASCII only, sr/tr must be upper/lower case
+		if 'A' <= sr && sr <= 'Z' && tr == sr+'a'-'A' {
+			return true
+		}
+		return false
+	}
+
+	// General case. SimpleFold(x) returns the next equivalent rune > x
+	// or wraps around to smaller values.
+	r := unicode.SimpleFold(sr)
+	for r != sr && r < tr {
+		r = unicode.SimpleFold(r)
+	}
+	return r == tr
+}

--- a/internal/lsp/fuzzymatch/fuzzy_match_test.go
+++ b/internal/lsp/fuzzymatch/fuzzy_match_test.go
@@ -1,0 +1,208 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package fuzzymatch
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestFuzzyScoring(t *testing.T) {
+	cases := []struct {
+		input, target string
+		matches       bool
+		score         int
+	}{
+		{
+			input:   "",
+			target:  "hi",
+			matches: true,
+			score:   0,
+		},
+		{
+			input:   "h",
+			target:  "i",
+			matches: false,
+			score:   0,
+		},
+		{
+			input:   "hi",
+			target:  "i",
+			matches: false,
+			score:   0,
+		},
+		{
+			input:   "h",
+			target:  "hi",
+			matches: true,
+			score:   fuzzyStartMatch,
+		},
+		{
+			input:   "H",
+			target:  "hi",
+			matches: false,
+		},
+		{
+			input:   "H",
+			target:  "Hi",
+			matches: true,
+			score:   fuzzyStartMatch,
+		},
+		{
+			input:   "i",
+			target:  "hi",
+			matches: true,
+			score:   0,
+		},
+		{
+			input:   "hi",
+			target:  "hi",
+			matches: true,
+			score:   fuzzyStartMatch + fuzzyConsecMatch + fuzzyPrefixMatch,
+		},
+		{
+			input:   "hi",
+			target:  "foo.hi",
+			matches: true,
+			score:   fuzzyStartMatch + fuzzyConsecMatch + fuzzyPrefixMatch,
+		},
+		{
+			input:   "你好",
+			target:  "foo.你好",
+			matches: true,
+			score:   fuzzyStartMatch + fuzzyConsecMatch + fuzzyPrefixMatch,
+		},
+		{
+			input:   "ht",
+			target:  "hiThere",
+			matches: true,
+			score:   fuzzyStartMatch + fuzzyWordMatch,
+		},
+		{
+			input:   "h",
+			target:  "foo.Hi",
+			matches: true,
+			score:   fuzzyStartMatch,
+		},
+		{
+			input:   "ht",
+			target:  "hi_there",
+			matches: true,
+			score:   fuzzyStartMatch + fuzzyWordMatch,
+		},
+		{
+			input:   "h",
+			target:  "_hi",
+			matches: true,
+			score:   fuzzyWordMatch,
+		},
+		{
+			input:   "__",
+			target:  "hi__there",
+			matches: true,
+			score:   fuzzyConsecMatch,
+		},
+		{
+			input:   "h_i",
+			target:  "h_i",
+			matches: true,
+			score:   fuzzyStartMatch + 2*fuzzyConsecMatch + 2*fuzzyPrefixMatch,
+		},
+	}
+
+	for _, c := range cases {
+		matches, score := Match(c.input, c.target)
+		if c.matches {
+			if !matches {
+				t.Errorf("expected input %q to match %q", c.input, c.target)
+			} else if score != c.score {
+				t.Errorf("expected score %d, got %d for %q %q", c.score, score, c.input, c.target)
+			}
+		} else {
+			if matches {
+				t.Errorf("expected input %q to not match %q", c.input, c.target)
+			}
+		}
+	}
+}
+
+func TestFuzzyRelativeRanking(t *testing.T) {
+	cases := []struct {
+		input  string
+		ranked []string
+	}{
+		// prefer prefix matches
+		{
+			input:  "hi",
+			ranked: []string{"hit", "heIce"},
+		},
+		{
+			input:  "hit",
+			ranked: []string{"hit", "how.irk.tree"},
+		},
+	}
+
+	for _, c := range cases {
+		scores := make([]int, 0, len(c.ranked))
+		for _, r := range c.ranked {
+			matches, score := Match(c.input, r)
+			if !matches {
+				t.Fatalf("%q didn't match input %q", r, c.input)
+			}
+			scores = append(scores, score)
+		}
+		got := make([]string, len(c.ranked))
+		copy(got, c.ranked)
+		sort.Slice(got, func(i, j int) bool {
+			return scores[i] > scores[j]
+		})
+		if !reflect.DeepEqual(got, c.ranked) {
+			t.Errorf("expected %v, got %v", c.ranked, got)
+		}
+	}
+}
+
+func TestRankDistance(t *testing.T) {
+	cases := []struct {
+		input         string
+		targets       [2]string
+		maxScoreDelta int
+	}{
+		// "foo.Apple" should be ranked higher, but not by too much of a margin.
+		{
+			input:         "Apple",
+			targets:       [2]string{"foo.Apple", "foo.CrabApple"},
+			maxScoreDelta: 5,
+		},
+	}
+
+	for _, c := range cases {
+		matches, score1 := Match(c.input, c.targets[0])
+		if !matches {
+			t.Fatalf("%q didn't match input %q", c.targets[0], c.input)
+		}
+
+		matches, score2 := Match(c.input, c.targets[1])
+		if !matches {
+			t.Fatalf("%q didn't match input %q", c.targets[1], c.input)
+		}
+		if delta := score1 - score2; delta > c.maxScoreDelta {
+			t.Errorf("%q should be within %d of %q for input %q, was %d", c.targets[0], c.maxScoreDelta, c.targets[1], c.input, delta)
+		}
+	}
+}
+
+func BenchmarkASCIIFuzzyMatch(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Match("abcd", "colloidize-multitudinosity")
+	}
+}
+
+func BenchmarkNonASCIIFuzzyMatch(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Match("亢龙有悔", "降龙十八掌天下无敌")
+	}
+}


### PR DESCRIPTION
This algorithm will be used to perform server side fuzzy completion
candidate matching. In particular, this will allow the user to fuzzily
search through deep completion candidates (e.g. the user can type "fbb"
to filter to a completion candidate "foo.bar.baz").

Currently the algorithm does not try to find an optimal scoring match.
For example when matching "ct" against "CatTown", it will match
"<C>a<t>Town" instead of the optimal "<C>at<T>own". This can result in
sub-optimal completion rankings, but is somewhat mitigated by allowing
for exact uppercase matching (e.g. "cT" in the previous example would
give the optimal match).