### PR TITLE
Checking GOROOT under Bazel test

### DIFF
--- a/internal/testenv/testenv.go
+++ b/internal/testenv/testenv.go
@@ -69,9 +69,14 @@ func hasTool(tool string) error {
 				checkGoGoroot.err = err
 				return
 			}
-			GOROOT := strings.TrimSpace(string(out))
-			if GOROOT != runtime.GOROOT() {
-				checkGoGoroot.err = fmt.Errorf("'go env GOROOT' does not match runtime.GOROOT:\n\tgo env: %s\n\tGOROOT: %s", GOROOT, runtime.GOROOT())
+			toolGoRoot := strings.TrimSpace(string(out))
+			selfGoRoot := runtime.GOROOT()
+			if selfGoRoot == "GOROOT" {
+				// under 'bazel test'
+				selfGoRoot = os.Getenv("GOROOT")
+			}
+			if len(selfGoroot) > 0 && toolGoRoot != selfGoRoot {
+				checkGoGoroot.err = fmt.Errorf("'go env GOROOT' does not match runtime.GOROOT:\n\tgo env: %s\n\tGOROOT: %s", toolGoRoot, selfGoRoot)
 			}
 		})
 		if checkGoGoroot.err != nil {


### PR DESCRIPTION
It turned out that it is quite complicated to set correct `GOROOT` when a test is started by Bazel, according to the discussion at https://github.com/bazelbuild/rules_go/issues/2370. Maybe we should check if it is under bazel test and use `os.Getenv("GOROOT")` instead of` runtime.GOROOT()`.