### PR TITLE
internal/lsp: fix autocomplete appends on imports

### DIFF
--- a/internal/lsp/source/completion/completion.go
+++ b/internal/lsp/source/completion/completion.go
@@ -733,6 +733,10 @@ func (c *completer) emptySwitchStmt() bool {
 // (i.e. "golang.org/x/"). The user is meant to accept completion suggestions
 // until they reach a complete import path.
 func (c *completer) populateImportCompletions(ctx context.Context, searchImport *ast.ImportSpec) error {
+	if !strings.HasPrefix(searchImport.Path.Value, `"`) {
+		return nil
+	}
+
 	// deepSearch is not valuable for import completions.
 	c.deepState.enabled = false
 


### PR DESCRIPTION
Autocompleting a import without quotes appends to the completion,
producing this result: `import math "math/"`.
This commit changes to skip completions when typing a import without
quotes, because the users can be typing the alias of the import.

Fixes: golang/go#42748