### PR TITLE
gopls: update link to nvim-lspconfig gopls configuration

### DIFF
--- a/gopls/doc/vim.md
+++ b/gopls/doc/vim.md
@@ -215,5 +215,5 @@ autocmd FileType go setlocal omnifunc=v:lua.vim.lsp.omnifunc
 [govim-install]: https://github.com/myitcv/govim/blob/master/README.md#govim---go-development-plugin-for-vim8
 [nvim-docs]: https://neovim.io/doc/user/lsp.html
 [nvim-install]: https://github.com/neovim/neovim/wiki/Installing-Neovim
-[nvim-lspconfig]: https://github.com/neovim/nvim-lspconfig#gopls
+[nvim-lspconfig]: https://github.com/neovim/nvim-lspconfig/blob/master/CONFIG.md#gopls
 [nvim-lspconfig-imports]: https://github.com/neovim/nvim-lspconfig/issues/115


### PR DESCRIPTION
The README of nvim-lspconfig was restructured and now the link is out-dated. This change reflects the change and brings it up-to-date.