### PR TITLE
go/analysis/passes/printf: warn against using %v verb in Error() methods

### DIFF
--- a/go/analysis/passes/printf/printf.go
+++ b/go/analysis/passes/printf/printf.go
@@ -896,57 +896,50 @@ func okPrintfArg(pass *analysis.Pass, call *ast.CallExpr, state *formatState) (o
 		return false
 	}
 	if v.typ&argString != 0 && v.verb != 'T' && !bytes.Contains(state.flags, []byte{'#'}) {
-		if recursiveStringer(pass, arg) {
-			pass.ReportRangef(call, "%s format %s with arg %s causes recursive String method call", state.name, state.format, analysisutil.Format(pass.Fset, arg))
-			return false
-		}
-		if recursiveError(pass, arg) {
-			pass.ReportRangef(call, "%s format %s with arg %s causes recursive Error method call", state.name, state.format, analysisutil.Format(pass.Fset, arg))
+		if methodName, ok := recursiveStringer(pass, arg); ok {
+			pass.ReportRangef(call, "%s format %s with arg %s causes recursive %s method call", state.name, state.format, analysisutil.Format(pass.Fset, arg), methodName)
 			return false
 		}
 	}
 	return true
 }
 
-func recursiveStringer(pass *analysis.Pass, e ast.Expr) bool {
-	return recursiveStringerKind("String", pass, e)
-}
-
-func recursiveError(pass *analysis.Pass, e ast.Expr) bool {
-	return recursiveStringerKind("Error", pass, e)
-}
-
-// recursiveStringerKind reports whether the argument e is a potential
+// recursiveStringer reports whether the argument e is a potential
 // recursive call to stringer or error, such as t and &t in these examples:
 //
 // 	func (t *T) String() string { printf("%s",  t) }
 // 	func (t  T) Error() string { printf("%s",  t) }
 // 	func (t  T) String() string { printf("%s", &t) }
-//
-// The `kind` argument must be either "String" or "Error".
-func recursiveStringerKind(kind string, pass *analysis.Pass, e ast.Expr) bool {
+func recursiveStringer(pass *analysis.Pass, e ast.Expr) (string, bool) {
 	typ := pass.TypesInfo.Types[e].Type
 
 	// It's unlikely to be a recursive stringer if it has a Format method.
 	if isFormatter(typ) {
-		return false
+		return "", false
 	}
 
-	// Does e allow e.String()?
-	obj, _, _ := types.LookupFieldOrMethod(typ, false, pass.Pkg, kind)
-	stringMethod, ok := obj.(*types.Func)
-	if !ok {
-		return false
+	// Does e allow e.String() or e.Error()?
+	strObj, _, _ := types.LookupFieldOrMethod(typ, false, pass.Pkg, "String")
+	strMethod, strOk := strObj.(*types.Func)
+	errObj, _, _ := types.LookupFieldOrMethod(typ, false, pass.Pkg, "Error")
+	errMethod, errOk := errObj.(*types.Func)
+	if !strOk && !errOk {
+		return "", false
 	}
 
-	// Is the expression e within the body of that String method?
-	if stringMethod.Pkg() != pass.Pkg || !stringMethod.Scope().Contains(e.Pos()) {
-		return false
+	// Is the expression e within the body of that String or Error method?
+	var method *types.Func
+	if strOk && strMethod.Pkg() == pass.Pkg && strMethod.Scope().Contains(e.Pos()) {
+		method = strMethod
+	} else if errOk && errMethod.Pkg() == pass.Pkg && errMethod.Scope().Contains(e.Pos()) {
+		method = errMethod
+	} else {
+		return "", false
 	}
 
-	sig := stringMethod.Type().(*types.Signature)
+	sig := method.Type().(*types.Signature)
 	if !isStringer(sig) {
-		return false
+		return "", false
 	}
 
 	// Is it the receiver r, or &r?
@@ -954,9 +947,11 @@ func recursiveStringerKind(kind string, pass *analysis.Pass, e ast.Expr) bool {
 		e = u.X // strip off & from &r
 	}
 	if id, ok := e.(*ast.Ident); ok {
-		return pass.TypesInfo.Uses[id] == sig.Recv()
+		if pass.TypesInfo.Uses[id] == sig.Recv() {
+			return method.Name(), true
+		}
 	}
-	return false
+	return "", false
 }
 
 // isStringer reports whether the method signature matches the String() definition in fmt.Stringer.
@@ -1080,11 +1075,8 @@ func checkPrint(pass *analysis.Pass, call *ast.CallExpr, fn *types.Func) {
 		if isFunctionValue(pass, arg) {
 			pass.ReportRangef(call, "%s arg %s is a func value, not called", fn.Name(), analysisutil.Format(pass.Fset, arg))
 		}
-		if recursiveStringer(pass, arg) {
-			pass.ReportRangef(call, "%s arg %s causes recursive call to String method", fn.Name(), analysisutil.Format(pass.Fset, arg))
-		}
-		if recursiveError(pass, arg) {
-			pass.ReportRangef(call, "%s arg %s causes recursive call to Error method", fn.Name(), analysisutil.Format(pass.Fset, arg))
+		if methodName, ok := recursiveStringer(pass, arg); ok {
+			pass.ReportRangef(call, "%s arg %s causes recursive call to %s method", fn.Name(), analysisutil.Format(pass.Fset, arg), methodName)
 		}
 	}
 }

--- a/go/analysis/passes/printf/printf.go
+++ b/go/analysis/passes/printf/printf.go
@@ -905,7 +905,7 @@ func okPrintfArg(pass *analysis.Pass, call *ast.CallExpr, state *formatState) (o
 }
 
 // recursiveStringer reports whether the argument e is a potential
-// recursive call to stringer or error, such as t and &t in these examples:
+// recursive call to stringer or is an error, such as t and &t in these examples:
 //
 // 	func (t *T) String() string { printf("%s",  t) }
 // 	func (t  T) Error() string { printf("%s",  t) }

--- a/go/analysis/passes/printf/testdata/src/a/a.go
+++ b/go/analysis/passes/printf/testdata/src/a/a.go
@@ -528,7 +528,7 @@ func (p *recursivePtrStringer) String() string {
 
 type recursiveError int
 
-func (s recursiveStringer) Error() string {
+func (s recursiveError) Error() string {
 	_ = fmt.Sprintf("%d", s)
 	_ = fmt.Sprintf("%#v", s)
 	_ = fmt.Sprintf("%v", s)  // want "Sprintf format %v with arg s causes recursive Error method call"
@@ -539,7 +539,41 @@ func (s recursiveStringer) Error() string {
 
 type recursivePtrError int
 
-func (p *recursivePtrStringer) Error() string {
+func (p *recursivePtrError) Error() string {
+	_ = fmt.Sprintf("%v", *p)
+	_ = fmt.Sprint(&p)     // ok; prints address
+	return fmt.Sprintln(p) // want "Sprintln arg p causes recursive call to Error method"
+}
+
+type recursiveStringerAndError int
+
+func (s recursiveStringerAndError) String() string {
+	_ = fmt.Sprintf("%d", s)
+	_ = fmt.Sprintf("%#v", s)
+	_ = fmt.Sprintf("%v", s)  // want "Sprintf format %v with arg s causes recursive String method call"
+	_ = fmt.Sprintf("%v", &s) // want "Sprintf format %v with arg &s causes recursive String method call"
+	_ = fmt.Sprintf("%T", s)  // ok; does not recursively call String
+	return fmt.Sprintln(s)    // want "Sprintln arg s causes recursive call to String method"
+}
+
+func (s recursiveStringerAndError) Error() string {
+	_ = fmt.Sprintf("%d", s)
+	_ = fmt.Sprintf("%#v", s)
+	_ = fmt.Sprintf("%v", s)  // want "Sprintf format %v with arg s causes recursive Error method call"
+	_ = fmt.Sprintf("%v", &s) // want "Sprintf format %v with arg &s causes recursive Error method call"
+	_ = fmt.Sprintf("%T", s)  // ok; does not recursively call Error
+	return fmt.Sprintln(s)    // want "Sprintln arg s causes recursive call to Error method"
+}
+
+type recursivePtrStringerAndError int
+
+func (p *recursivePtrStringerAndError) String() string {
+	_ = fmt.Sprintf("%v", *p)
+	_ = fmt.Sprint(&p)     // ok; prints address
+	return fmt.Sprintln(p) // want "Sprintln arg p causes recursive call to String method"
+}
+
+func (p *recursivePtrStringerAndError) Error() string {
 	_ = fmt.Sprintf("%v", *p)
 	_ = fmt.Sprint(&p)     // ok; prints address
 	return fmt.Sprintln(p) // want "Sprintln arg p causes recursive call to Error method"

--- a/go/analysis/passes/printf/testdata/src/a/a.go
+++ b/go/analysis/passes/printf/testdata/src/a/a.go
@@ -526,6 +526,25 @@ func (p *recursivePtrStringer) String() string {
 	return fmt.Sprintln(p) // want "Sprintln arg p causes recursive call to String method"
 }
 
+type recursiveError int
+
+func (s recursiveStringer) Error() string {
+	_ = fmt.Sprintf("%d", s)
+	_ = fmt.Sprintf("%#v", s)
+	_ = fmt.Sprintf("%v", s)  // want "Sprintf format %v with arg s causes recursive Error method call"
+	_ = fmt.Sprintf("%v", &s) // want "Sprintf format %v with arg &s causes recursive Error method call"
+	_ = fmt.Sprintf("%T", s)  // ok; does not recursively call Error
+	return fmt.Sprintln(s)    // want "Sprintln arg s causes recursive call to Error method"
+}
+
+type recursivePtrError int
+
+func (p *recursivePtrStringer) Error() string {
+	_ = fmt.Sprintf("%v", *p)
+	_ = fmt.Sprint(&p)     // ok; prints address
+	return fmt.Sprintln(p) // want "Sprintln arg p causes recursive call to Error method"
+}
+
 // implements a String() method but with non-matching return types
 type nonStringerWrongReturn int
 


### PR DESCRIPTION
go vet should warn against using %v verb in Error() methods just like it
does for String().

Fixes golang/go#33884