### PR TITLE
internal/lsp: fix errors when adding new file to existing package

### DIFF
--- a/internal/lsp/cache/pkg.go
+++ b/internal/lsp/cache/pkg.go
@@ -23,7 +23,7 @@ type pkg struct {
 	pkgPath packagePath
 
 	files      []string
-	syntax     []*astFile
+	syntax     map[string]*astFile
 	errors     []packages.Error
 	imports    map[packagePath]*pkg
 	types      *types.Package
@@ -146,9 +146,9 @@ func (pkg *pkg) GetFilenames() []string {
 }
 
 func (pkg *pkg) GetSyntax() []*ast.File {
-	syntax := make([]*ast.File, len(pkg.syntax))
-	for i := range pkg.syntax {
-		syntax[i] = pkg.syntax[i].file
+	syntax := make([]*ast.File, 0, len(pkg.syntax))
+	for _, astFile := range pkg.syntax {
+		syntax = append(syntax, astFile.file)
 	}
 	return syntax
 }

--- a/internal/lsp/cache/view.go
+++ b/internal/lsp/cache/view.go
@@ -251,6 +251,14 @@ func (f *goFile) invalidateAST() {
 	}
 }
 
+// invalidatePackage removes the specified package and dependents from the
+// package cache.
+func (v *view) invalidatePackage(pkgPath packagePath) {
+	v.pcache.mu.Lock()
+	defer v.pcache.mu.Unlock()
+	v.remove(pkgPath, make(map[packagePath]struct{}))
+}
+
 // remove invalidates a package and its reverse dependencies in the view's
 // package cache. It is assumed that the caller has locked both the mutexes
 // of both the mcache and the pcache.


### PR DESCRIPTION
Previously when you added a new file to an existing package, the new
file would get stuck with the "no package for file" error until you
saved the file and then made changed a different file in the
package. There were two changes required to fix the errors:

First, we need to invalidate the package cache when a new file is
added to a package so that the package will actually re-parse and
re-type check. We now notice if file names changed when updating a
package's metadata and invalidate the package cache accordingly.

Second, when dealing with overlay (unsaved) files, we need to map
the *goFile to the package even if we fail to parse the
file (e.g. the new file fails to parse when it is empty). If we don't
map it to the package, the package won't get refreshed as the file is
changed.

Fixes golang/go#32341