### PR TITLE
go/analysis/passes/errorsas: support other packages

### DIFF
--- a/go/analysis/passes/errorsas/errorsas_test.go
+++ b/go/analysis/passes/errorsas/errorsas_test.go
@@ -16,5 +16,6 @@ import (
 
 func Test(t *testing.T) {
 	testdata := analysistest.TestData()
+	errorsas.Analyzer.Flags.Set("pkgs", "github.com/lib/errors1,github.com/lib/errors2")
 	analysistest.Run(t, testdata, errorsas.Analyzer, "a")
 }

--- a/go/analysis/passes/errorsas/testdata/src/a/a.go
+++ b/go/analysis/passes/errorsas/testdata/src/a/a.go
@@ -6,7 +6,15 @@
 
 package a
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/lib/errors1"
+	"github.com/lib/errors2"
+	"github.com/lib/errors3"
+	pkgerrors "github.com/pkg/errors"
+	xerrors "golang.org/x/xerrors"
+)
 
 type myError int
 
@@ -40,4 +48,18 @@ func _() {
 	errors.As(nil, f)   // want `second argument to errors.As must be a non-nil pointer to either a type that implements error, or to any interface type`
 	errors.As(nil, &i)  // want `second argument to errors.As must be a non-nil pointer to either a type that implements error, or to any interface type`
 	errors.As(two())
+
+	// Check other default packages
+
+	xerrors.As(nil, nil)   // want `second argument to golang.org/x/xerrors.As must be a non-nil pointer to either a type that implements error, or to any interface type`
+	pkgerrors.As(nil, nil) // want `second argument to github.com/pkg/errors.As must be a non-nil pointer to either a type that implements error, or to any interface type`
+
+	// Check packages passed via -errorsas.pkgs flag
+
+	errors1.As(nil, nil) // want `second argument to github.com/lib/errors1.As must be a non-nil pointer to either a type that implements error, or to any interface type`
+	errors2.As(nil, nil) // want `second argument to github.com/lib/errors2.As must be a non-nil pointer to either a type that implements error, or to any interface type`
+
+	// Ignore package not passed via -errorsas.pkgs flag
+
+	errors3.As(nil, nil)
 }

--- a/go/analysis/passes/errorsas/testdata/src/github.com/lib/errors1/errors.go
+++ b/go/analysis/passes/errorsas/testdata/src/github.com/lib/errors1/errors.go
@@ -1,0 +1,9 @@
+// Package errors1 contains errors.As-like function,
+// which is used in unit-testing.
+package errors1
+
+import stderrors "errors"
+
+func As(err error, target interface{}) bool {
+	return stderrors.As(err, target)
+}

--- a/go/analysis/passes/errorsas/testdata/src/github.com/lib/errors2/errors.go
+++ b/go/analysis/passes/errorsas/testdata/src/github.com/lib/errors2/errors.go
@@ -1,0 +1,9 @@
+// Package errors2 contains errors.As-like function,
+// which is used in unit-testing.
+package errors2
+
+import stderrors "errors"
+
+func As(err error, target interface{}) bool {
+	return stderrors.As(err, target)
+}

--- a/go/analysis/passes/errorsas/testdata/src/github.com/lib/errors3/errors.go
+++ b/go/analysis/passes/errorsas/testdata/src/github.com/lib/errors3/errors.go
@@ -1,0 +1,9 @@
+// Package errors3 contains errors.As-like function,
+// which is used in unit-testing.
+package errors3
+
+import stderrors "errors"
+
+func As(err error, target interface{}) bool {
+	return stderrors.As(err, target)
+}

--- a/go/analysis/passes/errorsas/testdata/src/github.com/pkg/errors/errors.go
+++ b/go/analysis/passes/errorsas/testdata/src/github.com/pkg/errors/errors.go
@@ -1,0 +1,9 @@
+// Package errors synthesizes package "github.com/pkg/errors",
+// which is used in unit-testing.
+package errors
+
+import stderrors "errors"
+
+func As(err error, target interface{}) bool {
+	return stderrors.As(err, target)
+}

--- a/go/analysis/passes/errorsas/testdata/src/golang.org/x/xerrors/xerrors.go
+++ b/go/analysis/passes/errorsas/testdata/src/golang.org/x/xerrors/xerrors.go
@@ -1,0 +1,9 @@
+// Package xerrors synthesizes package "golang.org/x/xerrors",
+// which is used in unit-testing.
+package xerrors
+
+import stderrors "errors"
+
+func As(err error, target interface{}) bool {
+	return stderrors.As(err, target)
+}


### PR DESCRIPTION
errorsas now supports other packages. By default, it checks
github.com/pkg/errors and golang.org/x/xerrors, but additional
packages can be passed via -pkgs flag.

Fixes golang/go#44784