### PR TITLE
internal/imports: force to repair imports group regardless of how the…

### DIFF
--- a/cmd/goimports/goimports.go
+++ b/cmd/goimports/goimports.go
@@ -54,6 +54,7 @@ var (
 
 func init() {
 	flag.BoolVar(&options.AllErrors, "e", false, "report all errors (not just the first 10 on different lines)")
+	flag.BoolVar(&options.Env.RepairGroup, "repair-group", false, "force to repair imports group regardless of how they were originally grouped")
 	flag.StringVar(&options.Env.LocalPrefix, "local", "", "put imports beginning with this string after 3rd-party packages; comma-separated list")
 	flag.BoolVar(&options.FormatOnly, "format-only", false, "if true, don't fix imports and only format. In this mode, goimports is effectively gofmt, with the addition that imports are grouped into sections.")
 }

--- a/internal/imports/fix.go
+++ b/internal/imports/fix.go
@@ -614,6 +614,7 @@ func getAllCandidates(filename string, env *ProcessEnv) ([]ImportFix, error) {
 type ProcessEnv struct {
 	LocalPrefix string
 	Debug       bool
+	RepairGroup bool
 
 	// If non-empty, these will be used instead of the
 	// process-wide values.

--- a/internal/imports/sortimports.go
+++ b/internal/imports/sortimports.go
@@ -37,11 +37,14 @@ func sortImports(env *ProcessEnv, fset *token.FileSet, f *ast.File) {
 		// Identify and sort runs of specs on successive lines.
 		i := 0
 		specs := d.Specs[:0]
-		for j, s := range d.Specs {
-			if j > i && fset.Position(s.Pos()).Line > 1+fset.Position(d.Specs[j-1].End()).Line {
-				// j begins a new run.  End this one.
-				specs = append(specs, sortSpecs(env, fset, f, d.Specs[i:j])...)
-				i = j
+		// If repairGroup is true, treats all specs in the same import group.
+		if !env.RepairGroup {
+			for j, s := range d.Specs {
+				if j > i && fset.Position(s.Pos()).Line > 1+fset.Position(d.Specs[j-1].End()).Line {
+					// j begins a new run.  End this one.
+					specs = append(specs, sortSpecs(env, fset, f, d.Specs[i:j])...)
+					i = j
+				}
 			}
 		}
 		specs = append(specs, sortSpecs(env, fset, f, d.Specs[i:])...)


### PR DESCRIPTION
### What this PR does
Add a new flag `repair-group`. If true, forcing to repair imports group regardless of how they were originally grouped

## Why
### What goimports does not do
example:
```
import (
	"testing"

	"context"

	"github.com/Sirupsen/logrus"
)
```
The imports will keep intact because `"testing"` and `"context"` are considered in two different sections.

### Manually correct
If we delete the blank line, goimports will re-sort imports correctly.

input:
```
import (
	"testing"
	"context"

	"github.com/Sirupsen/logrus"
)
```
after formatting:
```
import (
	"context"
	"testing"

	"github.com/Sirupsen/logrus"
)
```

### Root case
When goimports formats the imports, it puts imports into different sections by successive lines, and sorts them in each section. It turns out that sorting will only happens in the same section.

In order to solve this problem, we only need to consider all imports in one group regardless of how they were originally grouped

### Use repair-group
input:
```
package foo // github.com/org/repo1/foo

import (
    "context"

    "os"

    "github.com/org/repo1/foo/bar"
 
    "github.com/org/repo1/foo/baz"

    "github.com/org/repo2/quux"

    "github.com/thirdparty/repo"
)
```
```
goimports -repair-group -local github.com/org/repo1
```

