### PR TITLE
internal/lsp/cache: fix leaking wg.Done() and <-ioLimit

### DIFF
--- a/internal/lsp/cache/parse.go
+++ b/internal/lsp/cache/parse.go
@@ -60,11 +60,10 @@ func (imp *importer) parseFiles(filenames []string) ([]*ast.File, []error) {
 
 		wg.Add(1)
 		go func(i int, filename string) {
-			defer wg.Done()
-
 			ioLimit <- true // wait
 			defer func() {
 				<-ioLimit // signal done
+				wg.Done()
 			}()
 
 			if gof.ast != nil { // already have an ast
@@ -79,7 +78,7 @@ func (imp *importer) parseFiles(filenames []string) ([]*ast.File, []error) {
 			}
 
 			src := gof.fc.Data
-			if len(src) == 0 { // no source
+			if src == nil { // no source
 				parsed[i], errors[i] = nil, fmt.Errorf("No source for %v", filename)
 				return
 			}

--- a/internal/lsp/cache/parse.go
+++ b/internal/lsp/cache/parse.go
@@ -60,33 +60,38 @@ func (imp *importer) parseFiles(filenames []string) ([]*ast.File, []error) {
 
 		wg.Add(1)
 		go func(i int, filename string) {
+			defer wg.Done()
+
 			ioLimit <- true // wait
+			defer func() {
+				<-ioLimit // signal done
+			}()
 
-			if gof.ast != nil {
+			if gof.ast != nil { // already have an ast
 				parsed[i], errors[i] = gof.ast, nil
-			} else {
-				// We don't have a cached AST for this file.
-				gof.read(imp.ctx)
-				if gof.fc.Error != nil {
-					return
-				}
-				src := gof.fc.Data
-				if src == nil {
-					parsed[i], errors[i] = nil, fmt.Errorf("No source for %v", filename)
-				} else {
-					// ParseFile may return both an AST and an error.
-					parsed[i], errors[i] = parseFile(imp.fset, filename, src)
-
-					// Fix any badly parsed parts of the AST.
-					if file := parsed[i]; file != nil {
-						tok := imp.fset.File(file.Pos())
-						imp.view.fix(imp.ctx, parsed[i], tok, src)
-					}
-				}
+				return
 			}
 
-			<-ioLimit // signal
-			wg.Done()
+			// No cached AST for this file, so try parsing it.
+			gof.read(imp.ctx)
+			if gof.fc.Error != nil { // file content error, so abort
+				return
+			}
+
+			src := gof.fc.Data
+			if len(src) == 0 { // no source
+				parsed[i], errors[i] = nil, fmt.Errorf("No source for %v", filename)
+				return
+			}
+
+			// ParseFile may return a partial AST AND an error.
+			parsed[i], errors[i] = parseFile(imp.fset, filename, src)
+
+			// Fix any badly parsed parts of the AST.
+			if file := parsed[i]; file != nil {
+				tok := imp.fset.File(file.Pos())
+				imp.view.fix(imp.ctx, parsed[i], tok, src)
+			}
 		}(i, filename)
 	}
 	wg.Wait()


### PR DESCRIPTION
There were several returns in this function that could leak both the
wg.Done() and <-ioLimit. This refactors them into defers close to their
counterparts.

Additionally I refactored the function to favor early returns over
nested if statements.

Fixes golang/go#32368