### PR TITLE
go/analysis/unitchecker: add erroras analysis to align with go vet

### DIFF
--- a/go/analysis/unitchecker/main.go
+++ b/go/analysis/unitchecker/main.go
@@ -22,6 +22,7 @@ import (
 	"golang.org/x/tools/go/analysis/passes/cgocall"
 	"golang.org/x/tools/go/analysis/passes/composite"
 	"golang.org/x/tools/go/analysis/passes/copylock"
+	"golang.org/x/tools/go/analysis/passes/errorsas"
 	"golang.org/x/tools/go/analysis/passes/httpresponse"
 	"golang.org/x/tools/go/analysis/passes/loopclosure"
 	"golang.org/x/tools/go/analysis/passes/lostcancel"
@@ -47,6 +48,7 @@ func main() {
 		cgocall.Analyzer,
 		composite.Analyzer,
 		copylock.Analyzer,
+		errorsas.Analyzer,
 		httpresponse.Analyzer,
 		loopclosure.Analyzer,
 		lostcancel.Analyzer,


### PR DESCRIPTION
Add `erroras` analysis to the `unitchecker` example that mimics go vet.

The unitchecker according to its comments is an example of replicating
the analysis performed by go vet using the unitchecker. The example is
missing the erroras analysis that was added to go vet in
golang/go@9f76566. This change brings the example back inline with the
analysis performed by go vet.

Close golang/go#35486