### PR TITLE
internal/lsp: fix function value completions

### DIFF
--- a/internal/lsp/source/util.go
+++ b/internal/lsp/source/util.go
@@ -132,6 +132,11 @@ func isTypeName(obj types.Object) bool {
 	return ok
 }
 
+func isFunc(obj types.Object) bool {
+	_, ok := obj.(*types.Func)
+	return ok
+}
+
 func formatParams(tup *types.Tuple, variadic bool, qf types.Qualifier) []string {
 	params := make([]string, 0, tup.Len())
 	for i := 0; i < tup.Len(); i++ {

--- a/internal/lsp/testdata/funcvalue/func_value.go
+++ b/internal/lsp/testdata/funcvalue/func_value.go
@@ -1,0 +1,27 @@
+package funcvalue
+
+func fooFunc() int { //@item(fvFooFunc, "fooFunc", "func() int", "func")
+	return 0
+}
+
+var _ = fooFunc() //@item(fvFooFuncCall, "fooFunc()", "int", "func")
+
+var fooVar = func() int { //@item(fvFooVar, "fooVar", "func() int", "var")
+	return 0
+}
+
+var _ = fooVar() //@item(fvFooVarCall, "fooVar()", "int", "var")
+
+type myFunc func() int
+
+var fooType myFunc = fooVar //@item(fvFooType, "fooType", "myFunc", "var")
+
+var _ = fooType() //@item(fvFooTypeCall, "fooType()", "int", "var")
+
+func _() {
+	var f func() int
+	f = foo //@complete(" //", fvFooFunc, fvFooType, fvFooVar)
+
+	var i int
+	i = foo //@complete(" //", fvFooFuncCall, fvFooTypeCall, fvFooVarCall)
+}

--- a/internal/lsp/testdata/unresolved/unresolved.go.in
+++ b/internal/lsp/testdata/unresolved/unresolved.go.in
@@ -1,6 +1,6 @@
 package unresolved
 
-func foo(interface{}) { //@item(unresolvedFoo, "foo(interface{})", "", "func")
+func foo(interface{}) { //@item(unresolvedFoo, "foo", "func(interface{})", "func")
 	// don't crash on fake "resolved" type
 	foo(func(i, j f //@complete(" //", unresolvedFoo)
 }

--- a/internal/lsp/tests/tests.go
+++ b/internal/lsp/tests/tests.go
@@ -25,7 +25,7 @@ import (
 // We hardcode the expected number of test cases to ensure that all tests
 // are being executed. If a test is added, this number must be changed.
 const (
-	ExpectedCompletionsCount       = 125
+	ExpectedCompletionsCount       = 127
 	ExpectedCompletionSnippetCount = 14
 	ExpectedDiagnosticsCount       = 17
 	ExpectedFormatCount            = 5


### PR DESCRIPTION
Previously we would always expand *types.Func completion candidates to
function calls, even if the expected type matched the function itself,
not its return value. Now we check the function itself before we check
its return value. This fixes cases like this:

func foo() int { return 0 }
var f func() int
f = <foo> // now completes to "foo" instead of "foo()"

Also, *types.Var function values were never getting expanded to calls.
I fixed the completion formatting to know that both *types.Func
and *types.Var objects might need to be invoked in the completion
item. This fixes cases like this:

foo := func() int { return 0 }
var i int
i = <foo()> // now completes to "foo()" instead of "foo"