### PR TITLE
cmd/goyacc: double ACTSIZE, NSTATE and TEMPSTATE

### DIFF
--- a/cmd/goyacc/yacc.go
+++ b/cmd/goyacc/yacc.go
@@ -60,9 +60,9 @@ import (
 // the following are adjustable
 // according to memory size
 const (
-	ACTSIZE  = 120000
-	NSTATES  = 8000
-	TEMPSIZE = 8000
+	ACTSIZE  = 240000
+	NSTATES  = 16000
+	TEMPSIZE = 16000
 
 	SYMINC   = 50  // increase for non-term or term
 	RULEINC  = 50  // increase for max rule length prodptr[i]


### PR DESCRIPTION
CockroachDB has yet again hit the limit of ACTSIZE. Following the
precedent set by CL 33585 and doubling the relevant ACTSIZE, NSTATE and
TEMPSTATE const variables.

