### PR TITLE
internal/lsp: Use file AST to construct field placeholders

### DIFF
--- a/internal/lsp/source/completion.go
+++ b/internal/lsp/source/completion.go
@@ -1374,3 +1374,23 @@ func (c *completer) formatFieldType(obj types.Object) string {
 	}
 	return types.TypeString(obj.Type(), c.qf)
 }
+
+func (c *completer) formatParams(tup *types.Tuple, variadic bool) []string {
+	params := make([]string, 0, tup.Len())
+	for i := 0; i < tup.Len(); i++ {
+		el := tup.At(i)
+		typ := c.formatFieldType(el)
+
+		// Handle a variadic parameter (can only be the final parameter).
+		if variadic && i == tup.Len()-1 {
+			typ = strings.Replace(typ, "[]", "...", 1)
+		}
+
+		if el.Name() == "" {
+			params = append(params, typ)
+		} else {
+			params = append(params, el.Name()+" "+typ)
+		}
+	}
+	return params
+}

--- a/internal/lsp/source/completion_format.go
+++ b/internal/lsp/source/completion_format.go
@@ -116,13 +116,14 @@ func (c *completer) item(cand candidate) (CompletionItem, error) {
 	if !c.opts.Documentation {
 		return item, nil
 	}
-	ident, err := c.findIdentifier(obj)
+	pos := c.view.Session().Cache().FileSet().Position(obj.Pos())
+	// We ignore ErrFindPos, because some types, like "unsafe" or "error",
+	// may not have valid positions that we can use to get documentation.
+	if !pos.IsValid() {
+		return item, nil
+	}
+	ident, err := c.findIdentifier(obj, pos)
 	if err != nil {
-		// We ignore ErrFindPos, because some types, like "unsafe" or "error",
-		// may not have valid positions that we can use to get documentation.
-		if _, ok := err.(ErrFindPos); ok {
-			return item, nil
-		}
 		return CompletionItem{}, err
 	}
 	hover, err := ident.Hover(c.ctx)

--- a/internal/lsp/source/completion_format.go
+++ b/internal/lsp/source/completion_format.go
@@ -40,7 +40,7 @@ func (c *completer) item(cand candidate) (CompletionItem, error) {
 	// expandFuncCall mutates the completion label, detail, and snippet
 	// to that of an invocation of sig.
 	expandFuncCall := func(sig *types.Signature) {
-		params := formatParams(sig.Params(), sig.Variadic(), c.qf)
+		params := c.formatParams(sig.Params(), sig.Variadic())
 		snip = c.functionCallSnippet(label, params)
 		results, writeParens := formatResults(sig.Results(), c.qf)
 		detail = "func" + formatFunction(params, results, writeParens)

--- a/internal/lsp/source/completion_format.go
+++ b/internal/lsp/source/completion_format.go
@@ -54,9 +54,10 @@ func (c *completer) item(cand candidate) (CompletionItem, error) {
 	case *types.Var:
 		if _, ok := obj.Type().(*types.Struct); ok {
 			detail = "struct{...}" // for anonymous structs
+		} else if obj.IsField() {
+			detail = c.formatFieldType(obj)
 		}
 		if obj.IsField() {
-			detail = c.formatFieldType(obj)
 			kind = protocol.FieldCompletion
 			snip = c.structFieldSnippet(label, detail)
 		} else {

--- a/internal/lsp/source/completion_format.go
+++ b/internal/lsp/source/completion_format.go
@@ -118,7 +118,7 @@ func (c *completer) item(cand candidate) (CompletionItem, error) {
 		return item, nil
 	}
 	pos := c.view.Session().Cache().FileSet().Position(obj.Pos())
-	// We ignore ErrFindPos, because some types, like "unsafe" or "error",
+	// We ignore errors here, because some types, like "unsafe" or "error",
 	// may not have valid positions that we can use to get documentation.
 	if !pos.IsValid() {
 		return item, nil

--- a/internal/lsp/testdata/snippets/snippets.go.in
+++ b/internal/lsp/testdata/snippets/snippets.go.in
@@ -3,8 +3,11 @@ package snippets
 func foo(i int, b bool) {} //@item(snipFoo, "foo", "func(i int, b bool)", "func")
 func bar(fn func()) func()    {} //@item(snipBar, "bar", "func(fn func())", "func")
 
+type AliasType = int //@item(sigAliasType, "AliasType", "AliasType", "type")
+
 type Foo struct {
 	Bar int //@item(snipFieldBar, "Bar", "int", "field")
+	Func func(at AliasType) error //@item(snipFieldFunc, "Func", "func(at AliasType) error", "field")
 }
 
 func (Foo) Baz() func() {} //@item(snipMethodBaz, "Baz", "func() func()", "method")
@@ -24,6 +27,10 @@ func _() {
 
 	Foo{
 		B //@snippet(" //", snipFieldBar, "Bar: ${1:},", "Bar: ${1:int},")
+	}
+
+	Foo{
+		F //@snippet(" //", snipFieldFunc, "Func: ${1:},", "Func: ${1:func(at AliasType) error},")
 	}
 
 	Foo{B} //@snippet("}", snipFieldBar, "Bar: ${1:}", "Bar: ${1:int}")

--- a/internal/lsp/testdata/snippets/snippets.go.in
+++ b/internal/lsp/testdata/snippets/snippets.go.in
@@ -1,9 +1,10 @@
 package snippets
 
+type AliasType = int //@item(sigAliasType, "AliasType", "AliasType", "type")
+
 func foo(i int, b bool) {} //@item(snipFoo, "foo", "func(i int, b bool)", "func")
 func bar(fn func()) func()    {} //@item(snipBar, "bar", "func(fn func())", "func")
-
-type AliasType = int //@item(sigAliasType, "AliasType", "AliasType", "type")
+func baz(at AliasType, b bool) {} //@item(snipBaz, "baz", "func(at AliasType, b bool)", "func")
 
 type Foo struct {
 	Bar int //@item(snipFieldBar, "Bar", "int", "field")
@@ -12,11 +13,14 @@ type Foo struct {
 
 func (Foo) Baz() func() {} //@item(snipMethodBaz, "Baz", "func() func()", "method")
 func (Foo) BazBar() func() {} //@item(snipMethodBazBar, "BazBar", "func() func()", "method")
+func (Foo) BazBaz(at AliasType) func() {} //@item(snipMethodBazBaz, "BazBaz", "func(at AliasType) func()", "method")
 
 func _() {
 	f //@snippet(" //", snipFoo, "foo(${1:})", "foo(${1:i int}, ${2:b bool})")
 
 	bar //@snippet(" //", snipBar, "bar(${1:})", "bar(${1:fn func()})")
+
+	baz //@snippet(" //", snipBaz, "baz(${1:})", "baz(${1:at AliasType}, ${2:b bool})")
 
 	bar(nil) //@snippet("(", snipBar, "bar", "bar")
 	bar(ba) //@snippet(")", snipBar, "bar(${1:})", "bar(${1:fn func()})")
@@ -43,4 +47,6 @@ func _() {
 	f.Baz()     //@snippet("B", snipMethodBaz, "Baz()", "Baz()")
 
 	f.Baz()     //@snippet("(", snipMethodBazBar, "BazBar", "BazBar")
+
+	f.Baz()     //@snippet("B", snipMethodBazBaz, "BazBaz(${1:})", "BazBaz(${1:at AliasType})")
 }

--- a/internal/lsp/testdata/summary.txt.golden
+++ b/internal/lsp/testdata/summary.txt.golden
@@ -1,6 +1,6 @@
 -- summary --
 CompletionsCount = 178
-CompletionSnippetCount = 39
+CompletionSnippetCount = 40
 UnimportedCompletionsCount = 1
 DeepCompletionsCount = 5
 FuzzyCompletionsCount = 7

--- a/internal/lsp/testdata/summary.txt.golden
+++ b/internal/lsp/testdata/summary.txt.golden
@@ -1,6 +1,6 @@
 -- summary --
 CompletionsCount = 178
-CompletionSnippetCount = 40
+CompletionSnippetCount = 42
 UnimportedCompletionsCount = 1
 DeepCompletionsCount = 5
 FuzzyCompletionsCount = 7


### PR DESCRIPTION
When there are type alias, types.TypeString() will use the underlining type,
it's OK for go/types because they use it to check the type's equality, but it's
not proper for placeholders.

So we use file AST as it's the canonical source of type string.

Fixes #33500

Change-Id: Ie8614fd713598e3b7b3d9b49f6b1308eae306ab4