### PR TITLE
fix: lsp panics when processing paths containing %

### DIFF
--- a/internal/span/uri.go
+++ b/internal/span/uri.go
@@ -58,11 +58,11 @@ func URIFromURI(s string) URI {
 		return URI(s)
 	}
 
-	// Bazel uses % in its temporary paths which is not a valid URI. 
+	// Bazel uses % in its temporary paths which is not a valid URI.
 	// Therefore url.PathUnescape will panic.
 	// See https://github.com/golang/go/issues/37984
 	s = url.PathEscape(s)
-	
+
 	// Even though the input is a URI, it may not be in canonical form. VS Code
 	// in particular over-escapes :, @, etc. Unescape and re-encode to canonicalize.
 	path, err := url.PathUnescape(s[len("file://"):])

--- a/internal/span/uri.go
+++ b/internal/span/uri.go
@@ -58,6 +58,11 @@ func URIFromURI(s string) URI {
 		return URI(s)
 	}
 
+	// Bazel uses % in its temporary paths which is not a valid URI. 
+	// Therefore url.PathUnescape will panic.
+	// See https://github.com/golang/go/issues/37984
+	s = url.PathEscape(s)
+	
 	// Even though the input is a URI, it may not be in canonical form. VS Code
 	// in particular over-escapes :, @, etc. Unescape and re-encode to canonicalize.
 	path, err := url.PathUnescape(s[len("file://"):])

--- a/internal/span/uri.go
+++ b/internal/span/uri.go
@@ -87,7 +87,7 @@ var invalidPercentEncodingRE = regexp.MustCompile(`(%[^0-9a-fA-F][0-9a-fA-F])|(%
 func stripInvalidPercentEncoding(s string) string {
 	matches := invalidPercentEncodingRE.FindAllString(s, -1)
 	for _, match := range matches {
-		s = invalidPercentEncodingRE.ReplaceAllString(s, "%25"+match[1:])
+		s = strings.ReplaceAll(s, match, "%25"+match[1:])
 	}
 	return s
 }

--- a/internal/span/uri.go
+++ b/internal/span/uri.go
@@ -82,12 +82,15 @@ func URIFromURI(s string) URI {
 	return URI(u.String())
 }
 
-var invalidPercentEncodingRE = regexp.MustCompile(`(%[^0-9a-fA-F])`)
+var invalidPercentEncodingRE = regexp.MustCompile(`%(?:[^A-Fa-f0-9]|$)`)
 
 func stripInvalidPercentEncoding(s string) string {
-	matches := invalidPercentEncodingRE.FindAllString(s, -1)
-	for _, match := range matches {
-		s = strings.ReplaceAll(s, match, "%25"+match[1:])
+	for {
+		match := invalidPercentEncodingRE.FindStringIndex(s)
+		if match == nil {
+			break
+		}
+		s = s[:match[0]] + "%25" + s[match[0]+1:]
 	}
 	return s
 }

--- a/internal/span/uri.go
+++ b/internal/span/uri.go
@@ -82,7 +82,7 @@ func URIFromURI(s string) URI {
 	return URI(u.String())
 }
 
-var invalidPercentEncodingRE = regexp.MustCompile(`(%[^0-9a-fA-F][0-9a-fA-F])|(%[0-9a-fA-F][^0-9a-fA-F])|(%[^0-9a-fA-F][^0-9a-fA-F])`)
+var invalidPercentEncodingRE = regexp.MustCompile(`(%[^0-9a-fA-F])`)
 
 func stripInvalidPercentEncoding(s string) string {
 	matches := invalidPercentEncodingRE.FindAllString(s, -1)

--- a/internal/span/uri_test.go
+++ b/internal/span/uri_test.go
@@ -99,9 +99,9 @@ func TestURIFromURI(t *testing.T) {
 			wantURI:  span.URI(`file:///`),
 		},
 		{
-			inputURI: `file:///bazel-out/darwin_amd64_stripped/go_default_test%/testmain.go`,
-			wantFile: `/bazel-out/darwin_amd64_stripped/go_default_test%/testmain.go`,
-			wantURI:  span.URI(`file:///bazel-out/darwin_amd64_stripped/go_default_test%25/testmain.go`),
+			inputURI: `file:///bazel-out/darwin_amd64_stripped%/go_default_test%/testmain.go`,
+			wantFile: `/bazel-out/darwin_amd64_stripped%/go_default_test%/testmain.go`,
+			wantURI:  span.URI(`file:///bazel-out/darwin_amd64_stripped%25/go_default_test%25/testmain.go`),
 		},
 	} {
 		got := span.URIFromURI(test.inputURI)

--- a/internal/span/uri_test.go
+++ b/internal/span/uri_test.go
@@ -103,6 +103,11 @@ func TestURIFromURI(t *testing.T) {
 			wantFile: `/bazel-out/darwin_amd64_stripped%/go_default_test%/testmain.go`,
 			wantURI:  span.URI(`file:///bazel-out/darwin_amd64_stripped%25/go_default_test%25/testmain.go`),
 		},
+		{
+			inputURI: `file:///bazel-out/darwin_amd64_stripped%/`,
+			wantFile: `/bazel-out/darwin_amd64_stripped%/`,
+			wantURI:  span.URI(`file:///bazel-out/darwin_amd64_stripped%25/`),
+		},
 	} {
 		got := span.URIFromURI(test.inputURI)
 		if got != test.wantURI {

--- a/internal/span/uri_test.go
+++ b/internal/span/uri_test.go
@@ -104,9 +104,9 @@ func TestURIFromURI(t *testing.T) {
 			wantURI:  span.URI(`file:///bazel-out/darwin_amd64_stripped%25/go_default_test%25/testmain.go`),
 		},
 		{
-			inputURI: `file:///bazel-out/darwin_amd64_stripped%/`,
-			wantFile: `/bazel-out/darwin_amd64_stripped%/`,
-			wantURI:  span.URI(`file:///bazel-out/darwin_amd64_stripped%25/`),
+			inputURI: `file:///bazel-out/darwin_amd64_stripped%`,
+			wantFile: `/bazel-out/darwin_amd64_stripped%`,
+			wantURI:  span.URI(`file:///bazel-out/darwin_amd64_stripped%25`),
 		},
 	} {
 		got := span.URIFromURI(test.inputURI)

--- a/internal/span/uri_test.go
+++ b/internal/span/uri_test.go
@@ -98,6 +98,11 @@ func TestURIFromURI(t *testing.T) {
 			wantFile: `/`,
 			wantURI:  span.URI(`file:///`),
 		},
+		{
+			inputURI: `file:///bazel-out/darwin_amd64_stripped/go_default_test%/testmain.go`,
+			wantFile: `/bazel-out/darwin_amd64_stripped/go_default_test%/testmain.go`,
+			wantURI:  span.URI(`file:///bazel-out/darwin_amd64_stripped/go_default_test%25/testmain.go`),
+		},
 	} {
 		got := span.URIFromURI(test.inputURI)
 		if got != test.wantURI {


### PR DESCRIPTION
Bazel uses % in its temporary paths which is not a valid URI. 
Therefore url.PathUnescape will panic.
See https://github.com/golang/go/issues/37984