### PR TITLE
internal/lsp: add tests to set configuration options

### DIFF
--- a/internal/lsp/source/options.go
+++ b/internal/lsp/source/options.go
@@ -665,6 +665,9 @@ func (o *Options) set(name string, value interface{}) OptionResult {
 			result.errorf("invalid type %T, expect map", value)
 			break
 		}
+		if o.Env == nil {
+			o.Env = make(map[string]string)
+		}
 		for k, v := range menv {
 			o.Env[k] = fmt.Sprint(v)
 		}

--- a/internal/lsp/source/options_test.go
+++ b/internal/lsp/source/options_test.go
@@ -60,6 +60,94 @@ func TestSetOption(t *testing.T) {
 				return true // just confirm that we handle this setting
 			},
 		},
+		{
+			name:  "hoverKind",
+			value: "FullDocumentation",
+			check: func(o Options) bool {
+				return o.HoverKind == FullDocumentation
+			},
+		},
+		{
+			name:  "hoverKind",
+			value: "NoDocumentation",
+			check: func(o Options) bool {
+				return o.HoverKind == NoDocumentation
+			},
+		},
+		{
+			name:  "hoverKind",
+			value: "SingleLine",
+			check: func(o Options) bool {
+				return o.HoverKind == SingleLine
+			},
+		},
+		{
+			name:  "hoverKind",
+			value: "Structured",
+			check: func(o Options) bool {
+				return o.HoverKind == Structured
+			},
+		},
+		{
+			name:  "matcher",
+			value: "Fuzzy",
+			check: func(o Options) bool {
+				return o.Matcher == Fuzzy
+			},
+		},
+		{
+			name:  "matcher",
+			value: "CaseSensitive",
+			check: func(o Options) bool {
+				return o.Matcher == CaseSensitive
+			},
+		},
+		{
+			name:  "matcher",
+			value: "CaseInsensitive",
+			check: func(o Options) bool {
+				return o.Matcher == CaseInsensitive
+			},
+		},
+		{
+			name:  "env",
+			value: map[string]interface{}{"testing": "true"},
+			check: func(o Options) bool {
+				v, found := o.Env["testing"]
+				return found && v == "true"
+			},
+		},
+		{
+			name:      "env",
+			value:     []string{"invalid", "input"},
+			wantError: true,
+			check: func(o Options) bool {
+				return o.Env == nil
+			},
+		},
+		{
+			name:  "directoryFilters",
+			value: []interface{}{"-node_modules", "+project_a"},
+			check: func(o Options) bool {
+				return len(o.DirectoryFilters) == 2
+			},
+		},
+		{
+			name:      "directoryFilters",
+			value:     []interface{}{"invalid"},
+			wantError: true,
+			check: func(o Options) bool {
+				return len(o.DirectoryFilters) == 0
+			},
+		},
+		{
+			name:      "directoryFilters",
+			value:     []string{"-invalid", "+type"},
+			wantError: true,
+			check: func(o Options) bool {
+				return len(o.DirectoryFilters) == 0
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Added some tests to hoverKind, matcher, env and directoryFilters
of configuration options.

I'm also add a validation on `env`configuration, to initialize the map if is nil to avoid the risk of inserting the values in a nil map. Please let me know if this validation is unnecessary. 

Fixes golang/go#34244