### PR TITLE
cmd/cover: add <title> tag to HTML template in go cover report

### DIFF
--- a/cmd/cover/html.go
+++ b/cmd/cover/html.go
@@ -197,6 +197,7 @@ const tmplHTML = `
 <html>
 	<head>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+		<title>Go Coverage Report</title>
 		<style>
 			body {
 				background: black;


### PR DESCRIPTION
add missing <title> tag to HTML template used by `go tool cover`
This will make the HTML code coverage report more compliant, as <title> tags
are generally required in valid HTML documents.