### PR TITLE
go/analysis/singlechecker: append a newline after "Flags:"

### DIFF
--- a/go/analysis/singlechecker/singlechecker.go
+++ b/go/analysis/singlechecker/singlechecker.go
@@ -56,7 +56,7 @@ func Main(a *analysis.Analyzer) {
 		if len(paras) > 1 {
 			fmt.Fprintln(os.Stderr, strings.Join(paras[1:], "\n\n"))
 		}
-		fmt.Fprintf(os.Stderr, "\nFlags:")
+		fmt.Fprintln(os.Stderr, "\nFlags:")
 		flag.PrintDefaults()
 	}
 


### PR DESCRIPTION
Currently `flag.Usage` set in `Main` prints a message as follows,
```
⋮
Flags:  -V      print version and exit
⋮
```
but this should be
```
⋮
Flags:
  -V      print version and exit
⋮
```
It seems this is caused by [this](https://go-review.googlesource.com/c/tools/+/162717).