### PR TITLE
go/ssa/interp: fix goroutines and channels leaks

### DIFF
--- a/go/ssa/interp/interp.go
+++ b/go/ssa/interp/interp.go
@@ -32,8 +32,6 @@
 // makes no attempt to distinguish target panics from interpreter
 // crashes.
 //
-// * map iteration is asymptotically inefficient.
-//
 // * the sizes of the int, uint and uintptr types in the target
 // program are assumed to be the same as those of the interpreter
 // itself.

--- a/go/ssa/interp/value.go
+++ b/go/ssa/interp/value.go
@@ -510,14 +510,16 @@ type hashmapIter struct {
 }
 
 func (it *hashmapIter) next() tuple {
-	if !it.ok {
-		return []value{false, nil, nil}
-	}
-	if it.cur == nil {
+	for {
+		if it.cur != nil {
+			k, v := it.cur.key, it.cur.value
+			it.cur = it.cur.next
+			return []value{true, k, v}
+		}
 		it.ok = it.iter.Next()
+		if !it.ok {
+			return []value{false, nil, nil}
+		}
 		it.cur = it.iter.Value().Interface().(*entry)
 	}
-	k, v := it.cur.key, it.cur.value
-	it.cur = it.cur.next
-	return []value{true, k, v}
 }


### PR DESCRIPTION
rangeIter leaks goroutines and channels
on each incomplete map iteration.
So remove goroutines and channels iterators
and use reflect.(Value).MapRange() iteration instead.

Resolves TODO left by @adonovan