### PR TITLE
internal/lsp: fix bad completion for variadic functions

### DIFF
--- a/internal/lsp/source/completion/completion.go
+++ b/internal/lsp/source/completion/completion.go
@@ -95,6 +95,7 @@ type completionOptions struct {
 	fullDocumentation bool
 	placeholders      bool
 	literal           bool
+	snippets          bool
 	matcher           source.Matcher
 	budget            time.Duration
 }
@@ -519,6 +520,7 @@ func Completion(ctx context.Context, snapshot source.Snapshot, fh source.FileHan
 			placeholders:      opts.UsePlaceholders,
 			literal:           opts.LiteralCompletions && opts.InsertTextFormat == protocol.SnippetTextFormat,
 			budget:            opts.CompletionBudget,
+			snippets:          opts.InsertTextFormat == protocol.SnippetTextFormat,
 		},
 		// default to a matcher that always matches
 		matcher:        prefixMatcher(""),

--- a/internal/lsp/source/completion/format.go
+++ b/internal/lsp/source/completion/format.go
@@ -150,9 +150,8 @@ func (c *completer) item(ctx context.Context, cand candidate) (CompletionItem, e
 		prefix = typeName + "(" + prefix
 		suffix = ")"
 	}
-
-	// Add variadic "..." if we are filling in a variadic param.
-	if cand.variadic {
+	// Add variadic "..." only if snippets if enabled or cand is not a function
+	if cand.variadic && (c.opts.snippets || !cand.expandFuncCall) {
 		suffix += "..."
 	}
 


### PR DESCRIPTION
Add variadic completion in functions only if snippets is enabled.

Fixes golang/go#42691