### PR TITLE
blog: fix swallowed error

### DIFF
--- a/blog/blog.go
+++ b/blog/blog.go
@@ -188,6 +188,9 @@ func (s *Server) loadDocs(root string) error {
 	// Read content into docs field.
 	const ext = ".article"
 	fn := func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 		if filepath.Ext(p) != ext {
 			return nil
 		}


### PR DESCRIPTION
A function created for filepath.Walk in the blog package accepts an error
as its third argument, but then does nothing with it. This change picks up
the dropped error and returns it should it be non-nil.