### PR TITLE
internal/lsp: fix watched file protocol constants

### DIFF
--- a/internal/lsp/protocol/enums.go
+++ b/internal/lsp/protocol/enums.go
@@ -13,7 +13,7 @@ var (
 	namesInitializeError        [int(UnknownProtocolVersion) + 1]string
 	namesMessageType            [int(Log) + 1]string
 	namesFileChangeType         [int(Deleted) + 1]string
-	namesWatchKind              [int(Change) + 1]string
+	namesWatchKind              [int(WatchDelete) + 1]string
 	namesCompletionTriggerKind  [int(TriggerForIncompleteCompletions) + 1]string
 	namesDiagnosticSeverity     [int(SeverityHint) + 1]string
 	namesDiagnosticTag          [int(Unnecessary) + 1]string
@@ -40,7 +40,9 @@ func init() {
 	namesFileChangeType[int(Changed)] = "Changed"
 	namesFileChangeType[int(Deleted)] = "Deleted"
 
-	namesWatchKind[int(Change)] = "Change"
+	namesWatchKind[int(WatchCreate)] = "WatchCreate"
+	namesWatchKind[int(WatchChange)] = "WatchChange"
+	namesWatchKind[int(WatchDelete)] = "WatchDelete"
 
 	namesCompletionTriggerKind[int(Invoked)] = "Invoked"
 	namesCompletionTriggerKind[int(TriggerCharacter)] = "TriggerCharacter"

--- a/internal/lsp/protocol/tsprotocol.go
+++ b/internal/lsp/protocol/tsprotocol.go
@@ -1,7 +1,7 @@
 // Package protocol contains data types and code for LSP jsonrpcs
 // generated automatically from vscode-languageserver-node
 // commit: 8801c20b667945f455d7e023c71d2f741caeda25
-// last fetched Thu Jul 11 2019 13:43:41 GMT-0400 (Eastern Daylight Time)
+// last fetched Sat Jul 13 2019 18:33:10 GMT-0700 (Pacific Daylight Time)
 package protocol
 
 // Code generated (see typescript/README.md) DO NOT EDIT.
@@ -3611,10 +3611,20 @@ const (
 	 */
 	Deleted FileChangeType = 3
 
-	/*Change defined:
+	/*WatchCreate defined:
+	 * Interested in create events.
+	 */
+	WatchCreate WatchKind = 1
+
+	/*WatchChange defined:
 	 * Interested in change events
 	 */
-	Change WatchKind = 2
+	WatchChange WatchKind = 2
+
+	/*WatchDelete defined:
+	 * Interested in delete events
+	 */
+	WatchDelete WatchKind = 4
 
 	/*Invoked defined:
 	 * Completion was triggered by typing an identifier (24x7 code

--- a/internal/lsp/protocol/typescript/README.md
+++ b/internal/lsp/protocol/typescript/README.md
@@ -4,10 +4,10 @@
 
 1. Make sure `node` is installed.
   As explained at the [node site](<https://nodejs.org> Node)
-  you may need `node install @types/node` for the node runtime types
-2. Install the typescript compiler, with `node install typescript`.
+  you may need `npm install @types/node` for the node runtime types
+2. Install the typescript compiler, with `npm install typescript`.
 3. Make sure `tsc` and `node` are in your execution path.
-4. Get the typescript code for the jsonrpc protocol with `git clone vscode-lanuageserver-node.git`
+4. Get the typescript code for the jsonrpc protocol with `git clone git@github.com:microsoft/vscode-languageserver-node.git`
 
 ## Usage
 

--- a/internal/lsp/protocol/typescript/go.ts
+++ b/internal/lsp/protocol/typescript/go.ts
@@ -927,7 +927,7 @@ let byName = new Map<string, Struct>();
     // consts are unique. (Go consts are package-level, but Typescript's are
     // not.) Use suffixes to minimize changes to gopls.
     let pref = new Map<string, string>(
-        [['DiagnosticSeverity', 'Severity']])  // typeName->prefix
+      [['DiagnosticSeverity', 'Severity'], ['WatchKind', 'Watch']])  // typeName->prefix
     let suff = new Map<string, string>([
       ['CompletionItemKind', 'Completion'], ['InsertTextFormat', 'TextFormat']
     ])


### PR DESCRIPTION
The "Create" and "Delete" WatchKind values were missing from the
generated code because their names were colliding with other
constants. Add "WatchKind" to go.ts prefix map to disambiguate.

Updates golang/go#31553