### PR TITLE
internal/lsp: report use of disallowed internal packages

### DIFF
--- a/internal/lsp/cache/check.go
+++ b/internal/lsp/cache/check.go
@@ -371,6 +371,9 @@ func typeCheck(ctx context.Context, fset *token.FileSet, m *metadata, mode sourc
 			if err != nil {
 				return nil, err
 			}
+			if !depPkg.IsValidImportFor(string(pkg.pkgPath)) {
+				return nil, errors.Errorf("invalid use of internal package %s", pkgPath)
+			}
 			pkg.imports[depPkg.pkgPath] = depPkg
 			return depPkg.types, nil
 		}),

--- a/internal/lsp/cache/check.go
+++ b/internal/lsp/cache/check.go
@@ -54,7 +54,7 @@ func (ph *packageHandle) packageKey() packageKey {
 	}
 }
 
-func (ph *packageHandle) IsValidImportFor(parentPkgPath string) bool {
+func (ph *packageHandle) isValidImportFor(parentPkgPath string) bool {
 	importPath := string(ph.m.pkgPath)
 
 	pkgRootIndex := strings.Index(importPath, "/internal")
@@ -380,7 +380,7 @@ func typeCheck(ctx context.Context, fset *token.FileSet, m *metadata, mode sourc
 			if dep == nil {
 				return nil, errors.Errorf("no package for import %s", pkgPath)
 			}
-			if !dep.IsValidImportFor(pkg.PkgPath()) {
+			if !dep.isValidImportFor(pkg.PkgPath()) {
 				return nil, errors.Errorf("invalid use of internal package %s", pkgPath)
 			}
 			depPkg, err := dep.check(ctx)

--- a/internal/lsp/cache/check.go
+++ b/internal/lsp/cache/check.go
@@ -380,7 +380,7 @@ func typeCheck(ctx context.Context, fset *token.FileSet, m *metadata, mode sourc
 			if dep == nil {
 				return nil, errors.Errorf("no package for import %s", pkgPath)
 			}
-			if !dep.IsValidImportFor(string(pkg.pkgPath)) {
+			if !dep.IsValidImportFor(pkg.PkgPath()) {
 				return nil, errors.Errorf("invalid use of internal package %s", pkgPath)
 			}
 			depPkg, err := dep.check(ctx)

--- a/internal/lsp/cache/check.go
+++ b/internal/lsp/cache/check.go
@@ -57,7 +57,7 @@ func (ph *packageHandle) packageKey() packageKey {
 func (ph *packageHandle) isValidImportFor(parentPkgPath string) bool {
 	importPath := string(ph.m.pkgPath)
 
-	pkgRootIndex := strings.Index(importPath, "/internal")
+	pkgRootIndex := strings.Index(importPath, "/internal/")
 	if pkgRootIndex != -1 && parentPkgPath != "command-line-arguments" {
 		if !strings.HasPrefix(parentPkgPath, importPath[0:pkgRootIndex]) {
 			return false

--- a/internal/lsp/cache/pkg.go
+++ b/internal/lsp/cache/pkg.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"go/ast"
 	"go/types"
+	"strings"
 
 	"golang.org/x/tools/internal/lsp/protocol"
 	"golang.org/x/tools/internal/lsp/source"
@@ -97,6 +98,19 @@ func (p *pkg) GetTypesSizes() types.Sizes {
 
 func (p *pkg) IsIllTyped() bool {
 	return p.types == nil || p.typesInfo == nil || p.typesSizes == nil
+}
+
+func (p *pkg) IsValidImportFor(parentPkgPath string) bool {
+	importPath := p.PkgPath()
+
+	pkgRootIndex := strings.Index(importPath, "/internal")
+	if pkgRootIndex != -1 && parentPkgPath != "command-line-arguments" {
+		if !strings.HasPrefix(parentPkgPath, importPath[0:pkgRootIndex]) {
+			return false
+		}
+	}
+
+	return true
 }
 
 func (p *pkg) ForTest() string {

--- a/internal/lsp/cache/pkg.go
+++ b/internal/lsp/cache/pkg.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"go/ast"
 	"go/types"
-	"strings"
 
 	"golang.org/x/tools/internal/lsp/protocol"
 	"golang.org/x/tools/internal/lsp/source"
@@ -98,19 +97,6 @@ func (p *pkg) GetTypesSizes() types.Sizes {
 
 func (p *pkg) IsIllTyped() bool {
 	return p.types == nil || p.typesInfo == nil || p.typesSizes == nil
-}
-
-func (p *pkg) IsValidImportFor(parentPkgPath string) bool {
-	importPath := p.PkgPath()
-
-	pkgRootIndex := strings.Index(importPath, "/internal")
-	if pkgRootIndex != -1 && parentPkgPath != "command-line-arguments" {
-		if !strings.HasPrefix(parentPkgPath, importPath[0:pkgRootIndex]) {
-			return false
-		}
-	}
-
-	return true
 }
 
 func (p *pkg) ForTest() string {


### PR DESCRIPTION
An error should be reported if an "internal" package is imported
into code that is outside of the tree rooted at the parent
of the "internal" directory.

Fixes #35937