### PR TITLE
go/analysis: fix path to example-test.go

### DIFF
--- a/go/ssa/ssautil/load.go
+++ b/go/ssa/ssautil/load.go
@@ -129,7 +129,7 @@ func CreateProgram(lprog *loader.Program, mode ssa.BuilderMode) *ssa.Program {
 //
 // The operation fails if there were any type-checking or import errors.
 //
-// See ../ssa/example_test.go for an example.
+// See ../example_test.go for an example.
 //
 func BuildPackage(tc *types.Config, fset *token.FileSet, pkg *types.Package, files []*ast.File, mode ssa.BuilderMode) (*ssa.Package, *types.Info, error) {
 	if fset == nil {


### PR DESCRIPTION
Hello 👋 

I found the wrong path in `go/ssa/ssautil/load.go`, so fixed it.