### PR TITLE
internal/lsp: make golint happy

### DIFF
--- a/internal/lsp/fuzzy/matcher.go
+++ b/internal/lsp/fuzzy/matcher.go
@@ -227,7 +227,7 @@ func (m *Matcher) computeScore(candidate string, candidateLower []byte) int {
 		var skipPenalty int
 		if i == 1 || (i-1) == lastSegStart {
 			// Skipping the start of first or last segment.
-			skipPenalty += 1
+			skipPenalty++
 		}
 
 		for j := 0; j <= pattLen; j++ {


### PR DESCRIPTION
This PR fixes internal/lsp/fuzzy/matcher.go:230:4: should replace skipPenalty += 1 with skipPenalty++ . 