### PR TITLE
internal/lsp: propagate context.Canceled when type checking

### DIFF
--- a/internal/lsp/cache/check.go
+++ b/internal/lsp/cache/check.go
@@ -142,10 +142,12 @@ func (imp *importer) typeCheck(id packageID) (*pkg, error) {
 	wg.Wait()
 
 	for _, f := range files {
-		if f != nil {
-			pkg.files = append(pkg.files, f)
-		}
+		pkg.files = append(pkg.files, f)
+
 		if f.err != nil {
+			if f.err == context.Canceled {
+				return nil, f.err
+			}
 			imp.view.session.cache.appendPkgError(pkg, f.err)
 		}
 	}


### PR DESCRIPTION
typeCheck() was swallowing context.Canceled errors and leaving the
cached package in a bad state. In particular, after two rapid changes
to imports I was left in the "no package for file" error mode until I
change my imports again. The second change canceled the first change
which ended up sticking a skeleton *pkg in the package cache instead
of propagating the canceled error.