### PR TITLE
internal/lsp: improve completion support for type conversions

### DIFF
--- a/internal/lsp/source/util.go
+++ b/internal/lsp/source/util.go
@@ -139,6 +139,27 @@ func isFunc(obj types.Object) bool {
 	return ok
 }
 
+// typeConversion returns the type being converted to if call is a type
+// conversion expression.
+func typeConversion(call *ast.CallExpr, info *types.Info) types.Type {
+	var ident *ast.Ident
+	switch expr := call.Fun.(type) {
+	case *ast.Ident:
+		ident = expr
+	case *ast.SelectorExpr:
+		ident = expr.Sel
+	default:
+		return nil
+	}
+
+	// Type conversion (e.g. "float64(foo)").
+	if fun, _ := info.ObjectOf(ident).(*types.TypeName); fun != nil {
+		return fun.Type()
+	}
+
+	return nil
+}
+
 func formatParams(tup *types.Tuple, variadic bool, qf types.Qualifier) []string {
 	params := make([]string, 0, tup.Len())
 	for i := 0; i < tup.Len(); i++ {

--- a/internal/lsp/testdata/rank/convert_rank.go.in
+++ b/internal/lsp/testdata/rank/convert_rank.go.in
@@ -1,0 +1,12 @@
+package rank
+
+func _() {
+	type strList []string
+	wantsStrList := func(strList) {}
+
+	var (
+		convA string   //@item(convertA, "convA", "string", "var")
+		convB []string //@item(convertB, "convB", "[]string", "var")
+	)
+	wantsStrList(strList(conv)) //@complete("))", convertB, convertA)
+}

--- a/internal/lsp/tests/tests.go
+++ b/internal/lsp/tests/tests.go
@@ -25,7 +25,7 @@ import (
 // We hardcode the expected number of test cases to ensure that all tests
 // are being executed. If a test is added, this number must be changed.
 const (
-	ExpectedCompletionsCount       = 136
+	ExpectedCompletionsCount       = 137
 	ExpectedCompletionSnippetCount = 15
 	ExpectedDiagnosticsCount       = 17
 	ExpectedFormatCount            = 5


### PR DESCRIPTION
Now when completing in code like:

foo := int64(<>)

we prefer candidates whose type is convertible to int64.