### PR TITLE
cmd/present: Fix position for H2 in markdown slides

### DIFF
--- a/cmd/present/static/styles.css
+++ b/cmd/present/static/styles.css
@@ -319,9 +319,6 @@ h2 {
   font-size: 45px;
   line-height: 45px;
 
-  position: absolute;
-  bottom: 150px;
-
   padding: 0;
   margin: 0;
   padding-right: 40px;


### PR DESCRIPTION
When using position:absolute, H2 section headers all crowd 150px from
the bottom of the slide, making the slide unreadable.