### PR TITLE
tools/gopls: add command line support for links

### DIFF
--- a/internal/lsp/cmd/cmd.go
+++ b/internal/lsp/cmd/cmd.go
@@ -143,6 +143,7 @@ func (app *Application) commands() []tool.Application {
 		&bug{},
 		&check{app: app},
 		&format{app: app},
+		&links{app: app},
 		&imports{app: app},
 		&query{app: app},
 		&references{app: app},

--- a/internal/lsp/cmd/links.go
+++ b/internal/lsp/cmd/links.go
@@ -1,0 +1,93 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+
+	"golang.org/x/tools/internal/lsp/protocol"
+	"golang.org/x/tools/internal/span"
+	"golang.org/x/tools/internal/tool"
+	errors "golang.org/x/xerrors"
+)
+
+// A CmdLink is the output for JSON
+type CmdLink struct {
+	Range protocol.Range `json:"range"` // location of the link
+	URI   string         `json:"uri"`   // the uri of the link
+}
+
+// links implements the links verb for gopls.
+type links struct {
+	JSON bool `flag:"json" help:"emit location range and uri in JSON format"`
+
+	app *Application
+}
+
+func (l *links) Name() string      { return "links" }
+func (l *links) Usage() string     { return "<filename>" }
+func (l *links) ShortHelp() string { return "list links in a file" }
+func (l *links) DetailedHelp(f *flag.FlagSet) {
+	fmt.Fprintf(f.Output(), `
+Example: list links contained within a file:
+
+  $ gopls links internal/lsp/cmd/check.go
+
+gopls links flags are:
+`)
+	f.PrintDefaults()
+}
+
+// Run finds all the links within a document
+// - if -json is specified, outputs location range and uri
+// - otherwise, prints the a list of unique links
+func (l *links) Run(ctx context.Context, args ...string) error {
+	if len(args) != 1 {
+		return tool.CommandLineErrorf("links expects 1 argument")
+	}
+	conn, err := l.app.connect(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.terminate(ctx)
+
+	from := span.Parse(args[0])
+	uri := from.URI()
+	file := conn.AddFile(ctx, uri)
+	if file.err != nil {
+		return file.err
+	}
+	gotLinks, err := conn.DocumentLink(ctx, &protocol.DocumentLinkParams{
+		TextDocument: protocol.TextDocumentIdentifier{
+			URI: protocol.NewURI(uri),
+		},
+	})
+	if err != nil {
+		return errors.Errorf("%v: %v", from, err)
+	}
+	result := make([]CmdLink, len(gotLinks))
+	for _, v := range gotLinks {
+		result = append(result, CmdLink{
+			Range: v.Range,
+			URI:   v.Target,
+		})
+	}
+	if l.JSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "\t")
+		return enc.Encode(result)
+	}
+	uniques := make(map[string]struct{})
+	for _, link := range gotLinks {
+		uniques[link.Target] = struct{}{}
+	}
+	for k := range uniques {
+		fmt.Println(k)
+	}
+	return nil
+}

--- a/internal/lsp/cmd/test/cmdtest.go
+++ b/internal/lsp/cmd/test/cmdtest.go
@@ -86,10 +86,6 @@ func (r *runner) SignatureHelp(t *testing.T, spn span.Span, expectedSignature *s
 	//TODO: add command line signature tests when it works
 }
 
-func (r *runner) Link(t *testing.T, uri span.URI, wantLinks []tests.Link) {
-	//TODO: add command line link tests when it works
-}
-
 func CaptureStdOut(t testing.TB, f func()) string {
 	r, out, err := os.Pipe()
 	if err != nil {

--- a/internal/lsp/cmd/test/links.go
+++ b/internal/lsp/cmd/test/links.go
@@ -1,6 +1,7 @@
 // Copyright 2019 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
+
 package cmdtest
 
 import (
@@ -24,14 +25,24 @@ func (r *runner) Link(t *testing.T, uri span.URI, wantLinks []tests.Link) {
 	})
 	got = strings.Trim(got, "\n") // remove extra new line
 	gotStrings := strings.Split(got, "\n")
+	// The files that are checked include `expect.Note`'s which also include expected links.
+	// For cmd testing we cannot ignore these comments so we get duplicates. So hence we select only the uniques.
+	uniques := make(map[string]struct{})
+	for _, v := range gotStrings {
+		uniques[v] = struct{}{}
+	}
+	var result []string
+	for k := range uniques {
+		result = append(result, k)
+	}
+	sort.Strings(result)
 
 	var wantStrings []string
 	for _, v := range wantLinks {
 		wantStrings = append(wantStrings, v.Target)
 	}
-	sort.Strings(gotStrings)
 	sort.Strings(wantStrings)
-	if !reflect.DeepEqual(gotStrings, wantStrings) {
-		t.Errorf("links not equal for %s, expected:\n%v\ngot:\n%v", filename, wantStrings, gotStrings)
+	if !reflect.DeepEqual(result, wantStrings) {
+		t.Errorf("links not equal for %s, expected:\n%v\ngot:\n%v", filename, wantStrings, result)
 	}
 }

--- a/internal/lsp/cmd/test/links.go
+++ b/internal/lsp/cmd/test/links.go
@@ -1,0 +1,37 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+package cmdtest
+
+import (
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"golang.org/x/tools/internal/lsp/cmd"
+	"golang.org/x/tools/internal/lsp/tests"
+	"golang.org/x/tools/internal/span"
+	"golang.org/x/tools/internal/tool"
+)
+
+func (r *runner) Link(t *testing.T, uri span.URI, wantLinks []tests.Link) {
+	filename := uri.Filename()
+	args := []string{"links", filename}
+	app := cmd.New("gopls-test", r.data.Config.Dir, r.data.Exported.Config.Env, r.options)
+	got := CaptureStdOut(t, func() {
+		_ = tool.Run(r.ctx, app, args)
+	})
+	got = strings.Trim(got, "\n") // remove extra new line
+	gotStrings := strings.Split(got, "\n")
+
+	var wantStrings []string
+	for _, v := range wantLinks {
+		wantStrings = append(wantStrings, v.Target)
+	}
+	sort.Strings(gotStrings)
+	sort.Strings(wantStrings)
+	if !reflect.DeepEqual(gotStrings, wantStrings) {
+		t.Errorf("links not equal for %s, expected:\n%v\ngot:\n%v", filename, wantStrings, gotStrings)
+	}
+}

--- a/internal/lsp/lsp_test.go
+++ b/internal/lsp/lsp_test.go
@@ -759,7 +759,7 @@ func (r *runner) Link(t *testing.T, uri span.URI, wantLinks []tests.Link) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	gotLinks, err := r.server.DocumentLink(r.ctx, &protocol.DocumentLinkParams{
+	got, err := r.server.DocumentLink(r.ctx, &protocol.DocumentLinkParams{
 		TextDocument: protocol.TextDocumentIdentifier{
 			URI: protocol.NewURI(uri),
 		},
@@ -767,41 +767,8 @@ func (r *runner) Link(t *testing.T, uri span.URI, wantLinks []tests.Link) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var notePositions []token.Position
-	links := make(map[span.Span]string, len(wantLinks))
-	for _, link := range wantLinks {
-		links[link.Src] = link.Target
-		notePositions = append(notePositions, link.NotePosition)
-	}
-
-	for _, link := range gotLinks {
-		spn, err := m.RangeSpan(link.Range)
-		if err != nil {
-			t.Fatal(err)
-		}
-		linkInNote := false
-		for _, notePosition := range notePositions {
-			// Drop the links found inside expectation notes arguments as this links are not collected by expect package
-			if notePosition.Line == spn.Start().Line() &&
-				notePosition.Column <= spn.Start().Column() {
-				delete(links, spn)
-				linkInNote = true
-			}
-		}
-		if linkInNote {
-			continue
-		}
-		if target, ok := links[spn]; ok {
-			delete(links, spn)
-			if target != link.Target {
-				t.Errorf("for %v want %v, got %v\n", spn, link.Target, target)
-			}
-		} else {
-			t.Errorf("unexpected link %v:%v\n", spn, link.Target)
-		}
-	}
-	for spn, target := range links {
-		t.Errorf("missing link %v:%v\n", spn, target)
+	if diff := tests.DiffLinks(m, wantLinks, got); diff != "" {
+		t.Error(diff)
 	}
 }
 

--- a/internal/lsp/tests/links.go
+++ b/internal/lsp/tests/links.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Go Authors. All rights reserved.
+// Copyright 2019 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/internal/lsp/tests/links.go
+++ b/internal/lsp/tests/links.go
@@ -1,0 +1,55 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package tests
+
+import (
+	"fmt"
+	"go/token"
+
+	"golang.org/x/tools/internal/lsp/protocol"
+	"golang.org/x/tools/internal/span"
+)
+
+// DiffLinks takes the links we got and checks if they are located within the source or a Note.
+// If the link is within a Note, the link is removed.
+// Returns an diff comment if there are differences and empty string if no diffs
+func DiffLinks(mapper *protocol.ColumnMapper, wantLinks []Link, gotLinks []protocol.DocumentLink) string {
+	var notePositions []token.Position
+	links := make(map[span.Span]string, len(wantLinks))
+	for _, link := range wantLinks {
+		links[link.Src] = link.Target
+		notePositions = append(notePositions, link.NotePosition)
+	}
+	for _, link := range gotLinks {
+		spn, err := mapper.RangeSpan(link.Range)
+		if err != nil {
+			return fmt.Sprintf("%v", err)
+		}
+		linkInNote := false
+		for _, notePosition := range notePositions {
+			// Drop the links found inside expectation notes arguments as this links are not collected by expect package
+			if notePosition.Line == spn.Start().Line() &&
+				notePosition.Column <= spn.Start().Column() {
+				delete(links, spn)
+				linkInNote = true
+			}
+		}
+		if linkInNote {
+			continue
+		}
+		if target, ok := links[spn]; ok {
+			delete(links, spn)
+			if target != link.Target {
+				return fmt.Sprintf("for %v want %v, got %v\n", spn, link.Target, target)
+			}
+		} else {
+			return fmt.Sprintf("unexpected link %v:%v\n", spn, link.Target)
+		}
+	}
+	for spn, target := range links {
+		return fmt.Sprintf("missing link %v:%v\n", spn, target)
+	}
+	return ""
+}


### PR DESCRIPTION
This adds support for calling links from the gopls command line,
e.g.

$ gopls links ~/tmp/foo/main.go

Optional arguments are:
-json, which emits range and uri in JSON
With no arguments, a unique list of links are emitted.

Updates golang/go#32875