### PR TITLE
cover: error on negative numbers in profiles

### DIFF
--- a/cover/profile.go
+++ b/cover/profile.go
@@ -168,6 +168,9 @@ func seekBack(l string, sep byte, end int, what string) (value int, nextSep int,
 			if err != nil {
 				return 0, 0, fmt.Errorf("couldn't parse %q: %v", what, err)
 			}
+			if i < 0 {
+				return 0, 0, fmt.Errorf("negative values are not allowed for %s, found %d", what, i)
+			}
 			return i, start, nil
 		}
 	}

--- a/cover/profile_test.go
+++ b/cover/profile_test.go
@@ -198,6 +198,12 @@ some/fancy/path:42.69,44.16 2`,
 :42.69,44.16 2 3`,
 			expectErr: true,
 		},
+		{
+			name: "a negative count is an error",
+			input: `mode: count
+some/fancy/path:42.69,44.16 2 -1`,
+			expectErr: true,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
CL 179377 introduced an optimized parser for coverage profiles.
The parser replaces the following regex:
^(.+):([0-9]+)\.([0-9]+),([0-9]+)\.([0-9]+) ([0-9]+) ([0-9]+)$

With this regex, negative numbers in the coverage profiles resulted
in parsing errors. With the new parser in place, this is no longer
the case. This commit restores the old behavior.