### PR TITLE
internal/lsp: improve completion support for untyped constants

### DIFF
--- a/internal/lsp/testdata/rank/convert_rank.go.in
+++ b/internal/lsp/testdata/rank/convert_rank.go.in
@@ -10,3 +10,30 @@ func _() {
 	)
 	wantsStrList(strList(conv)) //@complete("))", convertB, convertA)
 }
+
+func _() {
+	const (
+		convC        = "hi"    //@item(convertC, "convC", "string", "const")
+		convD        = 123     //@item(convertD, "convD", "int", "const")
+		convE int    = 123     //@item(convertE, "convE", "int", "const")
+		convF string = "there" //@item(convertF, "convF", "string", "const")
+	)
+
+	var foo int
+	foo = conv //@complete(" //", convertD, convertE, convertC, convertF)
+
+	type myInt int
+	var mi myInt
+	mi = conv //@complete(" //", convertD, convertC, convertE, convertF)
+	mi + conv //@complete(" //", convertD, convertC, convertE, convertF)
+
+	1 + conv //@complete(" //", convertD, convertE, convertC, convertF)
+
+	type myString string
+	var ms myString
+	ms = conv //@complete(" //", convertC, convertD, convertE, convertF)
+
+	type myUint uint32
+	var mu myUint
+	mu = conv //@complete(" //", convertD, convertC, convertE, convertF)
+}

--- a/internal/lsp/tests/tests.go
+++ b/internal/lsp/tests/tests.go
@@ -25,7 +25,7 @@ import (
 // We hardcode the expected number of test cases to ensure that all tests
 // are being executed. If a test is added, this number must be changed.
 const (
-	ExpectedCompletionsCount       = 138
+	ExpectedCompletionsCount       = 144
 	ExpectedCompletionSnippetCount = 15
 	ExpectedDiagnosticsCount       = 17
 	ExpectedFormatCount            = 5


### PR DESCRIPTION
Add some extra smarts when evaluating untyped constants as completion
candidates. Previously we called types.Default() on the expected type
and candidate type, but this loses the untypedness of an untyped
constant which prevents it from being assignable to any type or named
type other than the untyped constant's default type.

Note that the added logic does not take into account the untyped
constant's value, so you will still get some false positive
completions (e.g. suggesting an untyped negative integer constant when
only a uint would do). Unfortunately go/types doesn't provide a way of
answering the question "is this *types.Const assignable to this
types.Type" since types.AssignableTo only considers a constant's type,
not its value.