### PR TITLE
go/analysis: fix vet errors

### DIFF
--- a/go/analysis/internal/facts/facts.go
+++ b/go/analysis/internal/facts/facts.go
@@ -103,7 +103,7 @@ func (s *Set) AllObjectFacts(filter map[reflect.Type]bool) []analysis.ObjectFact
 	var facts []analysis.ObjectFact
 	for k, v := range s.m {
 		if k.obj != nil && filter[k.t] {
-			facts = append(facts, analysis.ObjectFact{k.obj, v})
+			facts = append(facts, analysis.ObjectFact{Object: k.obj, Fact: v})
 		}
 	}
 	return facts
@@ -136,7 +136,7 @@ func (s *Set) AllPackageFacts(filter map[reflect.Type]bool) []analysis.PackageFa
 	var facts []analysis.PackageFact
 	for k, v := range s.m {
 		if k.obj == nil && filter[k.t] {
-			facts = append(facts, analysis.PackageFact{k.pkg, v})
+			facts = append(facts, analysis.PackageFact{Package: k.pkg, Fact: v})
 		}
 	}
 	return facts

--- a/go/analysis/passes/assign/assign.go
+++ b/go/analysis/passes/assign/assign.go
@@ -63,7 +63,9 @@ func run(pass *analysis.Pass) (interface{}, error) {
 				pass.Report(analysis.Diagnostic{
 					Pos: stmt.Pos(), Message: fmt.Sprintf("self-assignment of %s to %s", re, le),
 					SuggestedFixes: []analysis.SuggestedFix{
-						{Message: "Remove", TextEdits: []analysis.TextEdit{{stmt.Pos(), stmt.End(), []byte{}}}},
+						{Message: "Remove", TextEdits: []analysis.TextEdit{
+							{Pos: stmt.Pos(), End: stmt.End(), NewText: []byte{}},
+						}},
 					},
 				})
 			}


### PR DESCRIPTION
Updating tools version in go fails the builds due to go vet errors as it can be observed in https://golang.org/cl/196843. 

Fix vet errors in facts.go and assign.go

Updates golang/go#34062