### PR TITLE
godoc: allow change of GOOS and GOARCH through environment

### DIFF
--- a/godoc/server.go
+++ b/godoc/server.go
@@ -98,9 +98,13 @@ func (h *handlerServer) GetPageInfo(abspath, relpath string, mode PageInfoMode, 
 	}
 	if goos != "" {
 		ctxt.GOOS = goos
+	} else if env := os.Getenv("GOOS"); env != "" {
+		ctxt.GOOS = env
 	}
 	if goarch != "" {
 		ctxt.GOARCH = goarch
+	} else if env := os.Getenv("GOARCH"); env != "" {
+		ctxt.GOARCH = env
 	}
 
 	pkginfo, err := ctxt.ImportDir(abspath, 0)


### PR DESCRIPTION
Currently there is no way to change the GOOS and GOARCH thorugh godoc.Presentation.Get[Pkg,Cmd]PageInfo() as the function trims the goos and goarch arguments passed to handlerServer.GetPageInfo.
When using this tool as a package, it is possible to change the target goos and goarch through environment variables only when the project is compiled into a binary.

My proposal is to check if the environment has those variables set (They are used when setting context.Default.[GOOS,GOARCH] anyway, but on package import).