### PR TITLE
internal/lsp: fix check for changed imports

### DIFF
--- a/internal/lsp/cache/load.go
+++ b/internal/lsp/cache/load.go
@@ -130,7 +130,7 @@ func (v *view) parseImports(ctx context.Context, f *goFile) bool {
 		return true
 	}
 	for i, importSpec := range f.imports {
-		if importSpec.Path.Value != f.imports[i].Path.Value {
+		if importSpec.Path.Value != parsed.Imports[i].Path.Value {
 			return true
 		}
 	}


### PR DESCRIPTION
We weren't comparing the right values when checking to see if a file's
import statements had changed. This was causing us to not refetch a
package's metadata when needed in certain cases. In particular, if you
typed out an import path by hand you would get stuck with "no metadata
for package" until you added or deleted another import line to trigger
metadata refresh.

Updates golang/go#32516, golang/go#32232