### PR TITLE
go/ssa: replace DefaultType with go/types.Default

### DIFF
--- a/go/ssa/builder.go
+++ b/go/ssa/builder.go
@@ -635,7 +635,7 @@ func (b *builder) expr0(fn *Function, e ast.Expr, tv types.TypeAndValue) Value {
 		case token.EQL, token.NEQ, token.GTR, token.LSS, token.LEQ, token.GEQ:
 			cmp := emitCompare(fn, e.Op, b.expr(fn, e.X), b.expr(fn, e.Y), e.OpPos)
 			// The type of x==y may be UntypedBool.
-			return emitConv(fn, cmp, DefaultType(tv.Type))
+			return emitConv(fn, cmp, types.Default(tv.Type))
 		default:
 			panic("illegal op in BinaryExpr: " + e.Op.String())
 		}

--- a/go/ssa/emit.go
+++ b/go/ssa/emit.go
@@ -204,7 +204,7 @@ func emitConv(f *Function, val Value, typ types.Type) Value {
 
 		// Convert (non-nil) "untyped" literals to their default type.
 		if t, ok := ut_src.(*types.Basic); ok && t.Info()&types.IsUntyped != 0 {
-			val = emitConv(f, val, DefaultType(ut_src))
+			val = emitConv(f, val, types.Default(ut_src))
 		}
 
 		f.Pkg.Prog.needMethodsOf(val.Type())

--- a/go/ssa/interp/ops.go
+++ b/go/ssa/interp/ops.go
@@ -149,7 +149,7 @@ func zero(t types.Type) value {
 			// this is unreachable.  Currently some
 			// constants have 'untyped' types when they
 			// should be defaulted by the typechecker.
-			t = ssa.DefaultType(t).(*types.Basic)
+			t = types.Default(t).(*types.Basic)
 		}
 		switch t.Kind() {
 		case types.Bool:

--- a/go/ssa/util.go
+++ b/go/ssa/util.go
@@ -52,36 +52,6 @@ func recvType(obj *types.Func) types.Type {
 	return obj.Type().(*types.Signature).Recv().Type()
 }
 
-// DefaultType returns the default "typed" type for an "untyped" type;
-// it returns the incoming type for all other types.  The default type
-// for untyped nil is untyped nil.
-//
-// Exported to ssa/interp.
-//
-// TODO(adonovan): use go/types.DefaultType after 1.8.
-//
-func DefaultType(typ types.Type) types.Type {
-	if t, ok := typ.(*types.Basic); ok {
-		k := t.Kind()
-		switch k {
-		case types.UntypedBool:
-			k = types.Bool
-		case types.UntypedInt:
-			k = types.Int
-		case types.UntypedRune:
-			k = types.Rune
-		case types.UntypedFloat:
-			k = types.Float64
-		case types.UntypedComplex:
-			k = types.Complex128
-		case types.UntypedString:
-			k = types.String
-		}
-		typ = types.Typ[k]
-	}
-	return typ
-}
-
 // logStack prints the formatted "start" message to stderr and
 // returns a closure that prints the corresponding "end" message.
 // Call using 'defer logStack(...)()' to show builder stack on panic.


### PR DESCRIPTION
Remove duplicate DefaultType and use go/types.Default instead.
DefaultTypes was moved to std repo in golang.org/cl/8530
and exposed in golang.org/cl/30715 .

The use of types.Default improves the package 
by resolving UntypedRune to proper 'rune' named type instead of int32.

Removes TODO left by adonovan.