### PR TITLE
internal/lsp: use x/xerrors to create new errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.11
 require (
 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
+	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7
 )

--- a/go.sum
+++ b/go.sum
@@ -5,3 +5,5 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEha
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/lsp/cache/gofile.go
+++ b/internal/lsp/cache/gofile.go
@@ -6,7 +6,6 @@ package cache
 
 import (
 	"context"
-	"fmt"
 	"go/ast"
 	"go/token"
 	"sync"
@@ -15,6 +14,7 @@ import (
 	"golang.org/x/tools/internal/lsp/telemetry"
 	"golang.org/x/tools/internal/lsp/telemetry/log"
 	"golang.org/x/tools/internal/span"
+	errors "golang.org/x/xerrors"
 )
 
 // goFile holds all of the information we know about a Go file.
@@ -55,7 +55,7 @@ func (f *goFile) GetToken(ctx context.Context) (*token.File, error) {
 	}
 	tok := f.view.session.cache.fset.File(file.Pos())
 	if tok == nil {
-		return nil, fmt.Errorf("no token.File for %s", f.URI())
+		return nil, errors.Errorf("no token.File for %s", f.URI())
 	}
 	return tok, nil
 }
@@ -67,7 +67,7 @@ func (f *goFile) GetAST(ctx context.Context, mode source.ParseMode) (*ast.File, 
 
 	if f.isDirty(ctx) || f.wrongParseMode(ctx, mode) {
 		if _, err := f.view.loadParseTypecheck(ctx, f); err != nil {
-			return nil, fmt.Errorf("GetAST: unable to check package for %s: %v", f.URI(), err)
+			return nil, errors.Errorf("GetAST: unable to check package for %s: %v", f.URI(), err)
 		}
 	}
 	fh := f.Handle(ctx)

--- a/internal/lsp/cache/modfile.go
+++ b/internal/lsp/cache/modfile.go
@@ -6,8 +6,9 @@ package cache
 
 import (
 	"context"
-	"fmt"
 	"go/token"
+
+	errors "golang.org/x/xerrors"
 )
 
 // modFile holds all of the information we know about a mod file.
@@ -16,7 +17,7 @@ type modFile struct {
 }
 
 func (*modFile) GetToken(context.Context) (*token.File, error) {
-	return nil, fmt.Errorf("GetToken: not implemented")
+	return nil, errors.Errorf("GetToken: not implemented")
 }
 
 func (*modFile) setContent(content []byte) {}

--- a/internal/lsp/cache/session.go
+++ b/internal/lsp/cache/session.go
@@ -6,7 +6,6 @@ package cache
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"sort"
 	"strconv"
@@ -21,6 +20,7 @@ import (
 	"golang.org/x/tools/internal/lsp/telemetry/trace"
 	"golang.org/x/tools/internal/span"
 	"golang.org/x/tools/internal/xcontext"
+	errors "golang.org/x/xerrors"
 )
 
 type session struct {
@@ -178,7 +178,7 @@ func (s *session) removeView(ctx context.Context, view *view) error {
 			return nil
 		}
 	}
-	return fmt.Errorf("view %s for %v not found", view.Name(), view.Folder())
+	return errors.Errorf("view %s for %v not found", view.Name(), view.Folder())
 }
 
 // TODO: Propagate the language ID through to the view.

--- a/internal/lsp/cache/sumfile.go
+++ b/internal/lsp/cache/sumfile.go
@@ -6,8 +6,9 @@ package cache
 
 import (
 	"context"
-	"fmt"
 	"go/token"
+
+	errors "golang.org/x/xerrors"
 )
 
 // sumFile holds all of the information we know about a sum file.
@@ -16,7 +17,7 @@ type sumFile struct {
 }
 
 func (*sumFile) GetToken(context.Context) (*token.File, error) {
-	return nil, fmt.Errorf("GetToken: not implemented")
+	return nil, errors.Errorf("GetToken: not implemented")
 }
 
 func (*sumFile) setContent(content []byte) {}

--- a/internal/lsp/cache/token.go
+++ b/internal/lsp/cache/token.go
@@ -6,11 +6,11 @@ package cache
 
 import (
 	"context"
-	"fmt"
 	"go/token"
 
 	"golang.org/x/tools/internal/lsp/source"
 	"golang.org/x/tools/internal/memoize"
+	errors "golang.org/x/xerrors"
 )
 
 type tokenKey struct {
@@ -87,7 +87,7 @@ func tokenFile(ctx context.Context, c *cache, fh source.FileHandle) (*token.File
 	}
 	tok := c.FileSet().AddFile(fh.Identity().URI.Filename(), -1, len(buf))
 	if tok == nil {
-		return nil, fmt.Errorf("no token.File for %s", fh.Identity().URI)
+		return nil, errors.Errorf("no token.File for %s", fh.Identity().URI)
 	}
 	tok.SetLinesForContent(buf)
 	return tok, nil

--- a/internal/lsp/cmd/check.go
+++ b/internal/lsp/cmd/check.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"golang.org/x/tools/internal/span"
+	errors "golang.org/x/xerrors"
 )
 
 // check implements the check verb for gopls.
@@ -60,14 +61,14 @@ func (c *check) Run(ctx context.Context, args ...string) error {
 		select {
 		case <-file.hasDiagnostics:
 		case <-time.After(30 * time.Second):
-			return fmt.Errorf("timed out waiting for results from %v", file.uri)
+			return errors.Errorf("timed out waiting for results from %v", file.uri)
 		}
 		file.diagnosticsMu.Lock()
 		defer file.diagnosticsMu.Unlock()
 		for _, d := range file.diagnostics {
 			spn, err := file.mapper.RangeSpan(d.Range)
 			if err != nil {
-				return fmt.Errorf("Could not convert position %v for %q", d.Range, d.Message)
+				return errors.Errorf("Could not convert position %v for %q", d.Range, d.Message)
 			}
 			fmt.Printf("%v: %v\n", spn, d.Message)
 		}

--- a/internal/lsp/cmd/cmd.go
+++ b/internal/lsp/cmd/cmd.go
@@ -28,6 +28,7 @@ import (
 	"golang.org/x/tools/internal/span"
 	"golang.org/x/tools/internal/tool"
 	"golang.org/x/tools/internal/xcontext"
+	errors "golang.org/x/xerrors"
 )
 
 // Application is the main application as passed to tool.Main
@@ -335,7 +336,7 @@ func (c *cmdClient) getFile(ctx context.Context, uri span.URI) *cmdFile {
 		fname := uri.Filename()
 		content, err := ioutil.ReadFile(fname)
 		if err != nil {
-			file.err = fmt.Errorf("%v: %v", uri, err)
+			file.err = errors.Errorf("%v: %v", uri, err)
 			return file
 		}
 		f := c.fset.AddFile(fname, -1, len(content))
@@ -359,7 +360,7 @@ func (c *connection) AddFile(ctx context.Context, uri span.URI) *cmdFile {
 	p.TextDocument.Text = string(file.mapper.Content)
 	p.TextDocument.LanguageID = source.DetectLanguage("", file.uri.Filename()).String()
 	if err := c.Server.DidOpen(ctx, p); err != nil {
-		file.err = fmt.Errorf("%v: %v", uri, err)
+		file.err = errors.Errorf("%v: %v", uri, err)
 	}
 	return file
 }

--- a/internal/lsp/cmd/definition.go
+++ b/internal/lsp/cmd/definition.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/tools/internal/lsp/protocol"
 	"golang.org/x/tools/internal/span"
 	"golang.org/x/tools/internal/tool"
+	errors "golang.org/x/xerrors"
 )
 
 // A Definition is the result of a 'definition' query.
@@ -79,26 +80,26 @@ func (d *definition) Run(ctx context.Context, args ...string) error {
 	}
 	locs, err := conn.Definition(ctx, &p)
 	if err != nil {
-		return fmt.Errorf("%v: %v", from, err)
+		return errors.Errorf("%v: %v", from, err)
 	}
 
 	if len(locs) == 0 {
-		return fmt.Errorf("%v: not an identifier", from)
+		return errors.Errorf("%v: not an identifier", from)
 	}
 	hover, err := conn.Hover(ctx, &p)
 	if err != nil {
-		return fmt.Errorf("%v: %v", from, err)
+		return errors.Errorf("%v: %v", from, err)
 	}
 	if hover == nil {
-		return fmt.Errorf("%v: not an identifier", from)
+		return errors.Errorf("%v: not an identifier", from)
 	}
 	file = conn.AddFile(ctx, span.NewURI(locs[0].URI))
 	if file.err != nil {
-		return fmt.Errorf("%v: %v", from, file.err)
+		return errors.Errorf("%v: %v", from, file.err)
 	}
 	definition, err := file.mapper.Span(locs[0])
 	if err != nil {
-		return fmt.Errorf("%v: %v", from, err)
+		return errors.Errorf("%v: %v", from, err)
 	}
 	description := strings.TrimSpace(hover.Contents.Value)
 	var result interface{}
@@ -115,7 +116,7 @@ func (d *definition) Run(ctx context.Context, args ...string) error {
 			Desc:   description,
 		}
 	default:
-		return fmt.Errorf("unknown emulation for definition: %s", d.query.Emulate)
+		return errors.Errorf("unknown emulation for definition: %s", d.query.Emulate)
 	}
 	if err != nil {
 		return err
@@ -131,7 +132,7 @@ func (d *definition) Run(ctx context.Context, args ...string) error {
 	case *guru.Definition:
 		fmt.Printf("%s: defined here as %s", d.ObjPos, d.Desc)
 	default:
-		return fmt.Errorf("no printer for type %T", result)
+		return errors.Errorf("no printer for type %T", result)
 	}
 	return nil
 }

--- a/internal/lsp/cmd/format.go
+++ b/internal/lsp/cmd/format.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/tools/internal/lsp/protocol"
 	"golang.org/x/tools/internal/lsp/source"
 	"golang.org/x/tools/internal/span"
+	errors "golang.org/x/xerrors"
 )
 
 // format implements the format verb for gopls.
@@ -68,18 +69,18 @@ func (f *format) Run(ctx context.Context, args ...string) error {
 			return err
 		}
 		if loc.Range.Start != loc.Range.End {
-			return fmt.Errorf("only full file formatting supported")
+			return errors.Errorf("only full file formatting supported")
 		}
 		p := protocol.DocumentFormattingParams{
 			TextDocument: protocol.TextDocumentIdentifier{URI: loc.URI},
 		}
 		edits, err := conn.Formatting(ctx, &p)
 		if err != nil {
-			return fmt.Errorf("%v: %v", spn, err)
+			return errors.Errorf("%v: %v", spn, err)
 		}
 		sedits, err := lsp.FromProtocolEdits(file.mapper, edits)
 		if err != nil {
-			return fmt.Errorf("%v: %v", spn, err)
+			return errors.Errorf("%v: %v", spn, err)
 		}
 		ops := source.EditsToDiff(sedits)
 		lines := diff.SplitLines(string(file.mapper.Content))

--- a/internal/lsp/cmd/serve.go
+++ b/internal/lsp/cmd/serve.go
@@ -24,6 +24,7 @@ import (
 	"golang.org/x/tools/internal/lsp/telemetry/tag"
 	"golang.org/x/tools/internal/lsp/telemetry/trace"
 	"golang.org/x/tools/internal/tool"
+	errors "golang.org/x/xerrors"
 )
 
 // Serve is a struct that exposes the configurable parts of the LSP server as
@@ -68,7 +69,7 @@ func (s *Serve) Run(ctx context.Context, args ...string) error {
 		}
 		f, err := os.Create(filename)
 		if err != nil {
-			return fmt.Errorf("Unable to create log file: %v", err)
+			return errors.Errorf("Unable to create log file: %v", err)
 		}
 		defer f.Close()
 		log.SetOutput(io.MultiWriter(os.Stderr, f))

--- a/internal/lsp/code_action.go
+++ b/internal/lsp/code_action.go
@@ -15,6 +15,7 @@ import (
 	"golang.org/x/tools/internal/lsp/telemetry"
 	"golang.org/x/tools/internal/lsp/telemetry/log"
 	"golang.org/x/tools/internal/span"
+	errors "golang.org/x/xerrors"
 )
 
 func (s *Server) codeAction(ctx context.Context, params *protocol.CodeActionParams) ([]protocol.CodeAction, error) {
@@ -33,7 +34,7 @@ func (s *Server) codeAction(ctx context.Context, params *protocol.CodeActionPara
 
 	uri := span.NewURI(params.TextDocument.URI)
 	if len(wanted) == 0 {
-		return nil, fmt.Errorf("no supported code action to execute for %s, wanted %v", uri, params.Context.Only)
+		return nil, errors.Errorf("no supported code action to execute for %s, wanted %v", uri, params.Context.Only)
 	}
 
 	view := s.session.ViewOf(uri)

--- a/internal/lsp/general.go
+++ b/internal/lsp/general.go
@@ -18,6 +18,7 @@ import (
 	"golang.org/x/tools/internal/lsp/telemetry/log"
 	"golang.org/x/tools/internal/lsp/telemetry/tag"
 	"golang.org/x/tools/internal/span"
+	errors "golang.org/x/xerrors"
 )
 
 func (s *Server) initialize(ctx context.Context, params *protocol.InitializeParams) (*protocol.InitializeResult, error) {
@@ -60,7 +61,7 @@ func (s *Server) initialize(ctx context.Context, params *protocol.InitializePara
 			// no folders and no root, single file mode
 			//TODO(iancottrell): not sure how to do single file mode yet
 			//issue: golang.org/issue/31168
-			return nil, fmt.Errorf("single file mode not supported yet")
+			return nil, errors.Errorf("single file mode not supported yet")
 		}
 	}
 
@@ -187,13 +188,13 @@ func (s *Server) processConfig(ctx context.Context, view source.View, config int
 	}
 	c, ok := config.(map[string]interface{})
 	if !ok {
-		return fmt.Errorf("invalid config gopls type %T", config)
+		return errors.Errorf("invalid config gopls type %T", config)
 	}
 	// Get the environment for the go/packages config.
 	if env := c["env"]; env != nil {
 		menv, ok := env.(map[string]interface{})
 		if !ok {
-			return fmt.Errorf("invalid config gopls.env type %T", env)
+			return errors.Errorf("invalid config gopls.env type %T", env)
 		}
 		env := view.Env()
 		for k, v := range menv {
@@ -205,7 +206,7 @@ func (s *Server) processConfig(ctx context.Context, view source.View, config int
 	if buildFlags := c["buildFlags"]; buildFlags != nil {
 		iflags, ok := buildFlags.([]interface{})
 		if !ok {
-			return fmt.Errorf("invalid config gopls.buildFlags type %T", buildFlags)
+			return errors.Errorf("invalid config gopls.buildFlags type %T", buildFlags)
 		}
 		flags := make([]string, 0, len(iflags))
 		for _, flag := range iflags {

--- a/internal/lsp/link.go
+++ b/internal/lsp/link.go
@@ -6,7 +6,6 @@ package lsp
 
 import (
 	"context"
-	"fmt"
 	"go/ast"
 	"go/token"
 	"regexp"
@@ -18,6 +17,7 @@ import (
 	"golang.org/x/tools/internal/lsp/telemetry/log"
 	"golang.org/x/tools/internal/lsp/telemetry/tag"
 	"golang.org/x/tools/internal/span"
+	errors "golang.org/x/xerrors"
 )
 
 func (s *Server) documentLink(ctx context.Context, params *protocol.DocumentLinkParams) ([]protocol.DocumentLink, error) {
@@ -82,7 +82,7 @@ func findLinksInString(src string, pos token.Pos, view source.View, mapper *prot
 	var links []protocol.DocumentLink
 	re, err := getURLRegexp()
 	if err != nil {
-		return nil, fmt.Errorf("cannot create regexp for links: %s", err.Error())
+		return nil, errors.Errorf("cannot create regexp for links: %s", err.Error())
 	}
 	for _, urlIndex := range re.FindAllIndex([]byte(src), -1) {
 		start := urlIndex[0]

--- a/internal/lsp/protocol/span.go
+++ b/internal/lsp/protocol/span.go
@@ -7,10 +7,10 @@
 package protocol
 
 import (
-	"fmt"
 	"go/token"
 
 	"golang.org/x/tools/internal/span"
+	errors "golang.org/x/xerrors"
 )
 
 type ColumnMapper struct {
@@ -47,7 +47,7 @@ func (m *ColumnMapper) Location(s span.Span) (Location, error) {
 
 func (m *ColumnMapper) Range(s span.Span) (Range, error) {
 	if span.CompareURI(m.URI, s.URI()) != 0 {
-		return Range{}, fmt.Errorf("column mapper is for file %q instead of %q", m.URI, s.URI())
+		return Range{}, errors.Errorf("column mapper is for file %q instead of %q", m.URI, s.URI())
 	}
 	s, err := s.WithAll(m.Converter)
 	if err != nil {

--- a/internal/lsp/source/completion.go
+++ b/internal/lsp/source/completion.go
@@ -6,7 +6,6 @@ package source
 
 import (
 	"context"
-	"fmt"
 	"go/ast"
 	"go/token"
 	"go/types"
@@ -16,6 +15,7 @@ import (
 	"golang.org/x/tools/internal/lsp/snippet"
 	"golang.org/x/tools/internal/lsp/telemetry/trace"
 	"golang.org/x/tools/internal/span"
+	errors "golang.org/x/xerrors"
 )
 
 type CompletionItem struct {
@@ -212,7 +212,7 @@ func (c *completer) setSurrounding(ident *ast.Ident) {
 // members for more candidates.
 func (c *completer) found(obj types.Object, score float64) error {
 	if obj.Pkg() != nil && obj.Pkg() != c.types && !obj.Exported() {
-		return fmt.Errorf("%s is inaccessible from %s", obj.Name(), c.types.Path())
+		return errors.Errorf("%s is inaccessible from %s", obj.Name(), c.types.Path())
 	}
 
 	if c.inDeepCompletion() {
@@ -287,14 +287,14 @@ func Completion(ctx context.Context, view View, f GoFile, pos token.Pos, opts Co
 	}
 	pkg := f.GetPackage(ctx)
 	if pkg == nil || pkg.IsIllTyped() {
-		return nil, nil, fmt.Errorf("package for %s is ill typed", f.URI())
+		return nil, nil, errors.Errorf("package for %s is ill typed", f.URI())
 	}
 
 	// Completion is based on what precedes the cursor.
 	// Find the path to the position before pos.
 	path, _ := astutil.PathEnclosingInterval(file, pos-1, pos-1)
 	if path == nil {
-		return nil, nil, fmt.Errorf("cannot find node enclosing position")
+		return nil, nil, errors.Errorf("cannot find node enclosing position")
 	}
 	// Skip completion inside comments.
 	for _, g := range file.Comments {
@@ -358,7 +358,7 @@ func Completion(ctx context.Context, view View, f GoFile, pos token.Pos, opts Co
 					qual := types.RelativeTo(pkg.GetTypes())
 					of += ", of " + types.ObjectString(obj, qual)
 				}
-				return nil, nil, fmt.Errorf("this is a definition%s", of)
+				return nil, nil, errors.Errorf("this is a definition%s", of)
 			}
 		}
 		if err := c.lexical(); err != nil {
@@ -423,7 +423,7 @@ func (c *completer) selector(sel *ast.SelectorExpr) error {
 	// Invariant: sel is a true selector.
 	tv, ok := c.info.Types[sel.X]
 	if !ok {
-		return fmt.Errorf("cannot resolve %s", sel.X)
+		return errors.Errorf("cannot resolve %s", sel.X)
 	}
 
 	return c.methodsAndFields(tv.Type, tv.Addressable())

--- a/internal/lsp/source/format.go
+++ b/internal/lsp/source/format.go
@@ -8,7 +8,6 @@ package source
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"go/format"
 
 	"golang.org/x/tools/go/ast/astutil"
@@ -18,6 +17,7 @@ import (
 	"golang.org/x/tools/internal/lsp/telemetry/log"
 	"golang.org/x/tools/internal/lsp/telemetry/trace"
 	"golang.org/x/tools/internal/span"
+	errors "golang.org/x/xerrors"
 )
 
 // Format formats a file with a given range.
@@ -43,7 +43,7 @@ func Format(ctx context.Context, f GoFile, rng span.Range) ([]TextEdit, error) {
 	}
 	path, exact := astutil.PathEnclosingInterval(file, rng.Start, rng.End)
 	if !exact || len(path) == 0 {
-		return nil, fmt.Errorf("no exact AST node matching the specified range")
+		return nil, errors.Errorf("no exact AST node matching the specified range")
 	}
 	node := path[0]
 
@@ -80,10 +80,10 @@ func Imports(ctx context.Context, view View, f GoFile, rng span.Range) ([]TextEd
 	}
 	pkg := f.GetPackage(ctx)
 	if pkg == nil || pkg.IsIllTyped() {
-		return nil, fmt.Errorf("no package for file %s", f.URI())
+		return nil, errors.Errorf("no package for file %s", f.URI())
 	}
 	if hasListErrors(pkg.GetErrors()) {
-		return nil, fmt.Errorf("%s has list errors, not running goimports", f.URI())
+		return nil, errors.Errorf("%s has list errors, not running goimports", f.URI())
 	}
 
 	options := &imports.Options{
@@ -125,10 +125,10 @@ func AllImportsFixes(ctx context.Context, view View, f GoFile, rng span.Range) (
 	}
 	pkg := f.GetPackage(ctx)
 	if pkg == nil || pkg.IsIllTyped() {
-		return nil, nil, fmt.Errorf("no package for file %s", f.URI())
+		return nil, nil, errors.Errorf("no package for file %s", f.URI())
 	}
 	if hasListErrors(pkg.GetErrors()) {
-		return nil, nil, fmt.Errorf("%s has list errors, not running goimports", f.URI())
+		return nil, nil, errors.Errorf("%s has list errors, not running goimports", f.URI())
 	}
 
 	options := &imports.Options{

--- a/internal/lsp/source/highlight.go
+++ b/internal/lsp/source/highlight.go
@@ -6,13 +6,13 @@ package source
 
 import (
 	"context"
-	"fmt"
 	"go/ast"
 	"go/token"
 
 	"golang.org/x/tools/go/ast/astutil"
 	"golang.org/x/tools/internal/lsp/telemetry/trace"
 	"golang.org/x/tools/internal/span"
+	errors "golang.org/x/xerrors"
 )
 
 func Highlight(ctx context.Context, f GoFile, pos token.Pos) ([]span.Span, error) {
@@ -26,11 +26,11 @@ func Highlight(ctx context.Context, f GoFile, pos token.Pos) ([]span.Span, error
 	fset := f.FileSet()
 	path, _ := astutil.PathEnclosingInterval(file, pos, pos)
 	if len(path) == 0 {
-		return nil, fmt.Errorf("no enclosing position found for %s", fset.Position(pos))
+		return nil, errors.Errorf("no enclosing position found for %s", fset.Position(pos))
 	}
 	id, ok := path[0].(*ast.Ident)
 	if !ok {
-		return nil, fmt.Errorf("%s is not an identifier", fset.Position(pos))
+		return nil, errors.Errorf("%s is not an identifier", fset.Position(pos))
 	}
 	var result []span.Span
 	if id.Obj != nil {

--- a/internal/lsp/source/hover.go
+++ b/internal/lsp/source/hover.go
@@ -6,7 +6,6 @@ package source
 
 import (
 	"context"
-	"fmt"
 	"go/ast"
 	"go/doc"
 	"go/format"
@@ -14,6 +13,7 @@ import (
 	"strings"
 
 	"golang.org/x/tools/internal/lsp/telemetry/trace"
+	errors "golang.org/x/xerrors"
 )
 
 type documentation struct {
@@ -124,7 +124,7 @@ func formatGenDecl(node *ast.GenDecl, obj types.Object, typ types.Type) (*docume
 		}
 	}
 	if spec == nil {
-		return nil, fmt.Errorf("no spec for node %v at position %v", node, obj.Pos())
+		return nil, errors.Errorf("no spec for node %v at position %v", node, obj.Pos())
 	}
 	// If we have a field or method.
 	switch obj.(type) {
@@ -145,7 +145,7 @@ func formatGenDecl(node *ast.GenDecl, obj types.Object, typ types.Type) (*docume
 	case *ast.ImportSpec:
 		return &documentation{spec, spec.Doc}, nil
 	}
-	return nil, fmt.Errorf("unable to format spec %v (%T)", spec, spec)
+	return nil, errors.Errorf("unable to format spec %v (%T)", spec, spec)
 }
 
 func formatVar(node ast.Spec, obj types.Object) (*documentation, error) {

--- a/internal/lsp/source/references.go
+++ b/internal/lsp/source/references.go
@@ -6,12 +6,12 @@ package source
 
 import (
 	"context"
-	"fmt"
 	"go/ast"
 	"go/types"
 
 	"golang.org/x/tools/internal/lsp/telemetry/trace"
 	"golang.org/x/tools/internal/span"
+	errors "golang.org/x/xerrors"
 )
 
 // ReferenceInfo holds information about reference to an identifier in Go source.
@@ -33,17 +33,17 @@ func (i *IdentifierInfo) References(ctx context.Context) ([]*ReferenceInfo, erro
 
 	// If the object declaration is nil, assume it is an import spec and do not look for references.
 	if i.decl.obj == nil {
-		return nil, fmt.Errorf("no references for an import spec")
+		return nil, errors.Errorf("no references for an import spec")
 	}
 
 	pkgs := i.File.GetPackages(ctx)
 	for _, pkg := range pkgs {
 		if pkg == nil || pkg.IsIllTyped() {
-			return nil, fmt.Errorf("package for %s is ill typed", i.File.URI())
+			return nil, errors.Errorf("package for %s is ill typed", i.File.URI())
 		}
 		info := pkg.GetTypesInfo()
 		if info == nil {
-			return nil, fmt.Errorf("package %s has no types info", pkg.PkgPath())
+			return nil, errors.Errorf("package %s has no types info", pkg.PkgPath())
 		}
 
 		if i.decl.wasImplicit {

--- a/internal/lsp/source/symbols.go
+++ b/internal/lsp/source/symbols.go
@@ -6,7 +6,6 @@ package source
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"go/ast"
 	"go/token"
@@ -14,6 +13,7 @@ import (
 
 	"golang.org/x/tools/internal/lsp/telemetry/trace"
 	"golang.org/x/tools/internal/span"
+	errors "golang.org/x/xerrors"
 )
 
 type SymbolKind int
@@ -52,7 +52,7 @@ func DocumentSymbols(ctx context.Context, f GoFile) ([]Symbol, error) {
 	}
 	pkg := f.GetPackage(ctx)
 	if pkg == nil || pkg.IsIllTyped() {
-		return nil, fmt.Errorf("no package for %s", f.URI())
+		return nil, errors.Errorf("no package for %s", f.URI())
 	}
 	info := pkg.GetTypesInfo()
 	q := qualifier(file, pkg.GetTypes(), info)

--- a/internal/lsp/text_synchronization.go
+++ b/internal/lsp/text_synchronization.go
@@ -7,7 +7,6 @@ package lsp
 import (
 	"bytes"
 	"context"
-	"fmt"
 
 	"golang.org/x/tools/internal/jsonrpc2"
 	"golang.org/x/tools/internal/lsp/protocol"
@@ -16,6 +15,7 @@ import (
 	"golang.org/x/tools/internal/lsp/telemetry/log"
 	"golang.org/x/tools/internal/lsp/telemetry/trace"
 	"golang.org/x/tools/internal/span"
+	errors "golang.org/x/xerrors"
 )
 
 func (s *Server) didOpen(ctx context.Context, params *protocol.DidOpenTextDocumentParams) error {
@@ -54,7 +54,7 @@ func (s *Server) didChange(ctx context.Context, params *protocol.DidChangeTextDo
 	if !isFullChange {
 		switch s.textDocumentSyncKind {
 		case protocol.Full:
-			return fmt.Errorf("expected a full content change, received incremental changes for %s", uri)
+			return errors.Errorf("expected a full content change, received incremental changes for %s", uri)
 		case protocol.Incremental:
 			// Determine the new file content.
 			var err error

--- a/internal/lsp/util.go
+++ b/internal/lsp/util.go
@@ -6,11 +6,11 @@ package lsp
 
 import (
 	"context"
-	"fmt"
 
 	"golang.org/x/tools/internal/lsp/protocol"
 	"golang.org/x/tools/internal/lsp/source"
 	"golang.org/x/tools/internal/span"
+	errors "golang.org/x/xerrors"
 )
 
 func getSourceFile(ctx context.Context, v source.View, uri span.URI) (source.File, *protocol.ColumnMapper, error) {
@@ -38,7 +38,7 @@ func getGoFile(ctx context.Context, v source.View, uri span.URI) (source.GoFile,
 	}
 	gof, ok := f.(source.GoFile)
 	if !ok {
-		return nil, nil, fmt.Errorf("not a Go file %v", f.URI())
+		return nil, nil, errors.Errorf("not a Go file %v", f.URI())
 	}
 	return gof, m, nil
 }

--- a/internal/lsp/workspace.go
+++ b/internal/lsp/workspace.go
@@ -6,10 +6,10 @@ package lsp
 
 import (
 	"context"
-	"fmt"
 
 	"golang.org/x/tools/internal/lsp/protocol"
 	"golang.org/x/tools/internal/span"
+	errors "golang.org/x/xerrors"
 )
 
 func (s *Server) changeFolders(ctx context.Context, event protocol.WorkspaceFoldersChangeEvent) error {
@@ -18,7 +18,7 @@ func (s *Server) changeFolders(ctx context.Context, event protocol.WorkspaceFold
 		if view != nil {
 			view.Shutdown(ctx)
 		} else {
-			return fmt.Errorf("view %s for %v not found", folder.Name, folder.URI)
+			return errors.Errorf("view %s for %v not found", folder.Name, folder.URI)
 		}
 	}
 


### PR DESCRIPTION
This relates to https://github.com/golang/go/issues/31374 and should switch all instances within `gopls` to use `x/errors` instead of `fmt` to create new errors.