### PR TITLE
tools/gopls: add command line support for suggestedfix

### DIFF
--- a/internal/lsp/cmd/cmd.go
+++ b/internal/lsp/cmd/cmd.go
@@ -145,6 +145,7 @@ func (app *Application) commands() []tool.Application {
 		&format{app: app},
 		&query{app: app},
 		&rename{app: app},
+		&suggestedfix{app: app},
 		&version{app: app},
 	}
 }

--- a/internal/lsp/cmd/suggested_fix.go
+++ b/internal/lsp/cmd/suggested_fix.go
@@ -1,6 +1,7 @@
 // Copyright 2019 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
+
 package cmd
 
 import (

--- a/internal/lsp/cmd/suggested_fix.go
+++ b/internal/lsp/cmd/suggested_fix.go
@@ -1,0 +1,108 @@
+package cmd
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"time"
+
+	"golang.org/x/tools/internal/lsp/diff"
+	"golang.org/x/tools/internal/lsp/protocol"
+	"golang.org/x/tools/internal/lsp/source"
+	"golang.org/x/tools/internal/span"
+	"golang.org/x/tools/internal/tool"
+	errors "golang.org/x/xerrors"
+)
+
+// suggestedfix implements the suggestedfix verb for gopls.
+type suggestedfix struct {
+	Diff  bool `flag:"d" help:"display diffs instead of rewriting files"`
+	Write bool `flag:"w" help:"write result to (source) file instead of stdout"`
+
+	app *Application
+}
+
+func (s *suggestedfix) Name() string      { return "suggestedfix" }
+func (s *suggestedfix) Usage() string     { return "<filename>" }
+func (s *suggestedfix) ShortHelp() string { return "apply suggested fixes" }
+func (s *suggestedfix) DetailedHelp(f *flag.FlagSet) {
+	fmt.Fprintf(f.Output(), `
+Example: apply all suggested fixes for this file:
+
+  $ gopls suggestedfix -w internal/lsp/cmd/check.go
+
+gopls suggestedfix flags are:
+`)
+	f.PrintDefaults()
+}
+
+// Run performs diagnostic checks on the file specified and either;
+// - if -w is specified, updates the file in place;
+// - if -d is specified, prints out unified diffs of the changes; or
+// - otherwise, prints the new versions to stdout.
+func (s *suggestedfix) Run(ctx context.Context, args ...string) error {
+	if len(args) != 1 {
+		return tool.CommandLineErrorf("suggestedfix expects 1 argument")
+	}
+	conn, err := s.app.connect(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.terminate(ctx)
+
+	from := span.Parse(args[0])
+	uri := from.URI()
+	file := conn.AddFile(ctx, uri)
+	if file.err != nil {
+		return file.err
+	}
+
+	// Wait for diagnostics results
+	select {
+	case <-file.hasDiagnostics:
+	case <-time.After(30 * time.Second):
+		return errors.Errorf("timed out waiting for results from %v", file.uri)
+	}
+
+	file.diagnosticsMu.Lock()
+	defer file.diagnosticsMu.Unlock()
+
+	p := protocol.CodeActionParams{
+		TextDocument: protocol.TextDocumentIdentifier{
+			URI: protocol.NewURI(uri),
+		},
+		Context: protocol.CodeActionContext{
+			Only:        []protocol.CodeActionKind{protocol.QuickFix},
+			Diagnostics: file.diagnostics,
+		},
+	}
+	actions, err := conn.CodeAction(ctx, &p)
+	if err != nil {
+		return err
+	}
+	var edits []protocol.TextEdit
+	for _, a := range actions {
+		edits = (*a.Edit.Changes)[string(uri)]
+	}
+
+	sedits, err := source.FromProtocolEdits(file.mapper, edits)
+	if err != nil {
+		return errors.Errorf("%v: %v", edits, err)
+	}
+	newContent := diff.ApplyEdits(string(file.mapper.Content), sedits)
+
+	filename := file.uri.Filename()
+	switch {
+	case s.Write:
+		if len(edits) > 0 {
+			ioutil.WriteFile(filename, []byte(newContent), 0644)
+		}
+	case s.Diff:
+		diffs := diff.ToUnified(filename+".orig", filename, string(file.mapper.Content), sedits)
+		fmt.Print(diffs)
+	default:
+		fmt.Print(string(newContent))
+	}
+	return nil
+}

--- a/internal/lsp/cmd/suggested_fix.go
+++ b/internal/lsp/cmd/suggested_fix.go
@@ -18,7 +18,7 @@ import (
 	errors "golang.org/x/xerrors"
 )
 
-// suggestedfix implements the suggestedfix verb for gopls.
+// suggestedfix implements the fix verb for gopls.
 type suggestedfix struct {
 	Diff  bool `flag:"d" help:"display diffs instead of rewriting files"`
 	Write bool `flag:"w" help:"write result to (source) file instead of stdout"`
@@ -27,16 +27,16 @@ type suggestedfix struct {
 	app *Application
 }
 
-func (s *suggestedfix) Name() string      { return "suggestedfix" }
+func (s *suggestedfix) Name() string      { return "fix" }
 func (s *suggestedfix) Usage() string     { return "<filename>" }
 func (s *suggestedfix) ShortHelp() string { return "apply suggested fixes" }
 func (s *suggestedfix) DetailedHelp(f *flag.FlagSet) {
 	fmt.Fprintf(f.Output(), `
 Example: apply suggested fixes for this file:
 
-  $ gopls suggestedfix -w internal/lsp/cmd/check.go
+  $ gopls fix -w internal/lsp/cmd/check.go
 
-gopls suggestedfix flags are:
+gopls fix flags are:
 `)
 	f.PrintDefaults()
 }
@@ -47,7 +47,7 @@ gopls suggestedfix flags are:
 // - otherwise, prints the new versions to stdout.
 func (s *suggestedfix) Run(ctx context.Context, args ...string) error {
 	if len(args) != 1 {
-		return tool.CommandLineErrorf("suggestedfix expects 1 argument")
+		return tool.CommandLineErrorf("fix expects 1 argument")
 	}
 	conn, err := s.app.connect(ctx)
 	if err != nil {

--- a/internal/lsp/cmd/suggested_fix.go
+++ b/internal/lsp/cmd/suggested_fix.go
@@ -1,3 +1,6 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
 package cmd
 
 import (

--- a/internal/lsp/cmd/suggested_fix.go
+++ b/internal/lsp/cmd/suggested_fix.go
@@ -82,7 +82,7 @@ func (s *suggestedfix) Run(ctx context.Context, args ...string) error {
 	}
 	actions, err := conn.CodeAction(ctx, &p)
 	if err != nil {
-		return err
+		return errors.Errorf("%v: %v", spn, err)
 	}
 	var edits []protocol.TextEdit
 	for _, a := range actions {

--- a/internal/lsp/cmd/test/cmdtest.go
+++ b/internal/lsp/cmd/test/cmdtest.go
@@ -98,10 +98,6 @@ func (r *runner) Import(t *testing.T, spn span.Span) {
 	//TODO: add command line imports tests when it works
 }
 
-func (r *runner) SuggestedFix(t *testing.T, spn span.Span) {
-	//TODO: add suggested fix tests when it works
-}
-
 func CaptureStdOut(t testing.TB, f func()) string {
 	r, out, err := os.Pipe()
 	if err != nil {

--- a/internal/lsp/cmd/test/suggested_fix.go
+++ b/internal/lsp/cmd/test/suggested_fix.go
@@ -1,6 +1,7 @@
 // Copyright 2019 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
+
 package cmdtest
 
 import (

--- a/internal/lsp/cmd/test/suggested_fix.go
+++ b/internal/lsp/cmd/test/suggested_fix.go
@@ -14,7 +14,7 @@ import (
 func (r *runner) SuggestedFix(t *testing.T, spn span.Span) {
 	uri := spn.URI()
 	filename := uri.Filename()
-	args := []string{"suggestedfix", "-a", filename}
+	args := []string{"fix", "-a", filename}
 	app := cmd.New("gopls-test", r.data.Config.Dir, r.data.Exported.Config.Env, r.options)
 	got := CaptureStdOut(t, func() {
 		_ = tool.Run(r.ctx, app, args)

--- a/internal/lsp/cmd/test/suggested_fix.go
+++ b/internal/lsp/cmd/test/suggested_fix.go
@@ -1,3 +1,6 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
 package cmdtest
 
 import (

--- a/internal/lsp/cmd/test/suggested_fix.go
+++ b/internal/lsp/cmd/test/suggested_fix.go
@@ -14,7 +14,7 @@ import (
 func (r *runner) SuggestedFix(t *testing.T, spn span.Span) {
 	uri := spn.URI()
 	filename := uri.Filename()
-	args := []string{"suggestedfix", filename}
+	args := []string{"suggestedfix", "-a", filename}
 	app := cmd.New("gopls-test", r.data.Config.Dir, r.data.Exported.Config.Env, r.options)
 	got := CaptureStdOut(t, func() {
 		_ = tool.Run(r.ctx, app, args)

--- a/internal/lsp/cmd/test/suggested_fix.go
+++ b/internal/lsp/cmd/test/suggested_fix.go
@@ -1,0 +1,25 @@
+package cmdtest
+
+import (
+	"testing"
+
+	"golang.org/x/tools/internal/lsp/cmd"
+	"golang.org/x/tools/internal/span"
+	"golang.org/x/tools/internal/tool"
+)
+
+func (r *runner) SuggestedFix(t *testing.T, spn span.Span) {
+	uri := spn.URI()
+	filename := uri.Filename()
+	args := []string{"suggestedfix", filename}
+	app := cmd.New("gopls-test", r.data.Config.Dir, r.data.Exported.Config.Env, r.options)
+	got := CaptureStdOut(t, func() {
+		_ = tool.Run(r.ctx, app, args)
+	})
+	want := string(r.data.Golden("suggestedfix", filename, func() ([]byte, error) {
+		return []byte(got), nil
+	}))
+	if want != got {
+		t.Errorf("suggested fixes failed for %s, expected:\n%v\ngot:\n%v", filename, want, got)
+	}
+}


### PR DESCRIPTION
This adds support for calling suggestedfix from the gopls command line, e.g.

$ gopls suggestedfix ~/tmp/foo/main.go

Optional arguments are:
-w, which writes the changes back to the original file; and
-d, which prints a unified diff to stdout
With no arguments, the changed files are printed to stdout.

Wasn't sure if the command should be `suggestedfix` or just `fix` or `quickfix`?
Also this applies all changes to a file, does not allow for selective fixes.

Updates golang/go#32875