### PR TITLE
go/analysis: validate report if analyzer.Run is empty

### DIFF
--- a/go/analysis/validate.go
+++ b/go/analysis/validate.go
@@ -10,6 +10,7 @@ import (
 // Validate reports an error if any of the analyzers are misconfigured.
 // Checks include:
 // that the name is a valid identifier;
+// that the Doc and Run are not empty;
 // that the Requires graph is acyclic;
 // that analyzer fact types are unique;
 // that each fact type is a pointer.
@@ -40,6 +41,10 @@ func Validate(analyzers []*Analyzer) error {
 
 			if a.Doc == "" {
 				return fmt.Errorf("analyzer %q is undocumented", a)
+			}
+
+			if a.Run == nil {
+				return fmt.Errorf("analyzer %q has nil Run", a)
 			}
 
 			// fact types

--- a/go/analysis/validate_test.go
+++ b/go/analysis/validate_test.go
@@ -11,33 +11,43 @@ import (
 
 func TestValidate(t *testing.T) {
 	var (
+		run = func(p *Pass) (interface{}, error) {
+			return nil, nil
+		}
 		dependsOnSelf = &Analyzer{
 			Name: "dependsOnSelf",
 			Doc:  "this analyzer depends on itself",
+			Run:  run,
 		}
 		inCycleA = &Analyzer{
 			Name: "inCycleA",
 			Doc:  "this analyzer depends on inCycleB",
+			Run:  run,
 		}
 		inCycleB = &Analyzer{
 			Name: "inCycleB",
 			Doc:  "this analyzer depends on inCycleA and notInCycleA",
+			Run:  run,
 		}
 		pointsToCycle = &Analyzer{
 			Name: "pointsToCycle",
 			Doc:  "this analyzer depends on inCycleA",
+			Run:  run,
 		}
 		notInCycleA = &Analyzer{
 			Name: "notInCycleA",
 			Doc:  "this analyzer depends on notInCycleB and notInCycleC",
+			Run:  run,
 		}
 		notInCycleB = &Analyzer{
 			Name: "notInCycleB",
 			Doc:  "this analyzer depends on notInCycleC",
+			Run:  run,
 		}
 		notInCycleC = &Analyzer{
 			Name: "notInCycleC",
 			Doc:  "this analyzer has no dependencies",
+			Run:  run,
 		}
 	)
 

--- a/go/analysis/validate_test.go
+++ b/go/analysis/validate_test.go
@@ -118,6 +118,28 @@ func TestValidate(t *testing.T) {
 	}
 }
 
+func TestValidateEmptyDocOrRun(t *testing.T) {
+	withoutDoc := &Analyzer{
+		Name: "withoutDoc",
+		Run: func(p *Pass) (interface{}, error) {
+			return nil, nil
+		},
+	}
+	err := Validate([]*Analyzer{withoutDoc})
+	if err == nil || !strings.Contains(err.Error(), "is undocumented") {
+		t.Errorf("got unexpected error while validating analyzers withoutDoc: %v", err)
+	}
+
+	withoutRun := &Analyzer{
+		Name: "withoutRun",
+		Doc:  "this analyzer has no Run",
+	}
+	err = Validate([]*Analyzer{withoutRun})
+	if err == nil || !strings.Contains(err.Error(), "has nil Run") {
+		t.Errorf("got unexpected error while validating analyzers withoutRun: %v", err)
+	}
+}
+
 func TestCycleInRequiresGraphErrorMessage(t *testing.T) {
 	err := CycleInRequiresGraphError{}
 	errMsg := err.Error()


### PR DESCRIPTION
The Run function is necessary for an analyzer, if left a nil Run, the runner will panic in run-time(singlechecker.Main, etc).