### PR TITLE
internal/lsp: fix completion insertion with non-identifier suffix

### DIFF
--- a/internal/lsp/source/completion.go
+++ b/internal/lsp/source/completion.go
@@ -312,7 +312,14 @@ func Completion(ctx context.Context, f GoFile, pos token.Pos) ([]CompletionItem,
 		}
 
 	case *ast.SelectorExpr:
-		c.setSurrounding(n.Sel)
+		// The go parser inserts a phantom "_" Sel node when the selector is
+		// not followed by an identifier or a "(". The "_" isn't actually in
+		// the text, so don't think it is our surrounding.
+		// TODO: Find a way to differentiate between phantom "_" and real "_",
+		//       perhaps by checking if "_" is present in file contents.
+		if n.Sel.Name != "_" || c.pos != n.Sel.Pos() {
+			c.setSurrounding(n.Sel)
+		}
 
 		if err := c.selector(n); err != nil {
 			return nil, nil, err


### PR DESCRIPTION
Completions like "foo.Bar(baz.<>)" were replacing one too many
characters resulting in "foo.Bar(baz.Qux()". This is because the go
parser adds a phantom "_" identifier when parsing "foo.". We thought
the "_" was really there, so we were issuing text edits to replace
it. Fix by ignoring "_" selectors when the cursor is positioned to
their left.

Fixes microsoft/vscode-go#2525