### PR TITLE
move signature position when SynopsisDocumentation

### DIFF
--- a/internal/lsp/source/hover.go
+++ b/internal/lsp/source/hover.go
@@ -381,7 +381,7 @@ func FormatHover(h *HoverInformation, options Options) (string, error) {
 	switch options.HoverKind {
 	case SynopsisDocumentation:
 		doc := formatDoc(h.Synopsis, options)
-		return formatHover(options, doc, link, signature), nil
+		return formatHover(options, signature, link, doc), nil
 	case FullDocumentation:
 		doc := formatDoc(h.FullDocumentation, options)
 		return formatHover(options, signature, link, doc), nil


### PR DESCRIPTION
Hello,
It's a small patch of eldoc format.
Moved a fuction's signature position to top in eldoc when hoverKind is SynopsisDocumentation.
Like FullDocumentation hoverKind, formatHover should have a first line function's signature.
Thanks 
