### PR TITLE
tools/gopls: add command line support for imports

### DIFF
--- a/internal/lsp/cmd/cmd.go
+++ b/internal/lsp/cmd/cmd.go
@@ -143,6 +143,7 @@ func (app *Application) commands() []tool.Application {
 		&bug{},
 		&check{app: app},
 		&format{app: app},
+		&imports{app: app},
 		&query{app: app},
 		&rename{app: app},
 		&version{app: app},

--- a/internal/lsp/cmd/imports.go
+++ b/internal/lsp/cmd/imports.go
@@ -1,6 +1,7 @@
 // Copyright 2019 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
+
 package cmd
 
 import (

--- a/internal/lsp/cmd/imports.go
+++ b/internal/lsp/cmd/imports.go
@@ -1,0 +1,96 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+package cmd
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io/ioutil"
+
+	"golang.org/x/tools/internal/lsp/diff"
+	"golang.org/x/tools/internal/lsp/protocol"
+	"golang.org/x/tools/internal/lsp/source"
+	"golang.org/x/tools/internal/span"
+	"golang.org/x/tools/internal/tool"
+	errors "golang.org/x/xerrors"
+)
+
+// imports implements the import verb for gopls.
+type imports struct {
+	Diff  bool `flag:"d" help:"display diffs instead of rewriting files"`
+	Write bool `flag:"w" help:"write result to (source) file instead of stdout"`
+
+	app *Application
+}
+
+func (t *imports) Name() string      { return "imports" }
+func (t *imports) Usage() string     { return "<filename>" }
+func (t *imports) ShortHelp() string { return "updates import statements" }
+func (t *imports) DetailedHelp(f *flag.FlagSet) {
+	fmt.Fprintf(f.Output(), `
+Example: update imports statements in a file:
+
+  $ gopls imports -w internal/lsp/cmd/check.go
+
+gopls imports flags are:
+`)
+	f.PrintDefaults()
+}
+
+// Run performs diagnostic checks on the file specified and either;
+// - if -w is specified, updates the file in place;
+// - if -d is specified, prints out unified diffs of the changes; or
+// - otherwise, prints the new versions to stdout.
+func (t *imports) Run(ctx context.Context, args ...string) error {
+	if len(args) != 1 {
+		return tool.CommandLineErrorf("imports expects 1 argument")
+	}
+	conn, err := t.app.connect(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.terminate(ctx)
+
+	from := span.Parse(args[0])
+	uri := from.URI()
+	file := conn.AddFile(ctx, uri)
+	if file.err != nil {
+		return file.err
+	}
+	actions, err := conn.CodeAction(ctx, &protocol.CodeActionParams{
+		TextDocument: protocol.TextDocumentIdentifier{
+			URI: protocol.NewURI(uri),
+		},
+	})
+	if err != nil {
+		return errors.Errorf("%v: %v", from, err)
+	}
+	var edits []protocol.TextEdit
+	for _, a := range actions {
+		if a.Title == "Organize Imports" {
+			edits = (*a.Edit.Changes)[string(uri)]
+		}
+	}
+	sedits, err := source.FromProtocolEdits(file.mapper, edits)
+	if err != nil {
+		return errors.Errorf("%v: %v", edits, err)
+	}
+
+	newContent := diff.ApplyEdits(string(file.mapper.Content), sedits)
+
+	filename := file.uri.Filename()
+	switch {
+	case t.Write:
+		if len(edits) > 0 {
+			ioutil.WriteFile(filename, []byte(newContent), 0644)
+		}
+	case t.Diff:
+		diffs := diff.ToUnified(filename+".orig", filename, string(file.mapper.Content), sedits)
+		fmt.Print(diffs)
+	default:
+		fmt.Print(string(newContent))
+	}
+	return nil
+}

--- a/internal/lsp/cmd/test/cmdtest.go
+++ b/internal/lsp/cmd/test/cmdtest.go
@@ -94,10 +94,6 @@ func (r *runner) Link(t *testing.T, uri span.URI, wantLinks []tests.Link) {
 	//TODO: add command line link tests when it works
 }
 
-func (r *runner) Import(t *testing.T, spn span.Span) {
-	//TODO: add command line imports tests when it works
-}
-
 func (r *runner) SuggestedFix(t *testing.T, spn span.Span) {
 	//TODO: add suggested fix tests when it works
 }

--- a/internal/lsp/cmd/test/imports.go
+++ b/internal/lsp/cmd/test/imports.go
@@ -1,6 +1,7 @@
 // Copyright 2019 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
+
 package cmdtest
 
 import (

--- a/internal/lsp/cmd/test/imports.go
+++ b/internal/lsp/cmd/test/imports.go
@@ -1,0 +1,31 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+package cmdtest
+
+import (
+	"os/exec"
+	"testing"
+
+	"golang.org/x/tools/internal/lsp/cmd"
+	"golang.org/x/tools/internal/span"
+	"golang.org/x/tools/internal/tool"
+)
+
+func (r *runner) Import(t *testing.T, spn span.Span) {
+	uri := spn.URI()
+	filename := uri.Filename()
+	args := []string{"imports", filename}
+	app := cmd.New("gopls-test", r.data.Config.Dir, r.data.Exported.Config.Env, r.options)
+	got := CaptureStdOut(t, func() {
+		_ = tool.Run(r.ctx, app, args)
+	})
+	want := string(r.data.Golden("goimports", filename, func() ([]byte, error) {
+		cmd := exec.Command("goimports", filename)
+		out, _ := cmd.Output() // ignore error, sometimes we have intentionally ungofmt-able files
+		return out, nil
+	}))
+	if want != got {
+		t.Errorf("imports failed for %s, expected:\n%v\ngot:\n%v", filename, want, got)
+	}
+}


### PR DESCRIPTION
This adds support for calling import from the gopls command line,
e.g.

$ gopls imports -w ~/tmp/foo/main.go

Optional arguments are:
-w, which writes the changes back to the original file; and
-d, which prints a unified diff to stdout
With no arguments, the changed file is printed to stdout.

Updates golang/go#32875