### PR TITLE
internal/lsp: use empty string to replace '```go\n\n```' with markdown enabled.

### DIFF
--- a/internal/lsp/source/hover.go
+++ b/internal/lsp/source/hover.go
@@ -84,6 +84,8 @@ func (d declaration) hover(ctx context.Context) (*documentation, error) {
 	defer ts.End()
 	obj := d.obj
 	switch node := d.node.(type) {
+	case *ast.ImportSpec:
+		return &documentation{node, nil}, nil
 	case *ast.GenDecl:
 		switch obj := obj.(type) {
 		case *types.TypeName, *types.Var, *types.Const, *types.Func:

--- a/internal/lsp/source/identifier.go
+++ b/internal/lsp/source/identifier.go
@@ -74,7 +74,7 @@ func identifier(ctx context.Context, view View, f GoFile, pos token.Pos) (*Ident
 		return nil, fmt.Errorf("pkg for %s is ill-typed", f.URI())
 	}
 	// Handle import specs separately, as there is no formal position for a package declaration.
-	if result, err := importSpec(ctx, f, file, pkg, pos); result != nil || err != nil {
+	if result, err := importSpec(f, file, pkg, pos); result != nil || err != nil {
 		return result, err
 	}
 	path, _ := astutil.PathEnclosingInterval(file, pos, pos)
@@ -267,7 +267,7 @@ func objToNode(ctx context.Context, view View, originPkg *types.Package, obj typ
 }
 
 // importSpec handles positions inside of an *ast.ImportSpec.
-func importSpec(ctx context.Context, f GoFile, fAST *ast.File, pkg Package, pos token.Pos) (*IdentifierInfo, error) {
+func importSpec(f GoFile, fAST *ast.File, pkg Package, pos token.Pos) (*IdentifierInfo, error) {
 	var imp *ast.ImportSpec
 	for _, spec := range fAST.Imports {
 		if spec.Pos() <= pos && pos < spec.End() {
@@ -306,6 +306,7 @@ func importSpec(ctx context.Context, f GoFile, fAST *ast.File, pkg Package, pos 
 		return nil, fmt.Errorf("package %q has no files", importPath)
 	}
 	result.decl.rng = span.NewRange(f.FileSet(), dest.Name.Pos(), dest.Name.End())
+	result.decl.node = imp
 	return result, nil
 }
 

--- a/internal/lsp/testdata/godef/b/b.go.golden
+++ b/internal/lsp/testdata/godef/b/b.go.golden
@@ -66,6 +66,7 @@ foo/foo.go:1:9-12: defined here as
 }
 
 -- PackageFoo-hover --
+myFoo "golang.org/x/tools/internal/lsp/foo" //@godef("foo", PackageFoo),godef("myFoo", PackageFoo)
 
 -- S1-definition --
 godef/b/b.go:8:6-8: defined here as S1 struct {


### PR DESCRIPTION
There are some circumstances where go langserver returns '```go\n\n```',
clients may render this empty markdown string. It's better to return
an empty string instead. Related issue:
https://github.com/golang/go/issues/33000.