### PR TITLE
remove: VS Code hack for incompleteResults

### DIFF
--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -49,19 +49,6 @@ func (s *Server) completion(ctx context.Context, params *protocol.CompletionPara
 
 	items := toProtocolCompletionItems(candidates, rng, options)
 
-	if incompleteResults {
-		for i := 1; i < len(items); i++ {
-			// Give all the candidates the same filterText to trick VSCode
-			// into not reordering our candidates. All the candidates will
-			// appear to be equally good matches, so VSCode's fuzzy
-			// matching/ranking just maintains the natural "sortText"
-			// ordering. We can only do this in tandem with
-			// "incompleteResults" since otherwise client side filtering is
-			// important.
-			items[i].FilterText = items[0].FilterText
-		}
-	}
-
 	return &protocol.CompletionList{
 		IsIncomplete: incompleteResults,
 		Items:        items,


### PR DESCRIPTION
**Why**
Including editor specific "hacks" in a language server is the incorrect approach to fixing issues like this. If an editor is having issues with the results returned by the LS, then the client side implementation should handle the issue.

When implementing hacks like this for one specific editor, it impacts all other editors utilizing the language server, whether or not they have a similar issue.

In the case, an example can be Sublime Text, with the current code, it forces a new label filter and results in scenarios like this.

<img width="308" alt="image" src="https://user-images.githubusercontent.com/32599364/80712674-4ee1db80-8ac0-11ea-8ba4-3f7e216452e6.png">


**Suggestion**
Strip this hack from the LS and implement it on VS Codes client side gopls extension.

**Similar Issue with Acceptable Solutions**
+ https://github.com/clangd/vscode-clangd/blob/435b5431356f076c41aa69d74210d1d08410ce90/src/extension.ts#L73-L98