### PR TITLE
Fixed bad config example in VSCode doc.

### DIFF
--- a/gopls/doc/vscode.md
+++ b/gopls/doc/vscode.md
@@ -16,7 +16,7 @@ Use the [VSCode-Go] plugin, with the following configuration:
 
     // Experimental settings
     "completeUnimported": true, // autocomplete unimported packages
-    "watchChangedFiles": true,  // watch file changes outside of the editor
+    "watchFileChanges": true,  // watch file changes outside of the editor
     "deepCompletion": true,     // enable deep completion
 },
 "files.eol": "\n", // formatting only supports LF line endings


### PR DESCRIPTION
# Current Behavior
While opening *.go file in VS Code pop-up appears:
```
unexpected config watchChangedFiles
```
# Expected Behavior
To not display any warning notifications.

# Solution
Documentation is flawed here: the correct configuration is `watchFileChanges`, instead of `watchChangedFiles`.