### PR TITLE
go/analysis/analysistest: fix nil pointer dereference when sorting facts

### DIFF
--- a/go/analysis/analysistest/analysistest.go
+++ b/go/analysis/analysistest/analysistest.go
@@ -277,6 +277,13 @@ func check(t Testing, gopath string, pass *analysis.Pass, diagnostics []analysis
 		objects = append(objects, obj)
 	}
 	sort.Slice(objects, func(i, j int) bool {
+		// Package facts are keyed by nil.
+		if objects[i] == nil {
+			return true
+		}
+		if objects[j] == nil {
+			return false
+		}
 		return objects[i].Pos() < objects[j].Pos()
 	})
 	for _, obj := range objects {

--- a/go/analysis/analysistest/analysistest.go
+++ b/go/analysis/analysistest/analysistest.go
@@ -277,12 +277,10 @@ func check(t Testing, gopath string, pass *analysis.Pass, diagnostics []analysis
 		objects = append(objects, obj)
 	}
 	sort.Slice(objects, func(i, j int) bool {
-		// Package facts are keyed by nil.
-		if objects[i] == nil {
-			return true
-		}
-		if objects[j] == nil {
-			return false
+		// Package facts compare less than object facts.
+		ip, jp := objects[i] == nil, objects[j] == nil // whether i, j is a package fact
+		if ip != jp {
+			return ip && !jp
 		}
 		return objects[i].Pos() < objects[j].Pos()
 	})

--- a/go/analysis/analysistest/analysistest_test.go
+++ b/go/analysis/analysistest/analysistest_test.go
@@ -33,7 +33,7 @@ func TestTheTest(t *testing.T) {
 	// which (by default) reports calls to functions named 'println'.
 	findcall.Analyzer.Flags.Set("name", "println")
 
-	filemap := map[string]string{"a/b.go": `package main
+	filemap := map[string]string{"a/b.go": `package main // want package:"found"
 
 func main() {
 	// The expectation is ill-formed:

--- a/go/analysis/passes/findcall/findcall.go
+++ b/go/analysis/passes/findcall/findcall.go
@@ -69,6 +69,8 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		}
 	}
 
+	pass.ExportPackageFact(new(foundFact))
+
 	return nil, nil
 }
 

--- a/go/analysis/passes/findcall/findcall.go
+++ b/go/analysis/passes/findcall/findcall.go
@@ -5,7 +5,10 @@
 // The findcall package defines an Analyzer that serves as a trivial
 // example and test of the Analysis API. It reports a diagnostic for
 // every call to a function or method of the name specified by its
-// -name flag.
+// -name flag. It also exports a fact for each declaration that
+// matches the name, plus a package-level fact if the package contained
+// one or more such declarations.
+
 package findcall
 
 import (
@@ -69,7 +72,9 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		}
 	}
 
-	pass.ExportPackageFact(new(foundFact))
+	if len(pass.AllObjectFacts()) > 0 {
+		pass.ExportPackageFact(new(foundFact))
+	}
 
 	return nil, nil
 }

--- a/go/analysis/passes/findcall/findcall_test.go
+++ b/go/analysis/passes/findcall/findcall_test.go
@@ -34,7 +34,9 @@ func TestFromStringLiterals(t *testing.T) {
 func main() {
 	println("hello") // want "call of println"
 	print("goodbye") // not a call of println
-}`,
+}
+
+func println(s string) {} // want println:"found"`,
 			},
 		},
 	} {

--- a/go/analysis/passes/findcall/findcall_test.go
+++ b/go/analysis/passes/findcall/findcall_test.go
@@ -29,7 +29,7 @@ func TestFromStringLiterals(t *testing.T) {
 		{
 			desc:    "SimpleTest",
 			pkgpath: "main",
-			files: map[string]string{"main/main.go": `package main
+			files: map[string]string{"main/main.go": `package main // want package:"found"
 
 func main() {
 	println("hello") // want "call of println"

--- a/go/analysis/passes/findcall/testdata/src/a/a.go
+++ b/go/analysis/passes/findcall/testdata/src/a/a.go
@@ -1,4 +1,4 @@
-package main
+package main // want package:"found"
 
 func main() {
 	println("hi") // want "call of println"

--- a/go/analysis/passes/findcall/testdata/src/a/a.go
+++ b/go/analysis/passes/findcall/testdata/src/a/a.go
@@ -4,3 +4,5 @@ func main() {
 	println("hi") // want "call of println"
 	print("hi")   // not a call of println
 }
+
+func println(s string) {} // want println:"found"


### PR DESCRIPTION
Without this change, we can't use `ExportPackageFact` function with analysistest package.

PackageFacts are keyed by nil and analysistest.check crashed while sorting, due to a nil object dereference.