### PR TITLE
internal/lsp/source: don't panic compiling regex

### DIFF
--- a/internal/lsp/source/rename.go
+++ b/internal/lsp/source/rename.go
@@ -91,7 +91,10 @@ func Rename(ctx context.Context, view View, f GoFile, pos token.Pos, newName str
 func (r *renamer) update(ctx context.Context, view View) (map[span.URI][]TextEdit, error) {
 	result := make(map[span.URI][]TextEdit)
 
-	docRegexp := regexp.MustCompile(`\b` + r.from + `\b`)
+	docRegexp, err := regexp.Compile(`\b` + r.from + `\b`)
+	if err != nil {
+		return nil, err
+	}
 	for _, ref := range r.refs {
 		refSpan, err := ref.Range.Span()
 		if err != nil {


### PR DESCRIPTION
This package is basically a library (even though it's internal) and
it's generally considered a bad practice for libraries to panic, so
don't.

Change-Id: I37d9d73ae48ececc6b31436f1076e1f85213f129