### PR TITLE
cmd/vet: fix a bad case of shadow check about redeclaration

### DIFF
--- a/go/analysis/passes/shadow/shadow.go
+++ b/go/analysis/passes/shadow/shadow.go
@@ -208,14 +208,15 @@ func idiomaticShortRedecl(pass *analysis.Pass, a *ast.AssignStmt) bool {
 func idiomaticRedecl(d *ast.ValueSpec) bool {
 	// Don't complain about deliberate redeclarations of the form
 	//	var i, j = i, j
+	// Don't ignore redeclarations of the form
+	//	var i = 3
 	if len(d.Names) != len(d.Values) {
 		return false
 	}
 	for i, lhs := range d.Names {
-		if rhs, ok := d.Values[i].(*ast.Ident); ok {
-			if lhs.Name != rhs.Name {
-				return false
-			}
+		rhs, ok := d.Values[i].(*ast.Ident)
+		if !ok || lhs.Name != rhs.Name {
+			return false
 		}
 	}
 	return true

--- a/go/analysis/passes/shadow/testdata/src/a/a.go
+++ b/go/analysis/passes/shadow/testdata/src/a/a.go
@@ -89,3 +89,12 @@ func shadowTypeSwitch(a interface{}) {
 		}
 	}
 }
+
+func shadowBlock() {
+	var a int
+	{
+		var a = 3 // want "declaration of .a. shadows declaration at line 94"
+		_ = a
+	}
+	_ = a
+}


### PR DESCRIPTION
`go tools vet -shadow` ignored the case like this form
```golang
func shadowBlock() {
    var a int
    {
        var a = 3
        _ = a
    }
    _ = a
}
```
This commit fix it on "idiomaticRedecl" func, and add the code above in testcase.