### PR TITLE
fixes #34299

### DIFF
--- a/internal/lsp/text_synchronization.go
+++ b/internal/lsp/text_synchronization.go
@@ -20,7 +20,7 @@ import (
 )
 
 func (s *Server) didOpen(ctx context.Context, params *protocol.DidOpenTextDocumentParams) error {
-	uri := span.NewURI(params.TextDocument.URI)
+	uri := span.URI(params.TextDocument.URI)
 	text := []byte(params.TextDocument.Text)
 
 	// Confirm that the file's language ID is related to Go.


### PR DESCRIPTION
If anyone could contact me about standardizing the encoding of file-paths I would greatly appreciate that.span.NewURI and span.FileURI are both used all over the place and these are the kind of bugs are a direct result.