### PR TITLE
Stdlib errors

### DIFF
--- a/internal/lsp/cache/analysis.go
+++ b/internal/lsp/cache/analysis.go
@@ -201,7 +201,7 @@ func runAnalysis(ctx context.Context, fset *token.FileSet, analyzer *analysis.An
 	defer func() {
 		if r := recover(); r != nil {
 			log.Print(ctx, fmt.Sprintf("analysis panicked: %s", r), telemetry.Package.Of(pkg.PkgPath))
-			data.err = fmt.Errorf("analysis %s for package %s panicked: %v", analyzer.Name, pkg.PkgPath())
+			data.err = fmt.Errorf("analysis %s for package %s panicked: %v", analyzer.Name, pkg.PkgPath(), r)
 		}
 	}()
 

--- a/internal/lsp/cache/check.go
+++ b/internal/lsp/cache/check.go
@@ -21,7 +21,6 @@ import (
 	"golang.org/x/tools/internal/span"
 	"golang.org/x/tools/internal/telemetry/log"
 	"golang.org/x/tools/internal/telemetry/trace"
-	errors "golang.org/x/xerrors"
 )
 
 // packageHandle implements source.CheckPackageHandle.
@@ -108,7 +107,7 @@ func (s *snapshot) packageHandle(ctx context.Context, id packageID, mode source.
 func (s *snapshot) buildKey(ctx context.Context, id packageID, mode source.ParseMode) (*packageHandle, map[packagePath]*packageHandle, error) {
 	m := s.getMetadata(id)
 	if m == nil {
-		return nil, nil, errors.Errorf("no metadata for %s", id)
+		return nil, nil, fmt.Errorf("no metadata for %s", id)
 	}
 	goFiles, err := s.parseGoHandles(ctx, m.goFiles, mode)
 	if err != nil {
@@ -184,7 +183,7 @@ func (ph *packageHandle) Check(ctx context.Context) (source.Package, error) {
 func (ph *packageHandle) check(ctx context.Context) (*pkg, error) {
 	v := ph.handle.Get(ctx)
 	if v == nil {
-		return nil, errors.Errorf("no package for %s", ph.m.id)
+		return nil, fmt.Errorf("no package for %s", ph.m.id)
 	}
 	data := v.(*packageData)
 	return data.pkg, data.err
@@ -213,7 +212,7 @@ func (ph *packageHandle) Cached() (source.Package, error) {
 func (ph *packageHandle) cached() (*pkg, error) {
 	v := ph.handle.Cached()
 	if v == nil {
-		return nil, errors.Errorf("no cached type information for %s", ph.m.pkgPath)
+		return nil, fmt.Errorf("no cached type information for %s", ph.m.pkgPath)
 	}
 	data := v.(*packageData)
 	return data.pkg, data.err
@@ -299,7 +298,7 @@ func typeCheck(ctx context.Context, fset *token.FileSet, m *metadata, mode sourc
 	if pkg.pkgPath == "unsafe" {
 		pkg.types = types.Unsafe
 	} else if len(files) == 0 { // not the unsafe package, no parsed files
-		return nil, errors.Errorf("no parsed files for package %s, expected: %s", pkg.pkgPath, pkg.compiledGoFiles)
+		return nil, fmt.Errorf("no parsed files for package %s, expected: %s", pkg.pkgPath, pkg.compiledGoFiles)
 	} else {
 		pkg.types = types.NewPackage(string(m.pkgPath), m.name)
 	}
@@ -311,7 +310,7 @@ func typeCheck(ctx context.Context, fset *token.FileSet, m *metadata, mode sourc
 		Importer: importerFunc(func(pkgPath string) (*types.Package, error) {
 			dep := deps[packagePath(pkgPath)]
 			if dep == nil {
-				return nil, errors.Errorf("no package for import %s", pkgPath)
+				return nil, fmt.Errorf("no package for import %s", pkgPath)
 			}
 			depPkg, err := dep.check(ctx)
 			if err != nil {

--- a/internal/lsp/cache/errors.go
+++ b/internal/lsp/cache/errors.go
@@ -16,7 +16,6 @@ import (
 	"golang.org/x/tools/internal/lsp/telemetry"
 	"golang.org/x/tools/internal/span"
 	"golang.org/x/tools/internal/telemetry/log"
-	errors "golang.org/x/xerrors"
 )
 
 func sourceError(ctx context.Context, fset *token.FileSet, pkg *pkg, e interface{}) (*source.Error, error) {
@@ -58,7 +57,7 @@ func sourceError(ctx context.Context, fset *token.FileSet, pkg *pkg, e interface
 	case scanner.ErrorList:
 		// The first parser error is likely the root cause of the problem.
 		if e.Len() <= 0 {
-			return nil, errors.Errorf("no errors in %v", e)
+			return nil, fmt.Errorf("no errors in %v", e)
 		}
 		msg = e[0].Msg
 		kind = source.ParseError
@@ -213,7 +212,7 @@ func scannerErrorRange(ctx context.Context, fset *token.FileSet, pkg *pkg, posn 
 	}
 	tok := fset.File(file.Pos())
 	if tok == nil {
-		return span.Span{}, errors.Errorf("no token.File for %s", ph.File().Identity().URI)
+		return span.Span{}, fmt.Errorf("no token.File for %s", ph.File().Identity().URI)
 	}
 	pos := tok.Pos(posn.Offset)
 	return span.NewRange(fset, pos, pos).Span()

--- a/internal/lsp/cache/errors.go
+++ b/internal/lsp/cache/errors.go
@@ -57,7 +57,7 @@ func sourceError(ctx context.Context, fset *token.FileSet, pkg *pkg, e interface
 	case scanner.ErrorList:
 		// The first parser error is likely the root cause of the problem.
 		if e.Len() <= 0 {
-			return nil, fmt.Errorf("no errors in %v", e)
+			return nil, fmt.Errorf("no errors in %w", e)
 		}
 		msg = e[0].Msg
 		kind = source.ParseError
@@ -97,7 +97,7 @@ func sourceError(ctx context.Context, fset *token.FileSet, pkg *pkg, e interface
 	}
 	ph, err := pkg.File(spn.URI())
 	if err != nil {
-		return nil, fmt.Errorf("finding file for error %q: %v", msg, err)
+		return nil, fmt.Errorf("finding file for error %q: %w", msg, err)
 	}
 	return &source.Error{
 		File:           ph.File().Identity(),

--- a/internal/lsp/cache/load.go
+++ b/internal/lsp/cache/load.go
@@ -59,7 +59,7 @@ func (s *snapshot) load(ctx context.Context, scope source.Scope) ([]*metadata, e
 	// If the context was canceled, return early.
 	// Otherwise, we might be type-checking an incomplete result.
 	if err == context.Canceled {
-		return nil, fmt.Errorf("no metadata for %s: %v", uri, err)
+		return nil, fmt.Errorf("no metadata for %s: %w", uri, err)
 	}
 	log.Print(ctx, "go/packages.Load", tag.Of("packages", len(pkgs)))
 	if len(pkgs) == 0 {

--- a/internal/lsp/cache/load.go
+++ b/internal/lsp/cache/load.go
@@ -16,7 +16,6 @@ import (
 	"golang.org/x/tools/internal/telemetry/log"
 	"golang.org/x/tools/internal/telemetry/tag"
 	"golang.org/x/tools/internal/telemetry/trace"
-	errors "golang.org/x/xerrors"
 )
 
 type metadata struct {
@@ -60,12 +59,12 @@ func (s *snapshot) load(ctx context.Context, scope source.Scope) ([]*metadata, e
 	// If the context was canceled, return early.
 	// Otherwise, we might be type-checking an incomplete result.
 	if err == context.Canceled {
-		return nil, errors.Errorf("no metadata for %s: %v", uri, err)
+		return nil, fmt.Errorf("no metadata for %s: %v", uri, err)
 	}
 	log.Print(ctx, "go/packages.Load", tag.Of("packages", len(pkgs)))
 	if len(pkgs) == 0 {
 		if err == nil {
-			err = errors.Errorf("no packages found for query %s", query)
+			err = fmt.Errorf("no packages found for query %s", query)
 		}
 	}
 	if err != nil {
@@ -132,7 +131,7 @@ func (s *snapshot) updateMetadata(ctx context.Context, uri source.Scope, pkgs []
 	s.clearAndRebuildImportGraph()
 
 	if len(results) == 0 {
-		return nil, errors.Errorf("no metadata for %s", uri)
+		return nil, fmt.Errorf("no metadata for %s", uri)
 	}
 	return results, nil
 }
@@ -140,7 +139,7 @@ func (s *snapshot) updateMetadata(ctx context.Context, uri source.Scope, pkgs []
 func (s *snapshot) updateImports(ctx context.Context, pkgPath packagePath, pkg *packages.Package, cfg *packages.Config, seen map[packageID]struct{}) error {
 	id := packageID(pkg.ID)
 	if _, ok := seen[id]; ok {
-		return errors.Errorf("import cycle detected: %q", id)
+		return fmt.Errorf("import cycle detected: %q", id)
 	}
 	// Recreate the metadata rather than reusing it to avoid locking.
 	m := &metadata{

--- a/internal/lsp/cache/parse.go
+++ b/internal/lsp/cache/parse.go
@@ -229,7 +229,7 @@ func fix(ctx context.Context, n ast.Node, tok *token.File, src []byte) error {
 				// Recursively fix in our fixed node.
 				err = fix(ctx, parent, tok, src)
 			} else {
-				err = fmt.Errorf("unable to parse defer or go from *ast.BadStmt: %v", err)
+				err = fmt.Errorf("unable to parse defer or go from *ast.BadStmt: %w", err)
 			}
 			return false
 		case *ast.BadExpr:
@@ -608,22 +608,22 @@ func parseExpr(pos token.Pos, src []byte) (ast.Expr, error) {
 	// best-effort behavior, whereas ParseExpr fails hard on any error.
 	fakeFile, err := parser.ParseFile(token.NewFileSet(), "", fileSrc, 0)
 	if fakeFile == nil {
-		return nil, fmt.Errorf("error reading fake file source: %v", err)
+		return nil, fmt.Errorf("error reading fake file source: %w", err)
 	}
 
 	// Extract our expression node from inside the fake file.
 	if len(fakeFile.Decls) == 0 {
-		return nil, fmt.Errorf("error parsing fake file: %v", err)
+		return nil, fmt.Errorf("error parsing fake file: %w", err)
 	}
 
 	fakeDecl, _ := fakeFile.Decls[0].(*ast.FuncDecl)
 	if fakeDecl == nil || len(fakeDecl.Body.List) == 0 {
-		return nil, fmt.Errorf("no statement in %s: %v", src, err)
+		return nil, fmt.Errorf("no statement in %s: %w", src, err)
 	}
 
 	exprStmt, ok := fakeDecl.Body.List[0].(*ast.ExprStmt)
 	if !ok {
-		return nil, fmt.Errorf("no expr in %s: %v", src, err)
+		return nil, fmt.Errorf("no expr in %s: %w", src, err)
 	}
 
 	expr := exprStmt.X

--- a/internal/lsp/cache/pkg.go
+++ b/internal/lsp/cache/pkg.go
@@ -6,13 +6,13 @@ package cache
 
 import (
 	"context"
+	"fmt"
 	"go/ast"
 	"go/types"
 
 	"golang.org/x/tools/internal/lsp/protocol"
 	"golang.org/x/tools/internal/lsp/source"
 	"golang.org/x/tools/internal/span"
-	errors "golang.org/x/xerrors"
 )
 
 // pkg contains the type information needed by the source package.
@@ -60,7 +60,7 @@ func (p *pkg) File(uri span.URI) (source.ParseGoHandle, error) {
 			return ph, nil
 		}
 	}
-	return nil, errors.Errorf("no ParseGoHandle for %s", uri)
+	return nil, fmt.Errorf("no ParseGoHandle for %s", uri)
 }
 
 func (p *pkg) GetSyntax() []*ast.File {
@@ -99,7 +99,7 @@ func (p *pkg) GetImport(pkgPath string) (source.Package, error) {
 		return imp, nil
 	}
 	// Don't return a nil pointer because that still satisfies the interface.
-	return nil, errors.Errorf("no imported package for %s", pkgPath)
+	return nil, fmt.Errorf("no imported package for %s", pkgPath)
 }
 
 func (p *pkg) Imports() []source.Package {
@@ -113,7 +113,7 @@ func (p *pkg) Imports() []source.Package {
 func (s *snapshot) FindAnalysisError(ctx context.Context, pkgID, analyzerName, msg string, rng protocol.Range) (*source.Error, error) {
 	analyzer, ok := s.View().Options().Analyzers[analyzerName]
 	if !ok {
-		return nil, errors.Errorf("unexpected analyzer: %s", analyzerName)
+		return nil, fmt.Errorf("unexpected analyzer: %s", analyzerName)
 	}
 	act, err := s.actionHandle(ctx, packageID(pkgID), source.ParseFull, analyzer)
 	if err != nil {
@@ -135,5 +135,5 @@ func (s *snapshot) FindAnalysisError(ctx context.Context, pkgID, analyzerName, m
 		}
 		return err, nil
 	}
-	return nil, errors.Errorf("no matching diagnostic for %s:%v", pkgID, analyzerName)
+	return nil, fmt.Errorf("no matching diagnostic for %s:%v", pkgID, analyzerName)
 }

--- a/internal/lsp/cache/session.go
+++ b/internal/lsp/cache/session.go
@@ -6,6 +6,7 @@ package cache
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -20,7 +21,6 @@ import (
 	"golang.org/x/tools/internal/telemetry/log"
 	"golang.org/x/tools/internal/telemetry/trace"
 	"golang.org/x/tools/internal/xcontext"
-	errors "golang.org/x/xerrors"
 )
 
 type session struct {
@@ -210,7 +210,7 @@ func (s *session) Views() []source.View {
 // viewMu must be held when calling this method.
 func (s *session) bestView(uri span.URI) (source.View, error) {
 	if len(s.views) == 0 {
-		return nil, errors.Errorf("no views in the session")
+		return nil, fmt.Errorf("no views in the session")
 	}
 	// we need to find the best view for this file
 	var longest source.View
@@ -276,7 +276,7 @@ func (s *session) dropView(ctx context.Context, view *view) (int, error) {
 			return i, nil
 		}
 	}
-	return -1, errors.Errorf("view %s for %v not found", view.Name(), view.Folder())
+	return -1, fmt.Errorf("view %s for %v not found", view.Name(), view.Folder())
 }
 
 // TODO: Propagate the language ID through to the view.

--- a/internal/lsp/cache/snapshot.go
+++ b/internal/lsp/cache/snapshot.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"sync"
 
@@ -10,7 +11,6 @@ import (
 	"golang.org/x/tools/internal/lsp/telemetry"
 	"golang.org/x/tools/internal/span"
 	"golang.org/x/tools/internal/telemetry/log"
-	errors "golang.org/x/xerrors"
 )
 
 type snapshot struct {
@@ -94,7 +94,7 @@ func (s *snapshot) PackageHandles(ctx context.Context, fh source.FileHandle) ([]
 		phs = results
 	}
 	if len(phs) == 0 {
-		return nil, errors.Errorf("no CheckPackageHandles for %s", fh.Identity().URI)
+		return nil, fmt.Errorf("no CheckPackageHandles for %s", fh.Identity().URI)
 	}
 
 	return phs, nil
@@ -127,21 +127,21 @@ func (s *snapshot) PackageHandle(ctx context.Context, id string) (source.Package
 
 	m := s.getMetadata(packageID(id))
 	if m == nil {
-		return nil, errors.Errorf("no known metadata for %s", id)
+		return nil, fmt.Errorf("no known metadata for %s", id)
 	}
 	// Determine if we need to type-check the package.
 	phs, load, check := s.shouldCheck([]*metadata{m})
 	if load {
-		return nil, errors.Errorf("outdated metadata for %s, needs re-load", id)
+		return nil, fmt.Errorf("outdated metadata for %s, needs re-load", id)
 	}
 	if check {
 		return s.packageHandle(ctx, m.id, source.ParseFull)
 	}
 	if len(phs) == 0 {
-		return nil, errors.Errorf("no check package handle for %s", id)
+		return nil, fmt.Errorf("no check package handle for %s", id)
 	}
 	if len(phs) > 1 {
-		return nil, errors.Errorf("multiple check package handles for a single id: %s", id)
+		return nil, fmt.Errorf("multiple check package handles for a single id: %s", id)
 	}
 	return phs[0], nil
 }

--- a/internal/lsp/cache/view.go
+++ b/internal/lsp/cache/view.go
@@ -26,7 +26,6 @@ import (
 	"golang.org/x/tools/internal/telemetry/log"
 	"golang.org/x/tools/internal/telemetry/tag"
 	"golang.org/x/tools/internal/xcontext"
-	errors "golang.org/x/xerrors"
 )
 
 type view struct {
@@ -435,7 +434,7 @@ func (v *view) mapFile(uri span.URI, f viewFile) {
 func (v *view) FindPosInPackage(searchpkg source.Package, pos token.Pos) (*ast.File, source.Package, error) {
 	tok := v.session.cache.fset.File(pos)
 	if tok == nil {
-		return nil, nil, errors.Errorf("no file for pos in package %s", searchpkg.ID())
+		return nil, nil, fmt.Errorf("no file for pos in package %s", searchpkg.ID())
 	}
 	uri := span.FileURI(tok.Name())
 
@@ -491,7 +490,7 @@ func (v *view) findIgnoredFile(uri span.URI) (source.ParseGoHandle, source.Packa
 			return h, nil, nil
 		}
 	}
-	return nil, nil, errors.Errorf("no ignored file for %s", uri)
+	return nil, nil, fmt.Errorf("no ignored file for %s", uri)
 }
 
 func findFileInPackage(pkg source.Package, uri span.URI) (source.ParseGoHandle, source.Package, error) {
@@ -512,7 +511,7 @@ func findFileInPackage(pkg source.Package, uri span.URI) (source.ParseGoHandle, 
 			}
 		}
 	}
-	return nil, nil, errors.Errorf("no file for %s in package %s", uri, pkg.ID())
+	return nil, nil, fmt.Errorf("no file for %s in package %s", uri, pkg.ID())
 }
 
 type debugView struct{ *view }

--- a/internal/lsp/cmd/capabilities_test.go
+++ b/internal/lsp/cmd/capabilities_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -11,7 +12,6 @@ import (
 	"golang.org/x/tools/internal/lsp/cache"
 	"golang.org/x/tools/internal/lsp/protocol"
 	"golang.org/x/tools/internal/span"
-	errors "golang.org/x/xerrors"
 )
 
 // TestCapabilities does some minimal validation of the server's adherence to the LSP.
@@ -107,11 +107,11 @@ func validateCapabilities(result *protocol.InitializeResult) error {
 	// If the client sends "false" for RenameProvider.PrepareSupport,
 	// the server must respond with a boolean.
 	if v, ok := result.Capabilities.RenameProvider.(bool); !ok {
-		return errors.Errorf("RenameProvider must be a boolean if PrepareSupport is false (got %T)", v)
+		return fmt.Errorf("RenameProvider must be a boolean if PrepareSupport is false (got %T)", v)
 	}
 	// The same goes for CodeActionKind.ValueSet.
 	if v, ok := result.Capabilities.CodeActionProvider.(bool); !ok {
-		return errors.Errorf("CodeActionSupport must be a boolean if CodeActionKind.ValueSet has length 0 (got %T)", v)
+		return fmt.Errorf("CodeActionSupport must be a boolean if CodeActionKind.ValueSet has length 0 (got %T)", v)
 	}
 	return nil
 }

--- a/internal/lsp/cmd/check.go
+++ b/internal/lsp/cmd/check.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"golang.org/x/tools/internal/span"
-	errors "golang.org/x/xerrors"
 )
 
 // check implements the check verb for gopls.
@@ -61,14 +60,14 @@ func (c *check) Run(ctx context.Context, args ...string) error {
 		select {
 		case <-file.hasDiagnostics:
 		case <-time.After(30 * time.Second):
-			return errors.Errorf("timed out waiting for results from %v", file.uri)
+			return fmt.Errorf("timed out waiting for results from %v", file.uri)
 		}
 		file.diagnosticsMu.Lock()
 		defer file.diagnosticsMu.Unlock()
 		for _, d := range file.diagnostics {
 			spn, err := file.mapper.RangeSpan(d.Range)
 			if err != nil {
-				return errors.Errorf("Could not convert position %v for %q", d.Range, d.Message)
+				return fmt.Errorf("Could not convert position %v for %q", d.Range, d.Message)
 			}
 			fmt.Printf("%v: %v\n", spn, d.Message)
 		}

--- a/internal/lsp/cmd/cmd.go
+++ b/internal/lsp/cmd/cmd.go
@@ -29,7 +29,6 @@ import (
 	"golang.org/x/tools/internal/telemetry/export/ocagent"
 	"golang.org/x/tools/internal/tool"
 	"golang.org/x/tools/internal/xcontext"
-	errors "golang.org/x/xerrors"
 )
 
 // Application is the main application as passed to tool.Main
@@ -359,7 +358,7 @@ func (c *cmdClient) getFile(ctx context.Context, uri span.URI) *cmdFile {
 		fname := uri.Filename()
 		content, err := ioutil.ReadFile(fname)
 		if err != nil {
-			file.err = errors.Errorf("getFile: %v: %v", uri, err)
+			file.err = fmt.Errorf("getFile: %v: %v", uri, err)
 			return file
 		}
 		f := c.fset.AddFile(fname, -1, len(content))
@@ -399,7 +398,7 @@ func (c *connection) AddFile(ctx context.Context, uri span.URI) *cmdFile {
 		},
 	}
 	if err := c.Server.DidOpen(ctx, p); err != nil {
-		file.err = errors.Errorf("%v: %v", uri, err)
+		file.err = fmt.Errorf("%v: %v", uri, err)
 	}
 	return file
 }

--- a/internal/lsp/cmd/cmd.go
+++ b/internal/lsp/cmd/cmd.go
@@ -358,7 +358,7 @@ func (c *cmdClient) getFile(ctx context.Context, uri span.URI) *cmdFile {
 		fname := uri.Filename()
 		content, err := ioutil.ReadFile(fname)
 		if err != nil {
-			file.err = fmt.Errorf("getFile: %v: %v", uri, err)
+			file.err = fmt.Errorf("getFile: %v: %w", uri, err)
 			return file
 		}
 		f := c.fset.AddFile(fname, -1, len(content))
@@ -398,7 +398,7 @@ func (c *connection) AddFile(ctx context.Context, uri span.URI) *cmdFile {
 		},
 	}
 	if err := c.Server.DidOpen(ctx, p); err != nil {
-		file.err = fmt.Errorf("%v: %v", uri, err)
+		file.err = fmt.Errorf("%v: %w", uri, err)
 	}
 	return file
 }

--- a/internal/lsp/cmd/definition.go
+++ b/internal/lsp/cmd/definition.go
@@ -82,7 +82,7 @@ func (d *definition) Run(ctx context.Context, args ...string) error {
 	}
 	locs, err := conn.Definition(ctx, &p)
 	if err != nil {
-		return fmt.Errorf("%v: %v", from, err)
+		return fmt.Errorf("%v: %w", from, err)
 	}
 
 	if len(locs) == 0 {
@@ -93,18 +93,18 @@ func (d *definition) Run(ctx context.Context, args ...string) error {
 	}
 	hover, err := conn.Hover(ctx, &q)
 	if err != nil {
-		return fmt.Errorf("%v: %v", from, err)
+		return fmt.Errorf("%v: %w", from, err)
 	}
 	if hover == nil {
 		return fmt.Errorf("%v: not an identifier", from)
 	}
 	file = conn.AddFile(ctx, span.NewURI(locs[0].URI))
 	if file.err != nil {
-		return fmt.Errorf("%v: %v", from, file.err)
+		return fmt.Errorf("%v: %w", from, file.err)
 	}
 	definition, err := file.mapper.Span(locs[0])
 	if err != nil {
-		return fmt.Errorf("%v: %v", from, err)
+		return fmt.Errorf("%v: %w", from, err)
 	}
 	description := strings.TrimSpace(hover.Contents.Value)
 	var result interface{}

--- a/internal/lsp/cmd/definition.go
+++ b/internal/lsp/cmd/definition.go
@@ -16,7 +16,6 @@ import (
 	"golang.org/x/tools/internal/lsp/protocol"
 	"golang.org/x/tools/internal/span"
 	"golang.org/x/tools/internal/tool"
-	errors "golang.org/x/xerrors"
 )
 
 // A Definition is the result of a 'definition' query.
@@ -83,29 +82,29 @@ func (d *definition) Run(ctx context.Context, args ...string) error {
 	}
 	locs, err := conn.Definition(ctx, &p)
 	if err != nil {
-		return errors.Errorf("%v: %v", from, err)
+		return fmt.Errorf("%v: %v", from, err)
 	}
 
 	if len(locs) == 0 {
-		return errors.Errorf("%v: not an identifier", from)
+		return fmt.Errorf("%v: not an identifier", from)
 	}
 	q := protocol.HoverParams{
 		TextDocumentPositionParams: tdpp,
 	}
 	hover, err := conn.Hover(ctx, &q)
 	if err != nil {
-		return errors.Errorf("%v: %v", from, err)
+		return fmt.Errorf("%v: %v", from, err)
 	}
 	if hover == nil {
-		return errors.Errorf("%v: not an identifier", from)
+		return fmt.Errorf("%v: not an identifier", from)
 	}
 	file = conn.AddFile(ctx, span.NewURI(locs[0].URI))
 	if file.err != nil {
-		return errors.Errorf("%v: %v", from, file.err)
+		return fmt.Errorf("%v: %v", from, file.err)
 	}
 	definition, err := file.mapper.Span(locs[0])
 	if err != nil {
-		return errors.Errorf("%v: %v", from, err)
+		return fmt.Errorf("%v: %v", from, err)
 	}
 	description := strings.TrimSpace(hover.Contents.Value)
 	var result interface{}
@@ -122,7 +121,7 @@ func (d *definition) Run(ctx context.Context, args ...string) error {
 			Desc:   description,
 		}
 	default:
-		return errors.Errorf("unknown emulation for definition: %s", d.query.Emulate)
+		return fmt.Errorf("unknown emulation for definition: %s", d.query.Emulate)
 	}
 	if err != nil {
 		return err
@@ -138,7 +137,7 @@ func (d *definition) Run(ctx context.Context, args ...string) error {
 	case *guru.Definition:
 		fmt.Printf("%s: defined here as %s", d.ObjPos, d.Desc)
 	default:
-		return errors.Errorf("no printer for type %T", result)
+		return fmt.Errorf("no printer for type %T", result)
 	}
 	return nil
 }

--- a/internal/lsp/cmd/format.go
+++ b/internal/lsp/cmd/format.go
@@ -73,11 +73,11 @@ func (c *format) Run(ctx context.Context, args ...string) error {
 		}
 		edits, err := conn.Formatting(ctx, &p)
 		if err != nil {
-			return fmt.Errorf("%v: %v", spn, err)
+			return fmt.Errorf("%v: %w", spn, err)
 		}
 		sedits, err := source.FromProtocolEdits(file.mapper, edits)
 		if err != nil {
-			return fmt.Errorf("%v: %v", spn, err)
+			return fmt.Errorf("%v: %w", spn, err)
 		}
 		formatted := diff.ApplyEdits(string(file.mapper.Content), sedits)
 		printIt := true

--- a/internal/lsp/cmd/format.go
+++ b/internal/lsp/cmd/format.go
@@ -14,7 +14,6 @@ import (
 	"golang.org/x/tools/internal/lsp/protocol"
 	"golang.org/x/tools/internal/lsp/source"
 	"golang.org/x/tools/internal/span"
-	errors "golang.org/x/xerrors"
 )
 
 // format implements the format verb for gopls.
@@ -67,18 +66,18 @@ func (c *format) Run(ctx context.Context, args ...string) error {
 			return err
 		}
 		if loc.Range.Start != loc.Range.End {
-			return errors.Errorf("only full file formatting supported")
+			return fmt.Errorf("only full file formatting supported")
 		}
 		p := protocol.DocumentFormattingParams{
 			TextDocument: protocol.TextDocumentIdentifier{URI: loc.URI},
 		}
 		edits, err := conn.Formatting(ctx, &p)
 		if err != nil {
-			return errors.Errorf("%v: %v", spn, err)
+			return fmt.Errorf("%v: %v", spn, err)
 		}
 		sedits, err := source.FromProtocolEdits(file.mapper, edits)
 		if err != nil {
-			return errors.Errorf("%v: %v", spn, err)
+			return fmt.Errorf("%v: %v", spn, err)
 		}
 		formatted := diff.ApplyEdits(string(file.mapper.Content), sedits)
 		printIt := true

--- a/internal/lsp/cmd/imports.go
+++ b/internal/lsp/cmd/imports.go
@@ -65,7 +65,7 @@ func (t *imports) Run(ctx context.Context, args ...string) error {
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("%v: %v", from, err)
+		return fmt.Errorf("%v: %w", from, err)
 	}
 	var edits []protocol.TextEdit
 	for _, a := range actions {
@@ -80,7 +80,7 @@ func (t *imports) Run(ctx context.Context, args ...string) error {
 	}
 	sedits, err := source.FromProtocolEdits(file.mapper, edits)
 	if err != nil {
-		return fmt.Errorf("%v: %v", edits, err)
+		return fmt.Errorf("%v: %w", edits, err)
 	}
 	newContent := diff.ApplyEdits(string(file.mapper.Content), sedits)
 

--- a/internal/lsp/cmd/imports.go
+++ b/internal/lsp/cmd/imports.go
@@ -15,7 +15,6 @@ import (
 	"golang.org/x/tools/internal/lsp/source"
 	"golang.org/x/tools/internal/span"
 	"golang.org/x/tools/internal/tool"
-	errors "golang.org/x/xerrors"
 )
 
 // imports implements the import verb for gopls.
@@ -66,7 +65,7 @@ func (t *imports) Run(ctx context.Context, args ...string) error {
 		},
 	})
 	if err != nil {
-		return errors.Errorf("%v: %v", from, err)
+		return fmt.Errorf("%v: %v", from, err)
 	}
 	var edits []protocol.TextEdit
 	for _, a := range actions {
@@ -81,7 +80,7 @@ func (t *imports) Run(ctx context.Context, args ...string) error {
 	}
 	sedits, err := source.FromProtocolEdits(file.mapper, edits)
 	if err != nil {
-		return errors.Errorf("%v: %v", edits, err)
+		return fmt.Errorf("%v: %v", edits, err)
 	}
 	newContent := diff.ApplyEdits(string(file.mapper.Content), sedits)
 

--- a/internal/lsp/cmd/links.go
+++ b/internal/lsp/cmd/links.go
@@ -14,7 +14,6 @@ import (
 	"golang.org/x/tools/internal/lsp/protocol"
 	"golang.org/x/tools/internal/span"
 	"golang.org/x/tools/internal/tool"
-	errors "golang.org/x/xerrors"
 )
 
 // links implements the links verb for gopls.
@@ -63,7 +62,7 @@ func (l *links) Run(ctx context.Context, args ...string) error {
 		},
 	})
 	if err != nil {
-		return errors.Errorf("%v: %v", from, err)
+		return fmt.Errorf("%v: %v", from, err)
 	}
 	if l.JSON {
 		enc := json.NewEncoder(os.Stdout)

--- a/internal/lsp/cmd/links.go
+++ b/internal/lsp/cmd/links.go
@@ -62,7 +62,7 @@ func (l *links) Run(ctx context.Context, args ...string) error {
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("%v: %v", from, err)
+		return fmt.Errorf("%v: %w", from, err)
 	}
 	if l.JSON {
 		enc := json.NewEncoder(os.Stdout)

--- a/internal/lsp/cmd/rename.go
+++ b/internal/lsp/cmd/rename.go
@@ -18,7 +18,6 @@ import (
 	"golang.org/x/tools/internal/lsp/source"
 	"golang.org/x/tools/internal/span"
 	"golang.org/x/tools/internal/tool"
-	errors "golang.org/x/xerrors"
 )
 
 // rename implements the rename verb for gopls.
@@ -96,7 +95,7 @@ func (r *rename) Run(ctx context.Context, args ...string) error {
 		// convert LSP-style edits to []diff.TextEdit cuz Spans are handy
 		renameEdits, err := source.FromProtocolEdits(cmdFile.mapper, edits[uri])
 		if err != nil {
-			return errors.Errorf("%v: %v", edits, err)
+			return fmt.Errorf("%v: %v", edits, err)
 		}
 		newContent := diff.ApplyEdits(string(cmdFile.mapper.Content), renameEdits)
 
@@ -105,7 +104,7 @@ func (r *rename) Run(ctx context.Context, args ...string) error {
 			fmt.Fprintln(os.Stderr, filename)
 			if r.Preserve {
 				if err := os.Rename(filename, filename+".orig"); err != nil {
-					return errors.Errorf("%v: %v", edits, err)
+					return fmt.Errorf("%v: %v", edits, err)
 				}
 			}
 			ioutil.WriteFile(filename, []byte(newContent), 0644)

--- a/internal/lsp/cmd/rename.go
+++ b/internal/lsp/cmd/rename.go
@@ -95,7 +95,7 @@ func (r *rename) Run(ctx context.Context, args ...string) error {
 		// convert LSP-style edits to []diff.TextEdit cuz Spans are handy
 		renameEdits, err := source.FromProtocolEdits(cmdFile.mapper, edits[uri])
 		if err != nil {
-			return fmt.Errorf("%v: %v", edits, err)
+			return fmt.Errorf("%v: %w", edits, err)
 		}
 		newContent := diff.ApplyEdits(string(cmdFile.mapper.Content), renameEdits)
 
@@ -104,7 +104,7 @@ func (r *rename) Run(ctx context.Context, args ...string) error {
 			fmt.Fprintln(os.Stderr, filename)
 			if r.Preserve {
 				if err := os.Rename(filename, filename+".orig"); err != nil {
-					return fmt.Errorf("%v: %v", edits, err)
+					return fmt.Errorf("%v: %w", edits, err)
 				}
 			}
 			ioutil.WriteFile(filename, []byte(newContent), 0644)

--- a/internal/lsp/cmd/serve.go
+++ b/internal/lsp/cmd/serve.go
@@ -68,7 +68,7 @@ func (s *Serve) Run(ctx context.Context, args ...string) error {
 		}
 		f, err := os.Create(filename)
 		if err != nil {
-			return fmt.Errorf("Unable to create log file: %v", err)
+			return fmt.Errorf("Unable to create log file: %w", err)
 		}
 		defer f.Close()
 		log.SetOutput(io.MultiWriter(os.Stderr, f))

--- a/internal/lsp/cmd/serve.go
+++ b/internal/lsp/cmd/serve.go
@@ -24,7 +24,6 @@ import (
 	"golang.org/x/tools/internal/lsp/telemetry"
 	"golang.org/x/tools/internal/telemetry/trace"
 	"golang.org/x/tools/internal/tool"
-	errors "golang.org/x/xerrors"
 )
 
 // Serve is a struct that exposes the configurable parts of the LSP server as
@@ -69,7 +68,7 @@ func (s *Serve) Run(ctx context.Context, args ...string) error {
 		}
 		f, err := os.Create(filename)
 		if err != nil {
-			return errors.Errorf("Unable to create log file: %v", err)
+			return fmt.Errorf("Unable to create log file: %v", err)
 		}
 		defer f.Close()
 		log.SetOutput(io.MultiWriter(os.Stderr, f))

--- a/internal/lsp/cmd/suggested_fix.go
+++ b/internal/lsp/cmd/suggested_fix.go
@@ -83,7 +83,7 @@ func (s *suggestedfix) Run(ctx context.Context, args ...string) error {
 	}
 	actions, err := conn.CodeAction(ctx, &p)
 	if err != nil {
-		return fmt.Errorf("%v: %v", from, err)
+		return fmt.Errorf("%v: %w", from, err)
 	}
 	var edits []protocol.TextEdit
 	for _, a := range actions {
@@ -99,7 +99,7 @@ func (s *suggestedfix) Run(ctx context.Context, args ...string) error {
 
 	sedits, err := source.FromProtocolEdits(file.mapper, edits)
 	if err != nil {
-		return fmt.Errorf("%v: %v", edits, err)
+		return fmt.Errorf("%v: %w", edits, err)
 	}
 	newContent := diff.ApplyEdits(string(file.mapper.Content), sedits)
 

--- a/internal/lsp/cmd/suggested_fix.go
+++ b/internal/lsp/cmd/suggested_fix.go
@@ -16,7 +16,6 @@ import (
 	"golang.org/x/tools/internal/lsp/source"
 	"golang.org/x/tools/internal/span"
 	"golang.org/x/tools/internal/tool"
-	errors "golang.org/x/xerrors"
 )
 
 // suggestedfix implements the fix verb for gopls.
@@ -67,7 +66,7 @@ func (s *suggestedfix) Run(ctx context.Context, args ...string) error {
 	select {
 	case <-file.hasDiagnostics:
 	case <-time.After(30 * time.Second):
-		return errors.Errorf("timed out waiting for results from %v", file.uri)
+		return fmt.Errorf("timed out waiting for results from %v", file.uri)
 	}
 
 	file.diagnosticsMu.Lock()
@@ -84,7 +83,7 @@ func (s *suggestedfix) Run(ctx context.Context, args ...string) error {
 	}
 	actions, err := conn.CodeAction(ctx, &p)
 	if err != nil {
-		return errors.Errorf("%v: %v", from, err)
+		return fmt.Errorf("%v: %v", from, err)
 	}
 	var edits []protocol.TextEdit
 	for _, a := range actions {
@@ -100,7 +99,7 @@ func (s *suggestedfix) Run(ctx context.Context, args ...string) error {
 
 	sedits, err := source.FromProtocolEdits(file.mapper, edits)
 	if err != nil {
-		return errors.Errorf("%v: %v", edits, err)
+		return fmt.Errorf("%v: %v", edits, err)
 	}
 	newContent := diff.ApplyEdits(string(file.mapper.Content), sedits)
 

--- a/internal/lsp/code_action.go
+++ b/internal/lsp/code_action.go
@@ -16,7 +16,6 @@ import (
 	"golang.org/x/tools/internal/lsp/telemetry"
 	"golang.org/x/tools/internal/span"
 	"golang.org/x/tools/internal/telemetry/log"
-	errors "golang.org/x/xerrors"
 )
 
 func (s *Server) codeAction(ctx context.Context, params *protocol.CodeActionParams) ([]protocol.CodeAction, error) {
@@ -50,7 +49,7 @@ func (s *Server) codeAction(ctx context.Context, params *protocol.CodeActionPara
 		}
 	}
 	if len(wanted) == 0 {
-		return nil, errors.Errorf("no supported code action to execute for %s, wanted %v", uri, params.Context.Only)
+		return nil, fmt.Errorf("no supported code action to execute for %s, wanted %v", uri, params.Context.Only)
 	}
 
 	var codeActions []protocol.CodeAction

--- a/internal/lsp/command.go
+++ b/internal/lsp/command.go
@@ -2,18 +2,18 @@ package lsp
 
 import (
 	"context"
+	"fmt"
 
 	"golang.org/x/tools/internal/lsp/protocol"
 	"golang.org/x/tools/internal/lsp/source"
 	"golang.org/x/tools/internal/span"
-	errors "golang.org/x/xerrors"
 )
 
 func (s *Server) executeCommand(ctx context.Context, params *protocol.ExecuteCommandParams) (interface{}, error) {
 	switch params.Command {
 	case "tidy":
 		if len(params.Arguments) == 0 || len(params.Arguments) > 1 {
-			return nil, errors.Errorf("expected one file URI for call to `go mod tidy`, got %v", params.Arguments)
+			return nil, fmt.Errorf("expected one file URI for call to `go mod tidy`, got %v", params.Arguments)
 		}
 		// Confirm that this action is being taken on a go.mod file.
 		uri := span.NewURI(params.Arguments[0].(string))
@@ -27,7 +27,7 @@ func (s *Server) executeCommand(ctx context.Context, params *protocol.ExecuteCom
 		}
 		fh := view.Snapshot().Handle(ctx, f)
 		if fh.Identity().Kind != source.Mod {
-			return nil, errors.Errorf("%s is not a mod file", uri)
+			return nil, fmt.Errorf("%s is not a mod file", uri)
 		}
 		// Run go.mod tidy on the view.
 		if err := source.ModTidy(ctx, view); err != nil {

--- a/internal/lsp/diff/difftest/difftest_test.go
+++ b/internal/lsp/diff/difftest/difftest_test.go
@@ -68,7 +68,7 @@ func getDiffOutput(a, b string) (string, error) {
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		if _, ok := err.(*exec.ExitError); !ok {
-			return "", fmt.Errorf("failed to run diff -u %v %v: %v\n%v", fileA.Name(), fileB.Name(), err, string(out))
+			return "", fmt.Errorf("failed to run diff -u %v %v: %w\n%v", fileA.Name(), fileB.Name(), err, string(out))
 		}
 	}
 	diff := string(out)

--- a/internal/lsp/general.go
+++ b/internal/lsp/general.go
@@ -17,7 +17,6 @@ import (
 	"golang.org/x/tools/internal/lsp/source"
 	"golang.org/x/tools/internal/span"
 	"golang.org/x/tools/internal/telemetry/log"
-	errors "golang.org/x/xerrors"
 )
 
 func (s *Server) initialize(ctx context.Context, params *protocol.ParamInitialize) (*protocol.InitializeResult, error) {
@@ -48,7 +47,7 @@ func (s *Server) initialize(ctx context.Context, params *protocol.ParamInitializ
 		} else {
 			// No folders and no root--we are in single file mode.
 			// TODO: https://golang.org/issue/34160.
-			return nil, errors.Errorf("gopls does not yet support editing a single file. Please open a directory.")
+			return nil, fmt.Errorf("gopls does not yet support editing a single file. Please open a directory.")
 		}
 	}
 

--- a/internal/lsp/link.go
+++ b/internal/lsp/link.go
@@ -88,7 +88,7 @@ func findLinksInString(src string, pos token.Pos, view source.View, mapper *prot
 	var links []protocol.DocumentLink
 	re, err := getURLRegexp()
 	if err != nil {
-		return nil, fmt.Errorf("cannot create regexp for links: %s", err.Error())
+		return nil, fmt.Errorf("cannot create regexp for links: %w", err)
 	}
 	indexUrl := re.FindAllIndex([]byte(src), -1)
 	for _, urlIndex := range indexUrl {
@@ -97,8 +97,8 @@ func findLinksInString(src string, pos token.Pos, view source.View, mapper *prot
 		end := urlIndex[1]
 		startPos := token.Pos(int(pos) + start)
 		endPos := token.Pos(int(pos) + end)
-	        target = src[start:end]
-	        l, err := toProtocolLink(view, mapper, target, startPos, endPos)
+		target = src[start:end]
+		l, err := toProtocolLink(view, mapper, target, startPos, endPos)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/lsp/link.go
+++ b/internal/lsp/link.go
@@ -18,7 +18,6 @@ import (
 	"golang.org/x/tools/internal/span"
 	"golang.org/x/tools/internal/telemetry/log"
 	"golang.org/x/tools/internal/telemetry/tag"
-	errors "golang.org/x/xerrors"
 )
 
 func (s *Server) documentLink(ctx context.Context, params *protocol.DocumentLinkParams) ([]protocol.DocumentLink, error) {
@@ -89,7 +88,7 @@ func findLinksInString(src string, pos token.Pos, view source.View, mapper *prot
 	var links []protocol.DocumentLink
 	re, err := getURLRegexp()
 	if err != nil {
-		return nil, errors.Errorf("cannot create regexp for links: %s", err.Error())
+		return nil, fmt.Errorf("cannot create regexp for links: %s", err.Error())
 	}
 	indexUrl := re.FindAllIndex([]byte(src), -1)
 	for _, urlIndex := range indexUrl {

--- a/internal/lsp/protocol/span.go
+++ b/internal/lsp/protocol/span.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 
 	"golang.org/x/tools/internal/span"
-	errors "golang.org/x/xerrors"
 )
 
 type ColumnMapper struct {
@@ -33,7 +32,7 @@ func (m *ColumnMapper) Location(s span.Span) (Location, error) {
 
 func (m *ColumnMapper) Range(s span.Span) (Range, error) {
 	if span.CompareURI(m.URI, s.URI()) != 0 {
-		return Range{}, errors.Errorf("column mapper is for file %q instead of %q", m.URI, s.URI())
+		return Range{}, fmt.Errorf("column mapper is for file %q instead of %q", m.URI, s.URI())
 	}
 	s, err := s.WithAll(m.Converter)
 	if err != nil {

--- a/internal/lsp/source/completion.go
+++ b/internal/lsp/source/completion.go
@@ -21,7 +21,6 @@ import (
 	"golang.org/x/tools/internal/lsp/protocol"
 	"golang.org/x/tools/internal/lsp/snippet"
 	"golang.org/x/tools/internal/telemetry/trace"
-	errors "golang.org/x/xerrors"
 )
 
 type CompletionItem struct {
@@ -415,7 +414,7 @@ func Completion(ctx context.Context, snapshot Snapshot, f File, pos protocol.Pos
 	// Find the path to the position before pos.
 	path, _ := astutil.PathEnclosingInterval(file, rng.Start-1, rng.Start-1)
 	if path == nil {
-		return nil, nil, errors.Errorf("cannot find node enclosing position")
+		return nil, nil, fmt.Errorf("cannot find node enclosing position")
 	}
 	// Skip completion inside comments.
 	for _, g := range file.Comments {

--- a/internal/lsp/source/completion.go
+++ b/internal/lsp/source/completion.go
@@ -396,7 +396,7 @@ func Completion(ctx context.Context, snapshot Snapshot, f File, pos protocol.Pos
 
 	pkg, pgh, err := getParsedFile(ctx, snapshot, f, NarrowestCheckPackageHandle)
 	if err != nil {
-		return nil, nil, fmt.Errorf("getting file for Completion: %v", err)
+		return nil, nil, fmt.Errorf("getting file for Completion: %w", err)
 	}
 	file, m, _, err := pgh.Cached()
 	if err != nil {

--- a/internal/lsp/source/completion_format.go
+++ b/internal/lsp/source/completion_format.go
@@ -20,7 +20,6 @@ import (
 	"golang.org/x/tools/internal/span"
 	"golang.org/x/tools/internal/telemetry/log"
 	"golang.org/x/tools/internal/telemetry/tag"
-	errors "golang.org/x/xerrors"
 )
 
 // formatCompletion creates a completion item for a given candidate.
@@ -194,7 +193,7 @@ func (c *completer) importEdits(imp *importInfo) ([]protocol.TextEdit, error) {
 		}
 	}
 	if ph == nil {
-		return nil, errors.Errorf("building import completion for %v: no ParseGoHandle for %s", imp.importPath, c.filename)
+		return nil, fmt.Errorf("building import completion for %v: no ParseGoHandle for %s", imp.importPath, c.filename)
 	}
 
 	return computeOneImportFixEdits(c.ctx, c.snapshot.View(), ph, &imports.ImportFix{

--- a/internal/lsp/source/completion_keywords.go
+++ b/internal/lsp/source/completion_keywords.go
@@ -1,11 +1,10 @@
 package source
 
 import (
+	"fmt"
 	"go/ast"
 
 	"golang.org/x/tools/internal/lsp/protocol"
-
-	errors "golang.org/x/xerrors"
 )
 
 const (
@@ -40,7 +39,7 @@ const (
 func (c *completer) keyword() error {
 	if _, ok := c.path[0].(*ast.Ident); !ok {
 		// TODO(golang/go#34009): Support keyword completion in any context
-		return errors.Errorf("keywords are currently only recommended for identifiers")
+		return fmt.Errorf("keywords are currently only recommended for identifiers")
 	}
 	// Track which keywords we've already determined are in a valid scope
 	// Use score to order keywords by how close we are to where they are useful

--- a/internal/lsp/source/diagnostics.go
+++ b/internal/lsp/source/diagnostics.go
@@ -14,7 +14,6 @@ import (
 	"golang.org/x/tools/internal/span"
 	"golang.org/x/tools/internal/telemetry/log"
 	"golang.org/x/tools/internal/telemetry/trace"
-	errors "golang.org/x/xerrors"
 )
 
 type Diagnostic struct {
@@ -208,7 +207,7 @@ func addReports(ctx context.Context, reports map[FileIdentity][]Diagnostic, snap
 		return nil
 	}
 	if _, ok := reports[fileID]; !ok {
-		return errors.Errorf("diagnostics for unexpected file %s", fileID.URI)
+		return fmt.Errorf("diagnostics for unexpected file %s", fileID.URI)
 	}
 	for _, diag := range diagnostics {
 		if diag == nil {

--- a/internal/lsp/source/errors.go
+++ b/internal/lsp/source/errors.go
@@ -92,7 +92,7 @@ func invokeGo(ctx context.Context, dir string, env []string, args ...string) (*b
 		if _, ok := err.(*exec.ExitError); !ok {
 			// Catastrophic error:
 			// - context cancellation
-			return nil, fmt.Errorf("couldn't exec 'go %v': %s %T", args, err, err)
+			return nil, fmt.Errorf("couldn't exec 'go %v': %w %T", args, err, err)
 		}
 	}
 	return stdout, nil

--- a/internal/lsp/source/format.go
+++ b/internal/lsp/source/format.go
@@ -20,7 +20,6 @@ import (
 	"golang.org/x/tools/internal/lsp/protocol"
 	"golang.org/x/tools/internal/span"
 	"golang.org/x/tools/internal/telemetry/trace"
-	errors "golang.org/x/xerrors"
 )
 
 // Format formats a file with a given range.
@@ -36,7 +35,7 @@ func Format(ctx context.Context, snapshot Snapshot, f File) ([]protocol.TextEdit
 	// Be extra careful that the file's ParseMode is correct,
 	// otherwise we might replace the user's code with a trimmed AST.
 	if pgh.Mode() != ParseFull {
-		return nil, errors.Errorf("%s was parsed in the incorrect mode", pgh.File().Identity().URI)
+		return nil, fmt.Errorf("%s was parsed in the incorrect mode", pgh.File().Identity().URI)
 	}
 	file, m, _, err := pgh.Parse(ctx)
 	if err != nil {
@@ -93,10 +92,10 @@ func AllImportsFixes(ctx context.Context, snapshot Snapshot, f File) (allFixEdit
 
 	pkg, pgh, err := getParsedFile(ctx, snapshot, f, NarrowestCheckPackageHandle)
 	if err != nil {
-		return nil, nil, errors.Errorf("getting file for AllImportsFixes: %v", err)
+		return nil, nil, fmt.Errorf("getting file for AllImportsFixes: %v", err)
 	}
 	if hasListErrors(pkg) {
-		return nil, nil, errors.Errorf("%s has list errors, not running goimports", f.URI())
+		return nil, nil, fmt.Errorf("%s has list errors, not running goimports", f.URI())
 	}
 	options := &imports.Options{
 		// Defaults.
@@ -112,7 +111,7 @@ func AllImportsFixes(ctx context.Context, snapshot Snapshot, f File) (allFixEdit
 		return err
 	}, options)
 	if err != nil {
-		return nil, nil, errors.Errorf("computing fix edits: %v", err)
+		return nil, nil, fmt.Errorf("computing fix edits: %v", err)
 	}
 
 	return allFixEdits, editsPerFix, nil
@@ -224,7 +223,7 @@ func computeFixEdits(view View, ph ParseGoHandle, options *imports.Options, orig
 		var ok bool
 		right, ok = trimToFirstNonImport(fixedFset, fixedAST, fixedData, err)
 		if !ok {
-			return nil, errors.Errorf("error %v detected in the import block", err)
+			return nil, fmt.Errorf("error %v detected in the import block", err)
 		}
 		// We're now working with a prefix of the original file, so we can
 		// use the original converter, and there is no offset on the edits.

--- a/internal/lsp/source/format.go
+++ b/internal/lsp/source/format.go
@@ -29,7 +29,7 @@ func Format(ctx context.Context, snapshot Snapshot, f File) ([]protocol.TextEdit
 
 	pkg, pgh, err := getParsedFile(ctx, snapshot, f, NarrowestCheckPackageHandle)
 	if err != nil {
-		return nil, fmt.Errorf("getting file for Format: %v", err)
+		return nil, fmt.Errorf("getting file for Format: %w", err)
 	}
 
 	// Be extra careful that the file's ParseMode is correct,
@@ -92,7 +92,7 @@ func AllImportsFixes(ctx context.Context, snapshot Snapshot, f File) (allFixEdit
 
 	pkg, pgh, err := getParsedFile(ctx, snapshot, f, NarrowestCheckPackageHandle)
 	if err != nil {
-		return nil, nil, fmt.Errorf("getting file for AllImportsFixes: %v", err)
+		return nil, nil, fmt.Errorf("getting file for AllImportsFixes: %w", err)
 	}
 	if hasListErrors(pkg) {
 		return nil, nil, fmt.Errorf("%s has list errors, not running goimports", f.URI())
@@ -111,7 +111,7 @@ func AllImportsFixes(ctx context.Context, snapshot Snapshot, f File) (allFixEdit
 		return err
 	}, options)
 	if err != nil {
-		return nil, nil, fmt.Errorf("computing fix edits: %v", err)
+		return nil, nil, fmt.Errorf("computing fix edits: %w", err)
 	}
 
 	return allFixEdits, editsPerFix, nil
@@ -223,7 +223,7 @@ func computeFixEdits(view View, ph ParseGoHandle, options *imports.Options, orig
 		var ok bool
 		right, ok = trimToFirstNonImport(fixedFset, fixedAST, fixedData, err)
 		if !ok {
-			return nil, fmt.Errorf("error %v detected in the import block", err)
+			return nil, fmt.Errorf("error detected in the import block: %w", err)
 		}
 		// We're now working with a prefix of the original file, so we can
 		// use the original converter, and there is no offset on the edits.

--- a/internal/lsp/source/highlight.go
+++ b/internal/lsp/source/highlight.go
@@ -22,7 +22,7 @@ func Highlight(ctx context.Context, snapshot Snapshot, f File, pos protocol.Posi
 
 	pkg, pgh, err := getParsedFile(ctx, snapshot, f, WidestCheckPackageHandle)
 	if err != nil {
-		return nil, fmt.Errorf("getting file for Highlight: %v", err)
+		return nil, fmt.Errorf("getting file for Highlight: %w", err)
 	}
 	file, m, _, err := pgh.Parse(ctx)
 	if err != nil {

--- a/internal/lsp/source/highlight.go
+++ b/internal/lsp/source/highlight.go
@@ -14,7 +14,6 @@ import (
 	"golang.org/x/tools/internal/lsp/protocol"
 	"golang.org/x/tools/internal/telemetry/log"
 	"golang.org/x/tools/internal/telemetry/trace"
-	errors "golang.org/x/xerrors"
 )
 
 func Highlight(ctx context.Context, snapshot Snapshot, f File, pos protocol.Position) ([]protocol.Range, error) {
@@ -39,7 +38,7 @@ func Highlight(ctx context.Context, snapshot Snapshot, f File, pos protocol.Posi
 	}
 	path, _ := astutil.PathEnclosingInterval(file, rng.Start, rng.Start)
 	if len(path) == 0 {
-		return nil, errors.Errorf("no enclosing position found for %v:%v", int(pos.Line), int(pos.Character))
+		return nil, fmt.Errorf("no enclosing position found for %v:%v", int(pos.Line), int(pos.Character))
 	}
 	switch path[0].(type) {
 	case *ast.ReturnStmt, *ast.FuncDecl, *ast.FuncType, *ast.BasicLit:
@@ -215,7 +214,7 @@ func highlightIdentifiers(ctx context.Context, snapshot Snapshot, m *protocol.Co
 	result := make(map[protocol.Range]bool)
 	id, ok := path[0].(*ast.Ident)
 	if !ok {
-		return nil, errors.Errorf("highlightIdentifiers called with an ast.Node of type %T", id)
+		return nil, fmt.Errorf("highlightIdentifiers called with an ast.Node of type %T", id)
 	}
 	// Check if ident is inside return or func decl.
 	if toAdd, err := highlightFuncControlFlow(ctx, snapshot, m, path); toAdd != nil && err == nil {

--- a/internal/lsp/source/hover.go
+++ b/internal/lsp/source/hover.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 
 	"golang.org/x/tools/internal/telemetry/trace"
-	errors "golang.org/x/xerrors"
 )
 
 type HoverInformation struct {
@@ -142,7 +141,7 @@ func formatGenDecl(node *ast.GenDecl, obj types.Object, typ types.Type) (*HoverI
 		}
 	}
 	if spec == nil {
-		return nil, errors.Errorf("no spec for node %v at position %v", node, obj.Pos())
+		return nil, fmt.Errorf("no spec for node %v at position %v", node, obj.Pos())
 	}
 	// If we have a field or method.
 	switch obj.(type) {
@@ -163,7 +162,7 @@ func formatGenDecl(node *ast.GenDecl, obj types.Object, typ types.Type) (*HoverI
 	case *ast.ImportSpec:
 		return &HoverInformation{source: spec, comment: spec.Doc}, nil
 	}
-	return nil, errors.Errorf("unable to format spec %v (%T)", spec, spec)
+	return nil, fmt.Errorf("unable to format spec %v (%T)", spec, spec)
 }
 
 func formatVar(node ast.Spec, obj types.Object, decl *ast.GenDecl) *HoverInformation {

--- a/internal/lsp/source/identifier.go
+++ b/internal/lsp/source/identifier.go
@@ -64,7 +64,7 @@ func Identifier(ctx context.Context, snapshot Snapshot, f File, pos protocol.Pos
 
 	pkg, pgh, err := getParsedFile(ctx, snapshot, f, WidestCheckPackageHandle)
 	if err != nil {
-		return nil, fmt.Errorf("getting file for Identifier: %v", err)
+		return nil, fmt.Errorf("getting file for Identifier: %w", err)
 	}
 	file, m, _, err := pgh.Cached()
 	if err != nil {
@@ -281,7 +281,7 @@ func importSpec(s Snapshot, pkg Package, file *ast.File, pos token.Pos) (*Identi
 	}
 	importPath, err := strconv.Unquote(imp.Path.Value)
 	if err != nil {
-		return nil, fmt.Errorf("import path not quoted: %s (%v)", imp.Path.Value, err)
+		return nil, fmt.Errorf("import path (%s) not quoted: %w", imp.Path.Value, err)
 	}
 	uri := span.FileURI(s.View().Session().Cache().FileSet().Position(pos).Filename)
 	var ph ParseGoHandle

--- a/internal/lsp/source/options.go
+++ b/internal/lsp/source/options.go
@@ -37,7 +37,6 @@ import (
 	"golang.org/x/tools/internal/lsp/diff/myers"
 	"golang.org/x/tools/internal/lsp/protocol"
 	"golang.org/x/tools/internal/telemetry/tag"
-	errors "golang.org/x/xerrors"
 )
 
 var (
@@ -180,7 +179,7 @@ func SetOptions(options *Options, opts interface{}) OptionResults {
 	default:
 		results = append(results, OptionResult{
 			Value: opts,
-			Error: errors.Errorf("Invalid options type %T", opts),
+			Error: fmt.Errorf("Invalid options type %T", opts),
 		})
 	}
 	return results
@@ -333,7 +332,7 @@ func (o *Options) set(name string, value interface{}) OptionResult {
 }
 
 func (r *OptionResult) errorf(msg string, values ...interface{}) {
-	r.Error = errors.Errorf(msg, values...)
+	r.Error = fmt.Errorf(msg, values...)
 }
 
 func (r *OptionResult) asBool() (bool, bool) {

--- a/internal/lsp/source/options.go
+++ b/internal/lsp/source/options.go
@@ -266,7 +266,7 @@ func (o *Options) set(name string, value interface{}) OptionResult {
 		case "Structured":
 			o.HoverKind = Structured
 		default:
-			result.errorf("Unsupported hover kind", tag.Of("HoverKind", hoverKind))
+			result.errorf("Unsupported hover kind: %v", tag.Of("HoverKind", hoverKind))
 		}
 
 	case "linkTarget":

--- a/internal/lsp/source/references.go
+++ b/internal/lsp/source/references.go
@@ -6,6 +6,7 @@ package source
 
 import (
 	"context"
+	"fmt"
 	"go/ast"
 	"go/types"
 
@@ -13,7 +14,6 @@ import (
 	"golang.org/x/tools/internal/lsp/telemetry"
 	"golang.org/x/tools/internal/telemetry/log"
 	"golang.org/x/tools/internal/telemetry/trace"
-	errors "golang.org/x/xerrors"
 )
 
 // ReferenceInfo holds information about reference to an identifier in Go source.
@@ -34,11 +34,11 @@ func (i *IdentifierInfo) References(ctx context.Context) ([]*ReferenceInfo, erro
 
 	// If the object declaration is nil, assume it is an import spec and do not look for references.
 	if i.Declaration.obj == nil {
-		return nil, errors.Errorf("no references for an import spec")
+		return nil, fmt.Errorf("no references for an import spec")
 	}
 	info := i.pkg.GetTypesInfo()
 	if info == nil {
-		return nil, errors.Errorf("package %s has no types info", i.pkg.PkgPath())
+		return nil, fmt.Errorf("package %s has no types info", i.pkg.PkgPath())
 	}
 	var searchpkgs []Package
 	if i.Declaration.obj.Exported() {

--- a/internal/lsp/source/rename.go
+++ b/internal/lsp/source/rename.go
@@ -7,6 +7,7 @@ package source
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"go/ast"
 	"go/format"
@@ -143,7 +144,7 @@ func (i *IdentifierInfo) Rename(ctx context.Context, newName string) (map[span.U
 		}
 	}
 	if r.hadConflicts {
-		return nil, fmt.Errorf(r.errors)
+		return nil, errors.New(r.errors)
 	}
 
 	changes, err := r.update()
@@ -185,7 +186,7 @@ func (i *IdentifierInfo) Rename(ctx context.Context, newName string) (map[span.U
 func (i *IdentifierInfo) getPkgName(ctx context.Context) (*IdentifierInfo, error) {
 	ph, err := i.pkg.File(i.URI())
 	if err != nil {
-		return nil, fmt.Errorf("finding file for identifier %v: %v", i.Name, err)
+		return nil, fmt.Errorf("finding file for identifier %v: %w", i.Name, err)
 	}
 	file, _, _, err := ph.Cached()
 	if err != nil {

--- a/internal/lsp/source/signature_help.go
+++ b/internal/lsp/source/signature_help.go
@@ -33,7 +33,7 @@ func SignatureHelp(ctx context.Context, snapshot Snapshot, f File, pos protocol.
 
 	pkg, pgh, err := getParsedFile(ctx, snapshot, f, NarrowestCheckPackageHandle)
 	if err != nil {
-		return nil, fmt.Errorf("getting file for SignatureHelp: %v", err)
+		return nil, fmt.Errorf("getting file for SignatureHelp: %w", err)
 	}
 	file, m, _, err := pgh.Cached()
 	if err != nil {

--- a/internal/lsp/source/source_test.go
+++ b/internal/lsp/source/source_test.go
@@ -7,6 +7,7 @@ package source_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -24,7 +25,6 @@ import (
 	"golang.org/x/tools/internal/lsp/tests"
 	"golang.org/x/tools/internal/span"
 	"golang.org/x/tools/internal/testenv"
-	errors "golang.org/x/xerrors"
 )
 
 func TestMain(m *testing.M) {

--- a/internal/lsp/source/symbols.go
+++ b/internal/lsp/source/symbols.go
@@ -20,7 +20,7 @@ func DocumentSymbols(ctx context.Context, snapshot Snapshot, f File) ([]protocol
 
 	pkg, pgh, err := getParsedFile(ctx, snapshot, f, NarrowestCheckPackageHandle)
 	if err != nil {
-		return nil, fmt.Errorf("getting file for DocumentSymbols: %v", err)
+		return nil, fmt.Errorf("getting file for DocumentSymbols: %w", err)
 	}
 	file, m, _, err := pgh.Cached()
 	if err != nil {

--- a/internal/lsp/source/util.go
+++ b/internal/lsp/source/util.go
@@ -18,7 +18,6 @@ import (
 
 	"golang.org/x/tools/internal/lsp/protocol"
 	"golang.org/x/tools/internal/span"
-	errors "golang.org/x/xerrors"
 )
 
 type mappedRange struct {
@@ -92,7 +91,7 @@ func getParsedFile(ctx context.Context, snapshot Snapshot, f File, selectPackage
 // as the test will have more files than the non-test package.
 func NarrowestCheckPackageHandle(handles []PackageHandle) (PackageHandle, error) {
 	if len(handles) < 1 {
-		return nil, errors.Errorf("no CheckPackageHandles")
+		return nil, fmt.Errorf("no CheckPackageHandles")
 	}
 	result := handles[0]
 	for _, handle := range handles[1:] {
@@ -101,7 +100,7 @@ func NarrowestCheckPackageHandle(handles []PackageHandle) (PackageHandle, error)
 		}
 	}
 	if result == nil {
-		return nil, errors.Errorf("nil CheckPackageHandles have been returned")
+		return nil, fmt.Errorf("nil CheckPackageHandles have been returned")
 	}
 	return result, nil
 }
@@ -112,7 +111,7 @@ func NarrowestCheckPackageHandle(handles []PackageHandle) (PackageHandle, error)
 // for as many files as possible.
 func WidestCheckPackageHandle(handles []PackageHandle) (PackageHandle, error) {
 	if len(handles) < 1 {
-		return nil, errors.Errorf("no CheckPackageHandles")
+		return nil, fmt.Errorf("no CheckPackageHandles")
 	}
 	result := handles[0]
 	for _, handle := range handles[1:] {
@@ -121,7 +120,7 @@ func WidestCheckPackageHandle(handles []PackageHandle) (PackageHandle, error) {
 		}
 	}
 	if result == nil {
-		return nil, errors.Errorf("nil CheckPackageHandles have been returned")
+		return nil, fmt.Errorf("nil CheckPackageHandles have been returned")
 	}
 	return result, nil
 }
@@ -199,10 +198,10 @@ func posToMappedRange(v View, pkg Package, pos, end token.Pos) (mappedRange, err
 
 func posToRange(view View, m *protocol.ColumnMapper, pos, end token.Pos) (mappedRange, error) {
 	if !pos.IsValid() {
-		return mappedRange{}, errors.Errorf("invalid position for %v", pos)
+		return mappedRange{}, fmt.Errorf("invalid position for %v", pos)
 	}
 	if !end.IsValid() {
-		return mappedRange{}, errors.Errorf("invalid position for %v", end)
+		return mappedRange{}, fmt.Errorf("invalid position for %v", end)
 	}
 	return newMappedRange(view.Session().Cache().FileSet(), m, pos, end), nil
 }
@@ -467,11 +466,11 @@ func formatFieldType(s Snapshot, srcpkg Package, obj types.Object, qf types.Qual
 		return "", err
 	}
 	if i := ident.ident; i == nil || i.Obj == nil || i.Obj.Decl == nil {
-		return "", errors.Errorf("no object for ident %v", i.Name)
+		return "", fmt.Errorf("no object for ident %v", i.Name)
 	}
 	f, ok := ident.ident.Obj.Decl.(*ast.Field)
 	if !ok {
-		return "", errors.Errorf("ident %s is not a field type", ident.Name)
+		return "", fmt.Errorf("ident %s is not a field type", ident.Name)
 	}
 	var typeNameBuf bytes.Buffer
 	fset := s.View().Session().Cache().FileSet()

--- a/internal/lsp/text_synchronization.go
+++ b/internal/lsp/text_synchronization.go
@@ -14,7 +14,6 @@ import (
 	"golang.org/x/tools/internal/lsp/source"
 	"golang.org/x/tools/internal/lsp/telemetry"
 	"golang.org/x/tools/internal/span"
-	errors "golang.org/x/xerrors"
 )
 
 func (s *Server) didOpen(ctx context.Context, params *protocol.DidOpenTextDocumentParams) error {
@@ -77,7 +76,7 @@ func (s *Server) didModifyFile(ctx context.Context, c source.FileModification) e
 	case source.Open:
 		kind := source.DetectLanguage(c.LanguageID, c.URI.Filename())
 		if kind == source.UnknownKind {
-			return errors.Errorf("didModifyFile: unknown file kind for %s", c.URI)
+			return fmt.Errorf("didModifyFile: unknown file kind for %s", c.URI)
 		}
 		if err := s.session.DidOpen(ctx, c.URI, kind, c.Version, c.Text); err != nil {
 			return err
@@ -129,7 +128,7 @@ func (s *Server) changedText(ctx context.Context, uri span.URI, changes []protoc
 
 	// We only accept an incremental change if that's what the server expects.
 	if s.session.Options().TextDocumentSyncKind == protocol.Full {
-		return nil, errors.Errorf("expected a full content change, received incremental changes for %s", uri)
+		return nil, fmt.Errorf("expected a full content change, received incremental changes for %s", uri)
 	}
 
 	return s.applyIncrementalChanges(ctx, uri, changes)

--- a/internal/lsp/workspace.go
+++ b/internal/lsp/workspace.go
@@ -6,11 +6,11 @@ package lsp
 
 import (
 	"context"
+	"fmt"
 
 	"golang.org/x/tools/internal/lsp/protocol"
 	"golang.org/x/tools/internal/lsp/source"
 	"golang.org/x/tools/internal/span"
-	errors "golang.org/x/xerrors"
 )
 
 func (s *Server) changeFolders(ctx context.Context, event protocol.WorkspaceFoldersChangeEvent) error {
@@ -19,7 +19,7 @@ func (s *Server) changeFolders(ctx context.Context, event protocol.WorkspaceFold
 		if view != nil {
 			view.Shutdown(ctx)
 		} else {
-			return errors.Errorf("view %s for %v not found", folder.Name, folder.URI)
+			return fmt.Errorf("view %s for %v not found", folder.Name, folder.URI)
 		}
 	}
 	s.addFolders(ctx, event.Added)
@@ -31,7 +31,7 @@ func (s *Server) addView(ctx context.Context, name string, uri span.URI) (source
 	state := s.state
 	s.stateMu.Unlock()
 	if state < serverInitialized {
-		return nil, nil, errors.Errorf("addView called before server initialized")
+		return nil, nil, fmt.Errorf("addView called before server initialized")
 	}
 
 	options := s.session.Options()


### PR DESCRIPTION
A few months ago I migrated internal errors to xerrors, since it is part of go 1.13 now, I thought it might make sense to use the latest feature directly from the std lib and use also correct error wrapping.