### PR TITLE
go/analysis/passes/unmarshal: Add check for asn1.Unmarshal

### DIFF
--- a/go/analysis/passes/unmarshal/testdata/src/a/a.go
+++ b/go/analysis/passes/unmarshal/testdata/src/a/a.go
@@ -7,6 +7,7 @@
 package testdata
 
 import (
+	"encoding/asn1"
 	"encoding/gob"
 	"encoding/json"
 	"encoding/xml"
@@ -30,6 +31,8 @@ func _() {
 	xml.Unmarshal([]byte{}, &v)
 	xml.NewDecoder(r).Decode(v) // want "call of Decode passes non-pointer"
 	xml.NewDecoder(r).Decode(&v)
+	asn1.Unmarshal([]byte{}, v) // want "call of Unmarshal passes non-pointer as second argument"
+	asn1.Unmarshal([]byte{}, &v)
 
 	var p *t
 	json.Unmarshal([]byte{}, p)
@@ -42,6 +45,8 @@ func _() {
 	xml.Unmarshal([]byte{}, *p) // want "call of Unmarshal passes non-pointer as second argument"
 	xml.NewDecoder(r).Decode(p)
 	xml.NewDecoder(r).Decode(*p) // want "call of Decode passes non-pointer"
+	asn1.Unmarshal([]byte{}, p)
+	asn1.Unmarshal([]byte{}, *p) // want "call of Unmarshal passes non-pointer as second argument"
 
 	var i interface{}
 	json.Unmarshal([]byte{}, i)

--- a/go/analysis/passes/unmarshal/unmarshal.go
+++ b/go/analysis/passes/unmarshal/unmarshal.go
@@ -30,7 +30,7 @@ var Analyzer = &analysis.Analyzer{
 
 func run(pass *analysis.Pass) (interface{}, error) {
 	switch pass.Pkg.Path() {
-	case "encoding/gob", "encoding/json", "encoding/xml":
+	case "encoding/gob", "encoding/json", "encoding/xml", "encoding/asn1":
 		// These packages know how to use their own APIs.
 		// Sometimes they are testing what happens to incorrect programs.
 		return nil, nil
@@ -53,9 +53,10 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		recv := fn.Type().(*types.Signature).Recv()
 		if fn.Name() == "Unmarshal" && recv == nil {
 			// "encoding/json".Unmarshal
-			//  "encoding/xml".Unmarshal
+			// "encoding/xml".Unmarshal
+			// "encoding/asn1".Unmarshal
 			switch fn.Pkg().Path() {
-			case "encoding/json", "encoding/xml":
+			case "encoding/json", "encoding/xml", "encoding/asn1":
 				argidx = 1 // func([]byte, interface{})
 			}
 		} else if fn.Name() == "Decode" && recv != nil {


### PR DESCRIPTION
Unmarshal package checks whether `Unmarshal` and(or) `Decode` call of `encoding/json`, `encoding/xml` and `encoding/gob` package is valid or not. However, it didn't check `encoding/asn1` package's one. 

This change makes it check whether `asn1.Unmarshal` call is valid or not as well.