### PR TITLE
internal/lsp: fix swallowed package errors

### DIFF
--- a/internal/lsp/cmd/cmd.go
+++ b/internal/lsp/cmd/cmd.go
@@ -339,7 +339,7 @@ func (c *cmdClient) getFile(ctx context.Context, uri span.URI) *cmdFile {
 		}
 		f := c.fset.AddFile(fname, -1, len(content))
 		f.SetLinesForContent(content)
-		file.mapper = protocol.NewColumnMapper(uri, c.fset, f, content)
+		file.mapper = protocol.NewColumnMapper(uri, fname, c.fset, f, content)
 	}
 	return file
 }

--- a/internal/lsp/link.go
+++ b/internal/lsp/link.go
@@ -6,6 +6,7 @@ package lsp
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 
 	"golang.org/x/tools/internal/lsp/protocol"
@@ -21,6 +22,10 @@ func (s *Server) documentLink(ctx context.Context, params *protocol.DocumentLink
 	}
 	// find the import block
 	ast := f.GetAST(ctx)
+	if ast == nil {
+		return nil, fmt.Errorf("no AST for %v", uri)
+	}
+
 	var result []protocol.DocumentLink
 	for _, imp := range ast.Imports {
 		spn, err := span.NewRange(f.GetFileSet(ctx), imp.Pos(), imp.End()).Span()

--- a/internal/lsp/lsp_test.go
+++ b/internal/lsp/lsp_test.go
@@ -594,7 +594,7 @@ func (r *runner) mapper(uri span.URI) (*protocol.ColumnMapper, error) {
 	if err != nil {
 		return nil, err
 	}
-	return protocol.NewColumnMapper(uri, fset, f, content), nil
+	return protocol.NewColumnMapper(uri, filename, fset, f, content), nil
 }
 
 func TestBytesOffset(t *testing.T) {
@@ -624,7 +624,7 @@ func TestBytesOffset(t *testing.T) {
 		fset := token.NewFileSet()
 		f := fset.AddFile(fname, -1, len(test.text))
 		f.SetLinesForContent([]byte(test.text))
-		mapper := protocol.NewColumnMapper(span.FileURI(fname), fset, f, []byte(test.text))
+		mapper := protocol.NewColumnMapper(span.FileURI(fname), fname, fset, f, []byte(test.text))
 		got, err := mapper.Point(test.pos)
 		if err != nil && test.want != -1 {
 			t.Errorf("unexpected error: %v", err)

--- a/internal/lsp/protocol/span.go
+++ b/internal/lsp/protocol/span.go
@@ -23,10 +23,17 @@ func NewURI(uri span.URI) string {
 	return string(uri)
 }
 
-func NewColumnMapper(uri span.URI, fset *token.FileSet, f *token.File, content []byte) *ColumnMapper {
+func NewColumnMapper(uri span.URI, fn string, fset *token.FileSet, f *token.File, content []byte) *ColumnMapper {
+	var converter *span.TokenConverter
+	if f == nil {
+		converter = span.NewContentConverter(fn, content)
+	} else {
+		converter = span.NewTokenConverter(fset, f)
+	}
+
 	return &ColumnMapper{
 		URI:       uri,
-		Converter: span.NewTokenConverter(fset, f),
+		Converter: converter,
 		Content:   content,
 	}
 }

--- a/internal/lsp/source/diagnostics_test.go
+++ b/internal/lsp/source/diagnostics_test.go
@@ -1,0 +1,55 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package source
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseErrorMessage(t *testing.T) {
+	tests := []struct {
+		name             string
+		in               string
+		expectedFileName string
+		expectedLine     int
+		expectedColumn   int
+	}{
+		{
+			name:             "from go list output",
+			in:               "\nattributes.go:13:1: expected 'package', found 'type'",
+			expectedFileName: "attributes.go",
+			expectedLine:     13,
+			expectedColumn:   1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spn := parseDiagnosticMessage(tt.in)
+			fn, err := spn.URI().Filename()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if !strings.HasSuffix(fn, tt.expectedFileName) {
+				t.Errorf("expected filename with suffix %v but got %v", tt.expectedFileName, fn)
+			}
+
+			if !spn.HasPosition() {
+				t.Fatalf("expected span to have position")
+			}
+
+			pos := spn.Start()
+			if pos.Line() != tt.expectedLine {
+				t.Errorf("expected line %v but got %v", tt.expectedLine, pos.Line())
+			}
+
+			if pos.Column() != tt.expectedColumn {
+				t.Errorf("expected line %v but got %v", tt.expectedLine, pos.Line())
+			}
+		})
+	}
+}

--- a/internal/lsp/util.go
+++ b/internal/lsp/util.go
@@ -51,11 +51,14 @@ func getSourceFile(ctx context.Context, v source.View, uri span.URI) (source.Fil
 	if err != nil {
 		return nil, nil, err
 	}
-	tok := f.GetToken(ctx)
-	if tok == nil {
-		return nil, nil, fmt.Errorf("no file information for %v", f.URI())
+
+	fname, err := f.URI().Filename()
+	if err != nil {
+		return nil, nil, err
 	}
-	m := protocol.NewColumnMapper(f.URI(), f.GetFileSet(ctx), tok, f.GetContent(ctx))
+
+	m := protocol.NewColumnMapper(f.URI(), fname, f.GetFileSet(ctx), f.GetToken(ctx), f.GetContent(ctx))
+
 	return f, m, nil
 }
 


### PR DESCRIPTION
If a package has an error that makes it completely unparseable, such as containing a .go file with no "package" statement, the error was previously unreported. Such errors would manifest as other errors.

Fixes golang/go#31712