### PR TITLE
x/tools/cmd/goimports: return exit code 0 when both -l and -w succeed

### DIFF
--- a/cmd/goimports/goimports.go
+++ b/cmd/goimports/goimports.go
@@ -154,7 +154,10 @@ func processFile(filename string, in io.Reader, out io.Writer, argType argumentT
 		// formatting has changed
 		if *list {
 			fmt.Fprintln(out, filename)
-			exitCode = 1
+			if !*write {
+				// If we aren't fixing the format, exit 1
+				exitCode = 1
+			}
 		}
 		if *write {
 			if argType == fromStdin {


### PR DESCRIPTION
Return zero if goimports was successfully able to modify files in place
even if -l is set to list the changed files.

Fixes: golang/go#39316