### PR TITLE
unusedresult.go: Include context.With* functions

### DIFF
--- a/go/analysis/passes/unusedresult/unusedresult.go
+++ b/go/analysis/passes/unusedresult/unusedresult.go
@@ -44,7 +44,7 @@ var funcs, stringMethods stringSetFlag
 func init() {
 	// TODO(adonovan): provide a comment syntax to allow users to
 	// add their functions to this set using facts.
-	funcs.Set("errors.New,fmt.Errorf,fmt.Sprintf,fmt.Sprint,sort.Reverse")
+	funcs.Set("errors.New,fmt.Errorf,fmt.Sprintf,fmt.Sprint,sort.Reverse,context.WithValue,context.WithCancel,context.WithDeadline,context.WithTimeout")
 	Analyzer.Flags.Var(&funcs, "funcs",
 		"comma-separated list of functions whose results must be used")
 


### PR DESCRIPTION
This commit includes the four "With" functions from the context package in the
list of unused functions. This will produce the following error:

    ./main.go:9:19: result of context.WithValue call not used

When analyzing this:

```go
func f(ctx context.Context) {
	context.WithValue(ctx, "foo", -6)
}
```

Fixes golang/go#41149