### PR TITLE
go/analysis/passes/inspect: fix incorrect example

### DIFF
--- a/go/analysis/passes/inspect/inspect.go
+++ b/go/analysis/passes/inspect/inspect.go
@@ -16,7 +16,7 @@
 //
 //	var Analyzer = &analysis.Analyzer{
 //		...
-//		Requires:       reflect.TypeOf(new(inspect.Analyzer)),
+//		Requires:       []*analysis.Analyzer{inspect.Analyzer},
 //	}
 //
 // 	func run(pass *analysis.Pass) (interface{}, error) {


### PR DESCRIPTION
Fixes golang/go#35028