### PR TITLE
Fix example of specifying value received method in `-funcs`

### DIFF
--- a/go/analysis/passes/printf/printf.go
+++ b/go/analysis/passes/printf/printf.go
@@ -58,7 +58,7 @@ known formatting functions or methods. If the name contains a period,
 it must denote a specific function using one of the following forms:
 
 	dir/pkg.Function
-	dir/pkg.Type.Method
+	(dir/pkg.Type).Method
 	(*dir/pkg.Type).Method
 
 Otherwise the name is interpreted as a case-insensitive unqualified


### PR DESCRIPTION
My experimentation shows that `dir/pkg.Type.Method` doesn't work, but `(dir/pkg.Type).Method` does.

Looking at https://golang.org/pkg/go/types/#Func.FullName implementation:
https://github.com/golang/go/blob/18bcc7c2854f900dfb631d7ef01a839021e24576/src/go/types/object.go#L465-L486

it seems to me that in both cases of pointer and value received the brackets are written.

CC: @alandonovan