### PR TITLE
Fix vscode config to watch file changes

### DIFF
--- a/gopls/doc/vscode.md
+++ b/gopls/doc/vscode.md
@@ -16,7 +16,7 @@ Use the [VSCode-Go] plugin, with the following configuration:
 
     // Experimental settings
     "completeUnimported": true, // autocomplete unimported packages
-    "watchChangedFiles": true,  // watch file changes outside of the editor
+    "watchFileChanges": true,  // watch file changes outside of the editor
     "deepCompletion": true,     // enable deep completion
 },
 "files.eol": "\n", // formatting only supports LF line endings


### PR DESCRIPTION
Fix the documentation by using the correct configuration for
watching file changes outside of the editor.

Fixes https://github.com/microsoft/vscode-go/issues/2810