### PR TITLE
expose PackageInfo.dir

### DIFF
--- a/go/loader/loader.go
+++ b/go/loader/loader.go
@@ -192,6 +192,8 @@ type PackageInfo struct {
 	errorFunc func(error)
 }
 
+func (info *PackageInfo) Dir() string { return info.dir }
+
 func (info *PackageInfo) String() string { return info.Pkg.Path() }
 
 func (info *PackageInfo) appendError(err error) {


### PR DESCRIPTION
The `dir` field of the `PackageInfo` type might be useful for some applications.