### PR TITLE
gopls/doc: update vscode-go GitHub link

### DIFF
--- a/gopls/doc/vscode.md
+++ b/gopls/doc/vscode.md
@@ -63,7 +63,7 @@ build tags will not be picked from `go.buildTags` configuration section, instead
 ```
 
 
-[VSCode-Go]: https://github.com/microsoft/vscode-go
+[VSCode-Go]: https://github.com/golang/vscode-go
 
 # VSCode Remote Development with gopls
 


### PR DESCRIPTION
The GitHub repository for vscode-go has been moved to https://github.com/golang/vscode-go. This change reflects that.