### PR TITLE
internal/lsp/cache: fix ineffectual err assignment

### DIFF
--- a/internal/lsp/cache/parse.go
+++ b/internal/lsp/cache/parse.go
@@ -231,7 +231,8 @@ func fix(ctx context.Context, file *ast.File, tok *token.File, src []byte) error
 		}
 		switch n := n.(type) {
 		case *ast.BadStmt:
-			if err := parseDeferOrGoStmt(n, parent, tok, src); err != nil {
+			err = parseDeferOrGoStmt(n, parent, tok, src) // don't shadow err
+			if err != nil {
 				err = fmt.Errorf("unable to parse defer or go from *ast.BadStmt: %v", err)
 			}
 			return false


### PR DESCRIPTION
The `if err :=` block creates a shadow err value that is then discarded
after the block.

Change-Id: I78f6a7298ac5d3d86ece056a9e328bcee9fdc683