### PR TITLE
internal/lsp: apply type modifiers to completion candidate

### DIFF
--- a/internal/lsp/testdata/channel/channel.go
+++ b/internal/lsp/testdata/channel/channel.go
@@ -20,6 +20,6 @@ func _() {
 	{
 		var foo chan int //@item(channelFoo, "foo", "chan int", "var")
 		wantsInt := func(int) {} //@item(channelWantsInt, "wantsInt", "func(int)", "var")
-		wantsInt(<-) //@complete(")", channelFoo, channelWantsInt, channelAA, channelAB)
+		wantsInt(<-) //@complete(")", channelFoo, channelAB, channelWantsInt, channelAA)
 	}
 }

--- a/internal/lsp/testdata/interfacerank/interface_rank.go
+++ b/internal/lsp/testdata/interfacerank/interface_rank.go
@@ -17,4 +17,7 @@ func _() {
 	)
 
 	wantsFoo(a) //@complete(")", irAB, irAA)
+
+	var ac fooImpl //@item(irAC, "ac", "fooImpl", "var")
+	wantsFoo(&a)   //@complete(")", irAC, irAA, irAB)
 }

--- a/internal/lsp/tests/tests.go
+++ b/internal/lsp/tests/tests.go
@@ -25,7 +25,7 @@ import (
 // We hardcode the expected number of test cases to ensure that all tests
 // are being executed. If a test is added, this number must be changed.
 const (
-	ExpectedCompletionsCount       = 124
+	ExpectedCompletionsCount       = 125
 	ExpectedCompletionSnippetCount = 14
 	ExpectedDiagnosticsCount       = 17
 	ExpectedFormatCount            = 5


### PR DESCRIPTION
In situations like:

var buf bytes.Buffer
var w io.Writer = &b<>

if we want to complete to "buf" properly we need to apply the "&" type
modifier to buf's type of bytes.Buffer to see that it is assignable
to type io.Writer. Previously we applied type modifiers in reverse to
the "expected" type (io.Writer in this case), but that is obviously
incorrect in this situation since it is nonsensical to
dereference (the reverse of "&") io.Writer.