### PR TITLE
go/packages: Fix loading syntax for imports when types not requested.

### DIFF
--- a/go/packages/packages.go
+++ b/go/packages/packages.go
@@ -713,7 +713,7 @@ func (ld *loader) loadPackage(lpkg *loaderPackage) {
 	// which would then require that such created packages be explicitly
 	// inserted back into the Import graph as a final step after export data loading.
 	// The Diamond test exercises this case.
-	if !lpkg.needtypes {
+	if !lpkg.needtypes && !lpkg.needsrc {
 		return
 	}
 	if !lpkg.needsrc {

--- a/go/packages/packages_test.go
+++ b/go/packages/packages_test.go
@@ -2470,13 +2470,15 @@ func testIssue35331(t *testing.T, exporter packagestest.Exporter) {
 	if len(pkgs) != 1 {
 		t.Fatalf("Expected 1 package, got %v", pkgs)
 	}
-	pkg := pkgs[0]
-	if len(pkg.Errors) > 0 {
-		t.Fatalf("Expected no errors in package, got %v", pkg.Errors)
-	}
-	if len(pkg.Syntax) == 0 {
-		t.Fatalf("Expected syntax on package, got none.")
-	}
+	packages.Visit(pkgs, func(pkg *packages.Package) bool {
+		if len(pkg.Errors) > 0 {
+			t.Errorf("Expected no errors in package %q, got %v", pkg.ID, pkg.Errors)
+		}
+		if len(pkg.Syntax) == 0 && pkg.ID != "unsafe" {
+			t.Errorf("Expected syntax on package %q, got none.", pkg.ID)
+		}
+		return true
+	}, nil)
 }
 
 func TestLoadModeStrings(t *testing.T) {


### PR DESCRIPTION
http://golang.org/cl/205160 fixed an issue when package syntax wasn't
loaded unless NeedTypes was specified, but syntax of imported packages
wasn't loaded even with NeedDeps specified. This change corrects this
error.

Fixes issue #35331.