### PR TITLE
internal/lsp: don't run debug instance when debug arg is empty

### DIFF
--- a/internal/lsp/cmd/cmd.go
+++ b/internal/lsp/cmd/cmd.go
@@ -141,7 +141,9 @@ gopls flags are:
 // If no arguments are passed it will invoke the server sub command, as a
 // temporary measure for compatibility.
 func (app *Application) Run(ctx context.Context, args ...string) error {
-	ctx = debug.WithInstance(ctx, app.wd, app.OCAgent)
+	if app.Serve.Debug != "" {
+		ctx = debug.WithInstance(ctx, app.wd, app.OCAgent)
+	}
 	app.Serve.app = app
 	if len(args) == 0 {
 		return tool.Run(ctx, &app.Serve, args)


### PR DESCRIPTION
In master branch if I run

```
gopls -profile.mem=gopls.profile.mem serve -listen=unix\;whatever.unix -listen.timeout=10s
```

Then run an editor with `-remote=unix;/home/wayne/whatever.unix` added to the `gopls` flags, wait for `gopls` memory usage to stabilize at a fairly large number (I am working within a big mono repo), then kill my editor process and let the 10s `-listen.timout` expire, I see a top-level 1784.40MB `*debug.Instance` when I look at the `alloc_space` web ui pprof view. I'll admit that I don't really understand what `alloc_space` means (or anything else really), but 1784.40 seems like a fairly big number to me, especially given that in order to keep my work laptop with 16 GB system memory running stably at all I need to contain `gopls` within a memory-limited cgroup.

Something I found surprising about the existing of that `*debug.Instance` however is the fact that it exists at all when I didn't pass a `-debug` flag.

This PR naively attempts to prevent unnecessary memory consumption by  `gopls` by preventing it from instantiating the `*debug.Instance` unless a non-empty value is passed to `-debug`, under the assumption that if the user doesn't pass this flag then they don't want to run the debug instance.

I believe this will work for both the `gopls` and the `gopls serve` usages since both appear to rely on `debug.GetInstance` to obtain the `*debug.Instance` from the context if it has been set by the line of code I am changing in this PR,.

Thanks for your consideration!