### PR TITLE
Allow buildutil.TagsFlag to handle comma-delimited tag lists

### DIFF
--- a/go/buildutil/tags.go
+++ b/go/buildutil/tags.go
@@ -39,7 +39,7 @@ func splitQuotedFields(s string) ([]string, error) {
 	// Quotes further inside the string do not count.
 	var f []string
 	for len(s) > 0 {
-		for len(s) > 0 && isSpaceByte(s[0]) {
+		for len(s) > 0 && isDelimiterByte(s[0]) {
 			s = s[1:]
 		}
 		if len(s) == 0 {
@@ -61,7 +61,7 @@ func splitQuotedFields(s string) ([]string, error) {
 			continue
 		}
 		i := 0
-		for i < len(s) && !isSpaceByte(s[i]) {
+		for i < len(s) && !isDelimiterByte(s[i]) {
 			i++
 		}
 		f = append(f, s[:i])
@@ -74,6 +74,6 @@ func (v *TagsFlag) String() string {
 	return "<tagsFlag>"
 }
 
-func isSpaceByte(c byte) bool {
-	return c == ' ' || c == '\t' || c == '\n' || c == '\r'
+func isDelimiterByte(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == ','
 }

--- a/go/buildutil/tags_test.go
+++ b/go/buildutil/tags_test.go
@@ -30,3 +30,21 @@ func TestTags(t *testing.T) {
 		t.Errorf("f.Args() = %q, want %q", f.Args(), want)
 	}
 }
+
+func TestTagsWithCommaDelimiter(t *testing.T) {
+	f := flag.NewFlagSet("TestTags", flag.PanicOnError)
+	var ctxt build.Context
+	f.Var((*buildutil.TagsFlag)(&ctxt.BuildTags), "tags", buildutil.TagsFlagDoc)
+	f.Parse([]string{"-tags", `'one,two,three,four'`, "rest"})
+
+	// BuildTags
+	want := []string{"one", "two", "three", "four"}
+	if !reflect.DeepEqual(ctxt.BuildTags, want) {
+		t.Errorf("BuildTags = %q, want %q", ctxt.BuildTags, want)
+	}
+
+	// Args()
+	if want := []string{"rest"}; !reflect.DeepEqual(f.Args(), want) {
+		t.Errorf("f.Args() = %q, want %q", f.Args(), want)
+	}
+}


### PR DESCRIPTION
As golang has deprecated space-delimited build tags in favor of comma-delimited, this PR allows buildutil.TagsFlag to handle comma-delimited build tags

Fixes golang/go#44787