### PR TITLE
internal/span/uri: fix NewURI for file:/// path

### DIFF
--- a/internal/span/uri.go
+++ b/internal/span/uri.go
@@ -58,7 +58,7 @@ func NewURI(s string) URI {
 		// Handle microsoft/vscode#75027 by making it a special case.
 		// On Windows, VS Code sends file URIs that look like file:///C%3A/x/y/z.
 		// Replace the %3A so that the URI looks like: file:///C:/x/y/z.
-		if strings.ToLower(s[i+2:i+5]) == "%3a" {
+		if len(s) >= i+5 && strings.ToLower(s[i+2:i+5]) == "%3a" {
 			s = s[:i+2] + ":" + s[i+5:]
 		}
 		// File URIs from Windows may have lowercase drive letters.

--- a/internal/span/uri_test.go
+++ b/internal/span/uri_test.go
@@ -71,6 +71,16 @@ func TestURI(t *testing.T) {
 			wantFile: `/path/to/%p%ercent%/per%cent.go`,
 			wantURI:  span.URI(`file:///path/to/%25p%25ercent%25/per%25cent.go`),
 		},
+		{
+			path:     `file:///C%3A/`,
+			wantFile: `C:/`,
+			wantURI:  span.URI(`file:///C:/`),
+		},
+		{
+			path:     `file:///`,
+			wantFile: `/`,
+			wantURI:  span.URI(`file:///`),
+		},
 	} {
 		got := span.NewURI(test.path)
 		if got != test.wantURI {


### PR DESCRIPTION
In case NewURI is called with 'file:///' as path it fails to replace %3a to
columns and gopls panics with error:

  slice bounds out of range [:12] with length 11

Ensure argument is long enough before %3a check, add test cases for short
and windows file:///C%3a/ pathes.

--------------------------------------------------------

Full stack of the error in my VSCode + Remote Containers + gopls inside the container environment:
```
user@f055aab4c903:/app$ gopls check cmd/crawler.go 
panic: runtime error: slice bounds out of range [:12] with length 11

goroutine 1 [running]:
golang.org/x/tools/internal/span.NewURI(0xc000190650, 0xb, 0x0, 0x0)
        /go/pkg/mod/golang.org/x/tools@v0.0.0-20200214144324-88be01311a71/internal/span/uri.go:61 +0x28d
golang.org/x/tools/internal/lsp.(*Server).addFolders(0xc00029c420, 0xe0eea0, 0xc00029b350, 0xc0000c2500, 0x1, 0x1)
        /go/pkg/mod/golang.org/x/tools@v0.0.0-20200214144324-88be01311a71/internal/lsp/general.go:168 +0x12e
golang.org/x/tools/internal/lsp.(*Server).initialized(0xc00029c420, 0xe0eea0, 0xc00029b350, 0x1338430, 0x0, 0x0)
        /go/pkg/mod/golang.org/x/tools@v0.0.0-20200214144324-88be01311a71/internal/lsp/general.go:157 +0x263
golang.org/x/tools/internal/lsp.(*Server).Initialized(0xc00029c420, 0xe0eea0, 0xc00029b350, 0x1338430, 0xc000108380, 0x0)
        /go/pkg/mod/golang.org/x/tools@v0.0.0-20200214144324-88be01311a71/internal/lsp/server_gen.go:112 +0x49
golang.org/x/tools/internal/lsp/cmd.(*connection).initialize(0xc000182f20, 0xe0eea0, 0xc00029b350, 0xd11da0, 0xcac600, 0xc000298d00)
        /go/pkg/mod/golang.org/x/tools@v0.0.0-20200214144324-88be01311a71/internal/lsp/cmd/cmd.go:255 +0x216
golang.org/x/tools/internal/lsp/cmd.(*Application).connect(0xc0002304e0, 0xe0ee20, 0xc0000b4000, 0x0, 0x0, 0x0)
        /go/pkg/mod/golang.org/x/tools@v0.0.0-20200214144324-88be01311a71/internal/lsp/cmd/cmd.go:202 +0x5e3
golang.org/x/tools/internal/lsp/cmd.(*check).Run(0xc0001762e8, 0xe0ee20, 0xc0000b4000, 0xc0000ae080, 0x1, 0x1, 0x0, 0x0)
        /go/pkg/mod/golang.org/x/tools@v0.0.0-20200214144324-88be01311a71/internal/lsp/cmd/check.go:45 +0xd2
golang.org/x/tools/internal/tool.Run(0xe0ee20, 0xc0000b4000, 0xe12520, 0xc0001762e8, 0xc0000ae080, 0x1, 0x1, 0x0, 0x0)
        /go/pkg/mod/golang.org/x/tools@v0.0.0-20200214144324-88be01311a71/internal/tool/tool.go:152 +0x29d
golang.org/x/tools/internal/lsp/cmd.(*Application).Run(0xc0002304e0, 0xe0ee20, 0xc0000b4000, 0xc0000ae080, 0x2, 0x2, 0x0, 0x0)
        /go/pkg/mod/golang.org/x/tools@v0.0.0-20200214144324-88be01311a71/internal/lsp/cmd/cmd.go:148 +0x352
golang.org/x/tools/internal/tool.Run(0xe0ee20, 0xc0000b4000, 0xe12460, 0xc0002304e0, 0xc0000ae070, 0x2, 0x2, 0x0, 0x0)
        /go/pkg/mod/golang.org/x/tools@v0.0.0-20200214144324-88be01311a71/internal/tool/tool.go:152 +0x29d
golang.org/x/tools/internal/tool.Main(0xe0ee20, 0xc0000b4000, 0xe12460, 0xc0002304e0, 0xc0000ae070, 0x2, 0x2)
        /go/pkg/mod/golang.org/x/tools@v0.0.0-20200214144324-88be01311a71/internal/tool/tool.go:91 +0x12f
main.main()
        /go/pkg/mod/golang.org/x/tools/gopls@v0.1.8-0.20200214144324-88be01311a71/main.go:25 +0xdb
```