### PR TITLE
go/analysis/passes/printf: allow # for b flag

### DIFF
--- a/go/analysis/passes/printf/printf.go
+++ b/go/analysis/passes/printf/printf.go
@@ -748,7 +748,7 @@ var printVerbs = []printVerb{
 	// '#' is alternate format for several verbs.
 	// ' ' is spacer for numbers
 	{'%', noFlag, 0},
-	{'b', numFlag, argInt | argFloat | argComplex | argPointer},
+	{'b', sharpNumFlag, argInt | argFloat | argComplex | argPointer},
 	{'c', "-", argRune | argInt},
 	{'d', numFlag, argInt | argPointer},
 	{'e', sharpNumFlag, argFloat | argComplex},

--- a/go/analysis/passes/printf/testdata/src/a/a.go
+++ b/go/analysis/passes/printf/testdata/src/a/a.go
@@ -160,6 +160,7 @@ func PrintfTests() {
 	fmt.Printf("%*% x", 0.22)                   // want `Printf format %\*% uses non-int 0.22 as argument of \*`
 	fmt.Printf("%q %q", multi()...)             // ok
 	fmt.Printf("%#q", `blah`)                   // ok
+	fmt.Printf("%#b", 3)                        // ok
 	// printf("now is the time", "buddy")          // no error "printf call has arguments but no formatting directives"
 	Printf("now is the time", "buddy") // want "Printf call has arguments but no formatting directives"
 	Printf("hi")                       // ok


### PR DESCRIPTION
Adding the `#` to a `b` flag is allowed and adds a leading `0b` to the output.