### PR TITLE
cmd/benchcmp: mention deprecation in docs

### DIFF
--- a/cmd/benchcmp/doc.go
+++ b/cmd/benchcmp/doc.go
@@ -4,6 +4,8 @@
 
 /*
 
+Deprecated: benchcmp is deprecated in favor of benchstat: golang.org/x/perf/cmd/benchstat
+
 The benchcmp command displays performance changes between benchmarks.
 
 Benchcmp parses the output of two 'go test' benchmark runs,


### PR DESCRIPTION
A deprecation notice was added to benchcmp in https://github.com/golang/tools/commit/a1f8cf00470bdcdcccb2aa1be10335441650c33e, but there is no mention of it in the benchcmp docs at https://pkg.go.dev/golang.org/x/tools/cmd/benchcmp, so it may not be immediately obvious to new users.

This PR adds the deprecation notice to the documentation as well to make it easier to discover.