### PR TITLE
internal/lsp: remove the unused function 'markupContent'.

### DIFF
--- a/internal/lsp/hover.go
+++ b/internal/lsp/hover.go
@@ -6,8 +6,6 @@ package lsp
 
 import (
 	"context"
-	"fmt"
-
 	"golang.org/x/tools/internal/lsp/protocol"
 	"golang.org/x/tools/internal/lsp/source"
 	"golang.org/x/tools/internal/span"
@@ -51,20 +49,4 @@ func (s *Server) hover(ctx context.Context, params *protocol.TextDocumentPositio
 		},
 		Range: &rng,
 	}, nil
-}
-
-func markupContent(decl, doc string, kind protocol.MarkupKind) protocol.MarkupContent {
-	result := protocol.MarkupContent{
-		Kind: kind,
-	}
-	switch kind {
-	case protocol.PlainText:
-		result.Value = decl
-	case protocol.Markdown:
-		result.Value = "```go\n" + decl + "\n```"
-	}
-	if doc != "" {
-		result.Value = fmt.Sprintf("%s\n%s", doc, result.Value)
-	}
-	return result
 }


### PR DESCRIPTION
The last usage of 'markupContent' has been deleted in
https://go-review.googlesource.com/c/tools/+/172958.