### PR TITLE
internal/lsp: suggest completions that satisfy interfaces

### DIFF
--- a/internal/lsp/source/util.go
+++ b/internal/lsp/source/util.go
@@ -74,7 +74,7 @@ func resolveInvalid(obj types.Object, node ast.Node, info *types.Info) types.Obj
 		default:
 			return nil
 		}
-		typ := types.NewNamed(types.NewTypeName(token.NoPos, obj.Pkg(), typename, nil), nil, nil)
+		typ := types.NewNamed(types.NewTypeName(token.NoPos, obj.Pkg(), typename, nil), types.Typ[types.Invalid], nil)
 		return types.NewVar(obj.Pos(), obj.Pkg(), obj.Name(), typ)
 	}
 	var resultExpr ast.Expr
@@ -125,6 +125,11 @@ func deref(typ types.Type) types.Type {
 		return p.Elem()
 	}
 	return typ
+}
+
+func isTypeName(obj types.Object) bool {
+	_, ok := obj.(*types.TypeName)
+	return ok
 }
 
 func formatParams(tup *types.Tuple, variadic bool, qf types.Qualifier) []string {

--- a/internal/lsp/testdata/interfacerank/interface_rank.go
+++ b/internal/lsp/testdata/interfacerank/interface_rank.go
@@ -1,0 +1,20 @@
+package interfacerank
+
+type foo interface {
+	foo()
+}
+
+type fooImpl int
+
+func (*fooImpl) foo() {}
+
+func wantsFoo(foo) {}
+
+func _() {
+	var (
+		aa string   //@item(irAA, "aa", "string", "var")
+		ab *fooImpl //@item(irAB, "ab", "*fooImpl", "var")
+	)
+
+	wantsFoo(a) //@complete(")", irAB, irAA)
+}

--- a/internal/lsp/testdata/unresolved/unresolved.go.in
+++ b/internal/lsp/testdata/unresolved/unresolved.go.in
@@ -1,0 +1,6 @@
+package unresolved
+
+func foo(interface{}) { //@item(unresolvedFoo, "foo(interface{})", "", "func")
+	// don't crash on fake "resolved" type
+	foo(func(i, j f //@complete(" //", unresolvedFoo)
+}

--- a/internal/lsp/tests/tests.go
+++ b/internal/lsp/tests/tests.go
@@ -25,7 +25,7 @@ import (
 // We hardcode the expected number of test cases to ensure that all tests
 // are being executed. If a test is added, this number must be changed.
 const (
-	ExpectedCompletionsCount       = 122
+	ExpectedCompletionsCount       = 124
 	ExpectedCompletionSnippetCount = 14
 	ExpectedDiagnosticsCount       = 17
 	ExpectedFormatCount            = 5


### PR DESCRIPTION
When checking if a completion candidate matches the expected type at
the cursor position, we now use types.AssignableTo instead of
types.Identical. This properly handles cases like using a concrete
type to satisfy an interface type.

Calling AssignableTo triggered some crashes related to the fake
"resolved" types we create. Their underlying type was nil, which is
not allowed. We now set their underlying type to the invalid type.

I've also rearranged things so expected type information lives in a
dedicated typeInference struct. For now there is no new information added,
but in subsequent commits there will be more metadata about the
expected type.