### PR TITLE
x/tools/gopls: Add note to vscode doc about tags

### DIFF
--- a/gopls/doc/vscode.md
+++ b/gopls/doc/vscode.md
@@ -52,6 +52,16 @@ See the section on [command line](command-line.md) arguments for more informatio
 
 You can disable features through the `"go.languageServerExperimentalFeatures"` section of the config. An example of a feature you may want to disable is `"documentLink"`, which opens [`pkg.go.dev`](https://pkg.go.dev) links when you click on import statements in your file.
 
+### Build tags
+
+build tags will not be picked from `go.buildTags` configuration section, instead they should be specified as part of the`GOFLAGS` environment variable:
+
+```json5
+"go.toolsEnvVars": {
+    "GOFLAGS": "-tags=<yourtag>"
+}
+```
+
 
 [VSCode-Go]: https://github.com/microsoft/vscode-go
 


### PR DESCRIPTION
As prompted [this issue](https://github.com/golang/go/issues/38963) it
is unclear how to setup build tags in gopls in vscode.

vscode has a configuration section specific for go build tags but it is
not honored by gopls which instead requires GOFLAGS environment variable
to be set with the -tags flag.