### PR TITLE
goyacc: reduce dependence on globals

### DIFF
--- a/cmd/goyacc/doc.go
+++ b/cmd/goyacc/doc.go
@@ -40,6 +40,9 @@ Error is equivalent to yyerror in the original yacc.
 Code inside the grammar actions may refer to the variable yylex,
 which holds the yyLexer passed to yyParse.
 
+Code inside the grammar actions may refer to yyrcvr,
+which holds the yyParser.
+
 Clients that need to understand more about the parser state can
 create the parser separately from invoking it. The function yyNewParser
 returns a yyParser conforming to the following interface:
@@ -47,6 +50,10 @@ returns a yyParser conforming to the following interface:
 	type yyParser interface {
 		Parse(yyLex) int
 		Lookahead() int
+		Debug() int
+		ErrorVerbose() bool
+		SetDebug(level int)
+		SetErrorVerbose(verbose bool)
 	}
 
 Parse runs the parser; the top-level call yyParse(yylex) is equivalent

--- a/cmd/goyacc/yacc.go
+++ b/cmd/goyacc/yacc.go
@@ -3277,20 +3277,53 @@ type $$Lexer interface {
 type $$Parser interface {
 	Parse($$Lexer) int
 	Lookahead() int
+	Debug() int
+	ErrorVerbose() bool
+	SetDebug(level int)
+	SetErrorVerbose(verbose bool)
 }
 
 type $$ParserImpl struct {
-	lval  $$SymType
-	stack [$$InitialStackSize]$$SymType
-	char  int
+	lval         $$SymType
+	stack        [$$InitialStackSize]$$SymType
+	char         int
+	debug        int
+	errorVerbose bool
 }
 
 func (p *$$ParserImpl) Lookahead() int {
 	return p.char
 }
 
+func (p *$$ParserImpl) Debug() int {
+	return p.debug
+}
+
+func (p *$$ParserImpl) SetDebug(level int) {
+	p.debug = level
+}
+
+func (p *$$ParserImpl) ErrorVerbose() bool {
+	return p.errorVerbose
+}
+
+func (p *$$ParserImpl) SetErrorVerbose(verbose bool) {
+	p.errorVerbose = verbose
+}
+
+
 func $$NewParser() $$Parser {
-	return &$$ParserImpl{}
+	return &$$ParserImpl{
+		debug:        $$Debug,
+		errorVerbose: $$ErrorVerbose,
+	}
+}
+
+func $$NewParserExt(debug int, errorVerbose bool) $$Parser {
+	return &$$ParserImpl{
+		debug:        debug,
+		errorVerbose: errorVerbose,
+	}
 }
 
 const $$Flag = -1000
@@ -3313,10 +3346,10 @@ func $$Statname(s int) string {
 	return __yyfmt__.Sprintf("state-%v", s)
 }
 
-func $$ErrorMessage(state, lookAhead int) string {
+func ($$rcvr *$$ParserImpl) $$ErrorMessage(state, lookAhead int) string {
 	const TOKSTART = 4
 
-	if !$$ErrorVerbose {
+	if !$$rcvr.errorVerbose {
 		return "syntax error"
 	}
 
@@ -3377,7 +3410,7 @@ func $$ErrorMessage(state, lookAhead int) string {
 	return res
 }
 
-func $$lex1(lex $$Lexer, lval *$$SymType) (char, token int) {
+func ($$rcvr *$$ParserImpl) $$lex1(lex $$Lexer, lval *$$SymType) (char, token int) {
 	token = 0
 	char = lex.Lex(lval)
 	if char <= 0 {
@@ -3406,7 +3439,7 @@ out:
 	if token == 0 {
 		token = $$Tok2[1] /* unknown char */
 	}
-	if $$Debug >= 3 {
+	if $$rcvr.debug >= 3 {
 		__yyfmt__.Printf("lex %s(%d)\n", $$Tokname(token), uint(char))
 	}
 	return char, token
@@ -3414,6 +3447,10 @@ out:
 
 func $$Parse($$lex $$Lexer) int {
 	return $$NewParser().Parse($$lex)
+}
+
+func $$ParseExt(debug int, errorVerbose bool, $$lex $$Lexer) int {
+	return $$NewParserExt(debug, errorVerbose).Parse($$lex)
 }
 
 func ($$rcvr *$$ParserImpl) Parse($$lex $$Lexer) int {
@@ -3445,7 +3482,7 @@ ret1:
 
 $$stack:
 	/* put a state and value onto the stack */
-	if $$Debug >= 4 {
+	if $$rcvr.debug >= 4 {
 		__yyfmt__.Printf("char %v in %v\n", $$Tokname($$token), $$Statname($$state))
 	}
 
@@ -3464,7 +3501,7 @@ $$newstate:
 		goto $$default /* simple state */
 	}
 	if $$rcvr.char < 0 {
-		$$rcvr.char, $$token = $$lex1($$lex, &$$rcvr.lval)
+		$$rcvr.char, $$token = $$rcvr.$$lex1($$lex, &$$rcvr.lval)
 	}
 	$$n += $$token
 	if $$n < 0 || $$n >= $$Last {
@@ -3487,7 +3524,7 @@ $$default:
 	$$n = $$Def[$$state]
 	if $$n == -2 {
 		if $$rcvr.char < 0 {
-			$$rcvr.char, $$token = $$lex1($$lex, &$$rcvr.lval)
+			$$rcvr.char, $$token = $$rcvr.$$lex1($$lex, &$$rcvr.lval)
 		}
 
 		/* look through exception table */
@@ -3513,9 +3550,9 @@ $$default:
 		/* error ... attempt to resume parsing */
 		switch Errflag {
 		case 0: /* brand new error */
-			$$lex.Error($$ErrorMessage($$state, $$token))
+			$$lex.Error($$rcvr.$$ErrorMessage($$state, $$token))
 			Nerrs++
-			if $$Debug >= 1 {
+			if $$rcvr.debug >= 1 {
 				__yyfmt__.Printf("%s", $$Statname($$state))
 				__yyfmt__.Printf(" saw %s\n", $$Tokname($$token))
 			}
@@ -3535,7 +3572,7 @@ $$default:
 				}
 
 				/* the current p has no shift on "error", pop stack */
-				if $$Debug >= 2 {
+				if $$rcvr.debug >= 2 {
 					__yyfmt__.Printf("error recovery pops state %d\n", $$S[$$p].yys)
 				}
 				$$p--
@@ -3544,7 +3581,7 @@ $$default:
 			goto ret1
 
 		case 3: /* no shift yet; clobber input char */
-			if $$Debug >= 2 {
+			if $$rcvr.debug >= 2 {
 				__yyfmt__.Printf("error recovery discards %s\n", $$Tokname($$token))
 			}
 			if $$token == $$EofCode {
@@ -3557,7 +3594,7 @@ $$default:
 	}
 
 	/* reduction by production $$n */
-	if $$Debug >= 2 {
+	if $$rcvr.debug >= 2 {
 		__yyfmt__.Printf("reduce %v in:\n\t%v\n", $$n, $$Statname($$state))
 	}
 


### PR DESCRIPTION
This is my attempt at resolving goyacc's dependence on certain global variables

Fixes golang/go#44774