### PR TITLE
internal/gopathwalk: Ignore Bazel symlinks

### DIFF
--- a/internal/gopathwalk/walk.go
+++ b/internal/gopathwalk/walk.go
@@ -191,6 +191,10 @@ func (w *walker) walk(path string, typ os.FileMode) error {
 	}
 	if typ == os.ModeSymlink {
 		base := filepath.Base(path)
+		if strings.HasPrefix(base, "bazel-") {
+			// Bazel symlinks, usually to tmp folders.
+			return filepath.SkipDir
+		}
 		if strings.HasPrefix(base, ".#") {
 			// Emacs noise.
 			return nil


### PR DESCRIPTION
For some folks working in the upstream Kubernetes community using goimports has been problematic.  One example is working with the [cluster-api](https://github.com/kubernetes-sigs/cluster-api) repository. In the past few days I've noticed a significant slowdown across multiple machines (one with 16 cores) and started debugging.

Performing a CPU profile showed where the application was spending most of its time:
```
Duration: 26.31s, Total samples = 1.77mins (402.59%)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top
Showing nodes accounting for 104.16s, 98.35% of 105.91s total
Dropped 152 nodes (cum <= 0.53s)
Showing top 10 nodes out of 38
      flat  flat%   sum%        cum   cum%
    53.39s 50.41% 50.41%     53.39s 50.41%  runtime.pthread_cond_wait
    29.70s 28.04% 78.45%     29.70s 28.04%  runtime.pthread_cond_signal
     9.11s  8.60% 87.06%      9.11s  8.60%  runtime.pthread_mutex_unlock
     5.21s  4.92% 91.97%      5.42s  5.12%  syscall.syscall
     4.50s  4.25% 96.22%      4.50s  4.25%  runtime.traceGoSysExit
     2.20s  2.08% 98.30%      2.46s  2.32%  syscall.syscall6
     0.02s 0.019% 98.32%      7.35s  6.94%  golang.org/x/tools/internal/fastwalk.readDir
     0.01s 0.0094% 98.33%      8.30s  7.84%  golang.org/x/tools/internal/fastwalk.(*walker).doWork
     0.01s 0.0094% 98.34%      3.11s  2.94%  golang.org/x/tools/internal/fastwalk.(*walker).onDirEnt
     0.01s 0.0094% 98.35%      0.81s  0.76%  runtime.lock
```

After further investigation, I was able to determine that the major slowdown was on repositories that were built and tested by Bazel. Bazel adds some symlinks to temporary folders when running in a project, which goimports [scans](https://github.com/golang/tools/blob/master/internal/imports/fix.go#L678-L681) as well.

Here is some simple benchmarks:

#### Runs pre bazel symlink ignore
```bash
$ go get golang.org/x/tools/cmd/goimports && time goimports -d pkg/controller/noderef/noderef_controller.go
real	0m8.172s
user	0m2.828s
sys	1m22.427s

real	0m15.525s
user	0m3.285s
sys	2m6.410s

real	0m14.007s
user	0m3.185s
sys	1m55.035s
```

#### Runs post bazel symlink ignore
```bash
$ go get golang.org/x/tools/cmd/goimports && time goimports -d pkg/controller/noderef/noderef_controller.go
real	0m0.439s
user	0m0.326s
sys	0m5.528s

real	0m0.450s
user	0m0.320s
sys	0m5.288s

real	0m0.450s
user	0m0.323s
sys	0m5.324s
```