### PR TITLE
internal/lsp: Use file AST to construct field placeholders

### DIFF
--- a/internal/lsp/testdata/snippets/snippets.go.in
+++ b/internal/lsp/testdata/snippets/snippets.go.in
@@ -3,8 +3,11 @@ package snippets
 func foo(i int, b bool) {} //@item(snipFoo, "foo", "func(i int, b bool)", "func")
 func bar(fn func()) func()    {} //@item(snipBar, "bar", "func(fn func())", "func")
 
+type AliasType = int //@item(sigAliasType, "AliasType", "AliasType", "type")
+
 type Foo struct {
 	Bar int //@item(snipFieldBar, "Bar", "int", "field")
+	Func func(at AliasType) error //@item(snipFieldFunc, "Func", "func(at AliasType) error", "field")
 }
 
 func (Foo) Baz() func() {} //@item(snipMethodBaz, "Baz", "func() func()", "method")
@@ -24,6 +27,10 @@ func _() {
 
 	Foo{
 		B //@snippet(" //", snipFieldBar, "Bar: ${1:},", "Bar: ${1:int},")
+	}
+
+	Foo{
+		F //@snippet(" //", snipFieldFunc, "Func: ${1:},", "Func: ${1:func(at AliasType) error},")
 	}
 
 	Foo{B} //@snippet("}", snipFieldBar, "Bar: ${1:}", "Bar: ${1:int}")

--- a/internal/lsp/testdata/summary.txt.golden
+++ b/internal/lsp/testdata/summary.txt.golden
@@ -1,6 +1,6 @@
 -- summary --
 CompletionsCount = 178
-CompletionSnippetCount = 39
+CompletionSnippetCount = 40
 UnimportedCompletionsCount = 1
 DeepCompletionsCount = 5
 FuzzyCompletionsCount = 7


### PR DESCRIPTION
When there are type alias, types.TypeString() will use the underlining type,
it's OK for go/types because they use it to check the type's equality, but it's
not proper for placeholders.

So we use file AST as it's the canonical source of type string.

Fixes #33500

Change-Id: I777854e30f79b61f75d69ae3fd9fa2b81589b1a1