### PR TITLE
x/tools/cmd/goimports: prevent panic on parsing local prefix

### DIFF
--- a/cmd/goimports/goimports.go
+++ b/cmd/goimports/goimports.go
@@ -42,6 +42,7 @@ var (
 		TabIndent: true,
 		Comments:  true,
 		Fragment:  true,
+		Env: &imports.ProcessEnv{},
 	}
 	exitCode = 0
 )


### PR DESCRIPTION
The existing flag parsing logic doesn't initialize a ProcessEnv struct,
which results in a nil dereference when trying to access the LocalPrefix
property. The fix is to initialize the default options with an initialized
ProcessEnv.

Fixes #39862