### PR TITLE
Fixed documentation for gopls installation

### DIFF
--- a/gopls/doc/user.md
+++ b/gopls/doc/user.md
@@ -34,7 +34,7 @@ go: cannot use path@version syntax in GOPATH mode
 ```
 then run
 ```sh
-GO111MODULE=on go get golang.org/x/tools gopls@latest
+GO111MODULE=on go get golang.org/x/tools/gopls@latest
 ```
 
 


### PR DESCRIPTION
Fixes this problem when trying to use the documented installation command:

```
$ GO111MODULE=on go get golang.org/x/tools gopls@latest
go: finding golang.org/x/tools latest
go: downloading golang.org/x/tools v0.0.0-20190911230505-6bfd74cf029c
go: extracting golang.org/x/tools v0.0.0-20190911230505-6bfd74cf029c
go get gopls@latest: malformed module path "gopls": missing dot in first path element
```