### PR TITLE
internal/lsp: fix error handling after a file is deleted

### DIFF
--- a/internal/lsp/cache/parse.go
+++ b/internal/lsp/cache/parse.go
@@ -89,7 +89,9 @@ func (imp *importer) parseFiles(filenames []string, ignoreFuncBodies bool) ([]*a
 			// We don't have a cached AST for this file, so we read its content and parse it.
 			src, _, err := gof.Handle(imp.ctx).Read(imp.ctx)
 			if err != nil {
-				setFatalErr(err)
+				// Don't treat this as a fatal error since we will get "file does not exist"
+				// after a file is deleted.
+				parsed[i], errors[i] = nil, err
 				return
 			}
 			if src == nil {


### PR DESCRIPTION
In a previous commit I made error checking stricter when parsing a
package's files. However, when a file is deleted from a package, our
parsing code starts to get "no such file" errors, which if treated as
a fatal error prevents the package from getting parsed. It doesn't
seem like there is a good way to detect when a file is deleted and
refresh the metadata, so revert the stricter error handling for now.