### PR TITLE
internal/lsp: don't complete test objects in non-test files

### DIFF
--- a/internal/lsp/cache/gofile.go
+++ b/internal/lsp/cache/gofile.go
@@ -82,7 +82,7 @@ func (f *goFile) GetActiveReverseDeps(ctx context.Context) []source.GoFile {
 
 	seen := make(map[string]struct{}) // visited packages
 	results := make(map[*goFile]struct{})
-	f.view.reverseDeps(ctx, seen, results, pkg.PkgPath())
+	f.view.reverseDeps(ctx, seen, results, pkgKey{path: pkg.PkgPath(), isTest: false})
 
 	var files []source.GoFile
 	for rd := range results {
@@ -98,12 +98,12 @@ func (f *goFile) GetActiveReverseDeps(ctx context.Context) []source.GoFile {
 	return files
 }
 
-func (v *view) reverseDeps(ctx context.Context, seen map[string]struct{}, results map[*goFile]struct{}, pkgPath string) {
-	if _, ok := seen[pkgPath]; ok {
+func (v *view) reverseDeps(ctx context.Context, seen map[string]struct{}, results map[*goFile]struct{}, key pkgKey) {
+	if _, ok := seen[key.path]; ok {
 		return
 	}
-	seen[pkgPath] = struct{}{}
-	m, ok := v.mcache.packages[pkgPath]
+	seen[key.path] = struct{}{}
+	m, ok := v.mcache.packages[key]
 	if !ok {
 		return
 	}
@@ -113,7 +113,7 @@ func (v *view) reverseDeps(ctx context.Context, seen map[string]struct{}, result
 			results[f.(*goFile)] = struct{}{}
 		}
 	}
-	for parentPkgPath := range m.parents {
-		v.reverseDeps(ctx, seen, results, parentPkgPath)
+	for parentKey := range m.parents {
+		v.reverseDeps(ctx, seen, results, parentKey)
 	}
 }

--- a/internal/lsp/cache/pkg.go
+++ b/internal/lsp/cache/pkg.go
@@ -19,6 +19,7 @@ import (
 // pkg contains the type information needed by the source package.
 type pkg struct {
 	id, pkgPath string
+	key         pkgKey
 	files       []string
 	syntax      []*ast.File
 	errors      []packages.Error

--- a/internal/lsp/cache/session.go
+++ b/internal/lsp/cache/session.go
@@ -63,10 +63,10 @@ func (s *session) NewView(name string, folder span.URI) source.View {
 		filesByBase:    make(map[string][]viewFile),
 		contentChanges: make(map[span.URI]func()),
 		mcache: &metadataCache{
-			packages: make(map[string]*metadata),
+			packages: make(map[pkgKey]*metadata),
 		},
 		pcache: &packageCache{
-			packages: make(map[string]*entry),
+			packages: make(map[pkgKey]*entry),
 		},
 		ignoredURIs: make(map[span.URI]struct{}),
 	}

--- a/internal/lsp/source/completion.go
+++ b/internal/lsp/source/completion.go
@@ -262,7 +262,7 @@ func Completion(ctx context.Context, f GoFile, pos token.Pos) ([]CompletionItem,
 		enclosingCompositeLiteral: clInfo,
 	}
 
-	// Set the filter surrounding.
+	// Record the identifer surrounding the position.
 	if ident, ok := path[0].(*ast.Ident); ok {
 		c.setSurrounding(ident)
 	}
@@ -314,7 +314,7 @@ func Completion(ctx context.Context, f GoFile, pos token.Pos) ([]CompletionItem,
 	case *ast.SelectorExpr:
 		// The go parser inserts a phantom "_" Sel node when the selector is
 		// not followed by an identifier or a "(". The "_" isn't actually in
-		// the text, so don't think it is our surrounding.
+		// the text, so don't mistake it for our surrounding.
 		// TODO: Find a way to differentiate between phantom "_" and real "_",
 		//       perhaps by checking if "_" is present in file contents.
 		if n.Sel.Name != "_" || c.pos != n.Sel.Pos() {

--- a/internal/lsp/testdata/testy/testy.go
+++ b/internal/lsp/testdata/testy/testy.go
@@ -1,3 +1,5 @@
 package testy
 
-func a() {}
+func a() { //@item(testyA, "a()", "", "func")
+	Test //@complete(" //")
+}

--- a/internal/lsp/testdata/testy/testy_test.go
+++ b/internal/lsp/testdata/testy/testy_test.go
@@ -4,5 +4,5 @@ import "testing"
 
 func TestSomething(t *testing.T) { //@item(TestSomething, "TestSomething(t *testing.T)", "", "func")
 	var x int //@diag("x", "LSP", "x declared but not used")
-	a()
+	a()       //@complete("(", testyA)
 }

--- a/internal/lsp/tests/tests.go
+++ b/internal/lsp/tests/tests.go
@@ -28,7 +28,7 @@ import (
 // We hardcode the expected number of test cases to ensure that all tests
 // are being executed. If a test is added, this number must be changed.
 const (
-	ExpectedCompletionsCount       = 121
+	ExpectedCompletionsCount       = 123
 	ExpectedCompletionSnippetCount = 14
 	ExpectedDiagnosticsCount       = 17
 	ExpectedFormatCount            = 5


### PR DESCRIPTION
go/packages already treats code and code+test as two separate
packages, but we were caching packages by only their package path,
which is not unique. If you loaded a test file first, all the non-test
files in the package would become associated to the code+test package,
so the non-test files would behave as if they could see objects
defined in the test files.

Now we cache packages by their path and whether they contain tests or
not. We also avoid associating the code+test package to the non-test
files so that opening a non-test file will properly load the non-test
package instead of reusing the code+test package.

This means we will now parse and type check non-test files twice,
which will impact memory usage and perhaps responsiveness in some
scenarios.

Fixes golang/go#30100