### PR TITLE
internal/lsp/cache: fix nil check by adding missing "continue"

### DIFF
--- a/internal/lsp/cache/check.go
+++ b/internal/lsp/cache/check.go
@@ -178,6 +178,7 @@ func (imp *importer) cachePackage(ctx context.Context, pkg *pkg, meta *metadata)
 		}
 		if gof.ast.file == nil {
 			imp.view.session.log.Errorf(ctx, "no AST for %s", filename)
+			continue
 		}
 		pos := gof.ast.file.Pos()
 		if !pos.IsValid() {


### PR DESCRIPTION
Without this accessing gof.ast.file.Pos() will panic if gof.ast.file is nil

Change-Id: I829f3667d201f026fcf0475f4fdabce0aced58f8