### PR TITLE
present: properly render sub-section heading

### DIFF
--- a/cmd/present/templates/action.tmpl
+++ b/cmd/present/templates/action.tmpl
@@ -4,7 +4,7 @@ It determines how the formatting actions are rendered.
 */}
 
 {{define "section"}}
-  <h{{len .Number}} id="TOC_{{.FormattedNumber}}">{{.FormattedNumber}} {{.Title}}</h{{len .Number}}>
+  <h{{ .Level}} id="TOC_{{.FormattedNumber}}">{{.FormattedNumber}} {{.Title}}</h{{ .Level}}>
   {{range .Elem}}{{elem $.Template .}}{{end}}
 {{end}}
 


### PR DESCRIPTION
If we take the example from the readme:

Some Text

- bullets
- more bullets
- a bullet continued
  on the next line

Some More text

	Preformatted text (code block)
	is indented (by one tab, or four spaces)

The sub-section and sub-subsection will have the headings <h2> and <h3> respectively,
which breaks the page, since the main title has a heading of <h3> so it pushes down the sub-section to
the bottom of the page.

If we use .Level for the section heading, they will have the headings <h3> and <h4> which will render properly.