### PR TITLE
Checking GOROOT under Bazel test

### DIFF
--- a/internal/testenv/testenv.go
+++ b/internal/testenv/testenv.go
@@ -11,6 +11,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -69,9 +70,18 @@ func hasTool(tool string) error {
 				checkGoGoroot.err = err
 				return
 			}
-			GOROOT := strings.TrimSpace(string(out))
-			if GOROOT != runtime.GOROOT() {
-				checkGoGoroot.err = fmt.Errorf("'go env GOROOT' does not match runtime.GOROOT:\n\tgo env: %s\n\tGOROOT: %s", GOROOT, runtime.GOROOT())
+			goEnvRoot, err := filepath.Abs(string(out))
+			if err != nil {
+				checkGoGoroot.err = err
+				return
+			}
+			runtimeRoot, err := filepath.Abs(runtime.GOROOT())
+			if err != nil {
+				checkGoGoroot.err = err
+				return
+			}
+			if goEnvRoot != runtimeRoot {
+				checkGoGoroot.err = fmt.Errorf("'go env GOROOT' does not match runtime.GOROOT:\n\tgo env: %s\n\tGOROOT: %s", goEnvRoot, runtimeRoot)
 			}
 		})
 		if checkGoGoroot.err != nil {

--- a/internal/testenv/testenv.go
+++ b/internal/testenv/testenv.go
@@ -11,7 +11,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -70,18 +69,14 @@ func hasTool(tool string) error {
 				checkGoGoroot.err = err
 				return
 			}
-			goEnvRoot, err := filepath.Abs(string(out))
-			if err != nil {
-				checkGoGoroot.err = err
-				return
+			toolGoRoot := strings.TrimSpace(string(out))
+			selfGoRoot := runtime.GOROOT()
+			if selfGoRoot == "GOROOT" {
+				// under 'bazel test'
+				selfGoRoot = os.Getenv("GOROOT")
 			}
-			runtimeRoot, err := filepath.Abs(runtime.GOROOT())
-			if err != nil {
-				checkGoGoroot.err = err
-				return
-			}
-			if goEnvRoot != runtimeRoot {
-				checkGoGoroot.err = fmt.Errorf("'go env GOROOT' does not match runtime.GOROOT:\n\tgo env: %s\n\tGOROOT: %s", goEnvRoot, runtimeRoot)
+			if len(selfGoroot) > 0 && toolGoRoot != selfGoRoot {
+				checkGoGoroot.err = fmt.Errorf("'go env GOROOT' does not match runtime.GOROOT:\n\tgo env: %s\n\tGOROOT: %s", toolGoRoot, selfGoRoot)
 			}
 		})
 		if checkGoGoroot.err != nil {


### PR DESCRIPTION
The environment variable `GOROOT` may be set to relative path, like in [rules_go](https://github.com/bazelbuild/rules_go/blob/8c7beb2fcb4d9c7fea0406cf9b3f1c1720ecfd3f/go/private/context.bzl#L383). x/tools should compare their absolute path in case `go env GOROOT` and runtime.GOROOT() are only different by absolute vs relative paths.

Partially fixing https://github.com/bazelbuild/rules_go/issues/2370