### PR TITLE
internal/lsp: improve completion support for type assertions

### DIFF
--- a/internal/lsp/testdata/good/good1.go
+++ b/internal/lsp/testdata/good/good1.go
@@ -12,7 +12,7 @@ func random() int { //@item(good_random, "random()", "int", "func")
 func random2(y int) int { //@item(good_random2, "random2(y int)", "int", "func"),item(good_y_param, "y", "int", "parameter")
 	//@complete("", good_y_param, types_import, good_random, good_random2, good_stuff)
 	var b types.Bob = &types.X{}
-	if _, ok := b.(*types.X); ok { //@complete("X", Bob_interface, X_struct, Y_struct)
+	if _, ok := b.(*types.X); ok { //@complete("X", X_struct, Y_struct, Bob_interface)
 	}
 
 	return y

--- a/internal/lsp/testdata/typeassert/type_assert.go
+++ b/internal/lsp/testdata/typeassert/type_assert.go
@@ -1,0 +1,24 @@
+package typeassert
+
+type abc interface { //@item(abcIntf, "abc", "interface{...}", "interface")
+	abc()
+}
+
+type abcImpl struct{} //@item(abcImpl, "abcImpl", "struct{...}", "struct")
+func (abcImpl) abc()
+
+type abcPtrImpl struct{} //@item(abcPtrImpl, "abcPtrImpl", "struct{...}", "struct")
+func (*abcPtrImpl) abc()
+
+type abcNotImpl struct{} //@item(abcNotImpl, "abcNotImpl", "struct{...}", "struct")
+
+func _() {
+	var a abc
+	switch a.(type) {
+	case ab: //@complete(":", abcImpl, abcIntf, abcNotImpl, abcPtrImpl)
+	case *ab: //@complete(":", abcImpl, abcPtrImpl, abcIntf, abcNotImpl)
+	}
+
+	a.(ab)  //@complete(")", abcImpl, abcIntf, abcNotImpl, abcPtrImpl)
+	a.(*ab) //@complete(")", abcImpl, abcPtrImpl, abcIntf, abcNotImpl)
+}

--- a/internal/lsp/tests/tests.go
+++ b/internal/lsp/tests/tests.go
@@ -25,7 +25,7 @@ import (
 // We hardcode the expected number of test cases to ensure that all tests
 // are being executed. If a test is added, this number must be changed.
 const (
-	ExpectedCompletionsCount       = 128
+	ExpectedCompletionsCount       = 132
 	ExpectedCompletionSnippetCount = 14
 	ExpectedDiagnosticsCount       = 17
 	ExpectedFormatCount            = 5


### PR DESCRIPTION
In type assertion expressions and type switch clauses we now infer the
type from which candidates must be assertable. For example in:

var foo io.Writer
bar := foo.(<>)

When suggesting concrete types we will prefer types that actually
implement io.Writer.

I also added support for the "*" type name modifier. Using the above
example:

bar := foo.(*<>)

we will prefer type T such that *T implements io.Writer.