### PR TITLE
internal/lsp/cmd: improve help output of gopls subcommands

### DIFF
--- a/internal/lsp/cmd/call_hierarchy.go
+++ b/internal/lsp/cmd/call_hierarchy.go
@@ -30,8 +30,6 @@ Example:
   $ # 1-indexed location (:line:column or :#offset) of the target identifier
   $ gopls call_hierarchy helper/helper.go:8:6
   $ gopls call_hierarchy helper/helper.go:#53
-
-  gopls call_hierarchy flags are:
 `)
 	f.PrintDefaults()
 }

--- a/internal/lsp/cmd/check.go
+++ b/internal/lsp/cmd/check.go
@@ -26,8 +26,6 @@ func (c *check) DetailedHelp(f *flag.FlagSet) {
 Example: show the diagnostic results of this file:
 
   $ gopls check internal/lsp/cmd/check.go
-
-	gopls check flags are:
 `)
 	f.PrintDefaults()
 }

--- a/internal/lsp/cmd/highlight.go
+++ b/internal/lsp/cmd/highlight.go
@@ -30,8 +30,6 @@ Example:
   $ # 1-indexed location (:line:column or :#offset) of the target identifier
   $ gopls highlight helper/helper.go:8:6
   $ gopls highlight helper/helper.go:#53
-
-  gopls highlight flags are:
 `)
 	f.PrintDefaults()
 }

--- a/internal/lsp/cmd/implementation.go
+++ b/internal/lsp/cmd/implementation.go
@@ -30,8 +30,6 @@ Example:
   $ # 1-indexed location (:line:column or :#offset) of the target identifier
   $ gopls implementation helper/helper.go:8:6
   $ gopls implementation helper/helper.go:#53
-
-  gopls implementation flags are:
 `)
 	f.PrintDefaults()
 }

--- a/internal/lsp/cmd/prepare_rename.go
+++ b/internal/lsp/cmd/prepare_rename.go
@@ -30,8 +30,6 @@ Example:
 	$ # 1-indexed location (:line:column or :#offset) of the target identifier
 	$ gopls prepare_rename helper/helper.go:8:6
 	$ gopls prepare_rename helper/helper.go:#53
-
-	gopls prepare_rename flags are:
 `)
 	f.PrintDefaults()
 }

--- a/internal/lsp/cmd/semantictokens.go
+++ b/internal/lsp/cmd/semantictokens.go
@@ -67,8 +67,6 @@ func (c *semtok) DetailedHelp(f *flag.FlagSet) {
 Example: show the semantic tokens for this file:
 
   $ gopls semtok internal/lsp/cmd/semtok.go
-
-	gopls semtok flags are:
 `)
 	f.PrintDefaults()
 }

--- a/internal/lsp/cmd/signature.go
+++ b/internal/lsp/cmd/signature.go
@@ -29,8 +29,6 @@ Example:
   $ # 1-indexed location (:line:column or :#offset) of the target identifier
   $ gopls signature helper/helper.go:8:6
   $ gopls signature helper/helper.go:#53
-
-  gopls signature flags are:
 `)
 	f.PrintDefaults()
 }


### PR DESCRIPTION
This cleans up empty flag documentation of gopls subcommands with no flags.

Fixes #43447