### PR TITLE
internal/lsp/source: refactor commentToMarkdown function

### DIFF
--- a/internal/lsp/source/comment.go
+++ b/internal/lsp/source/comment.go
@@ -42,45 +42,35 @@ var (
 )
 
 func commentToMarkdown(w io.Writer, text string) {
-	isFirstLine := true
-	for _, b := range blocks(text) {
+	blocks := blocks(text)
+	for i, b := range blocks {
 		switch b.op {
 		case opPara:
-			if !isFirstLine {
-				w.Write(mdNewline)
-			}
-
 			for _, line := range b.lines {
 				emphasize(w, line, true)
 			}
 		case opHead:
-			if !isFirstLine {
-				w.Write(mdNewline)
-			}
-			w.Write(mdNewline)
+			// Header is always a single line.
+			header := b.lines[0]
 
-			for _, line := range b.lines {
-				w.Write(mdHeader)
-				commentEscape(w, line, true)
-				w.Write(mdNewline)
-			}
+			w.Write(mdHeader)
+			commentEscape(w, header, true)
+			// Header doesn't end with \n unlike the lines of other blocks.
+			w.Write(mdNewline)
 		case opPre:
-			if !isFirstLine {
-				w.Write(mdNewline)
-			}
-			w.Write(mdNewline)
-
 			for _, line := range b.lines {
 				if isBlank(line) {
 					w.Write(mdNewline)
-				} else {
-					w.Write(mdIndent)
-					w.Write([]byte(line))
-					w.Write(mdNewline)
+					continue
 				}
+				w.Write(mdIndent)
+				w.Write([]byte(line))
 			}
 		}
-		isFirstLine = false
+
+		if i < len(blocks)-1 {
+			w.Write(mdNewline)
+		}
 	}
 }
 

--- a/internal/lsp/source/comment.go
+++ b/internal/lsp/source/comment.go
@@ -50,7 +50,12 @@ func commentToMarkdown(w io.Writer, text string) {
 				emphasize(w, line, true)
 			}
 		case opHead:
-			// Header is always a single line.
+			// The header block can consist of only one line.
+			// However, check the number of lines, just in case.
+			if len(b.lines) == 0 {
+				// Skip this block.
+				continue
+			}
 			header := b.lines[0]
 
 			w.Write(mdHeader)

--- a/internal/lsp/source/comment_test.go
+++ b/internal/lsp/source/comment_test.go
@@ -228,3 +228,141 @@ func TestCommentEscape(t *testing.T) {
 		}
 	}
 }
+
+func TestCommentToMarkdown(t *testing.T) {
+	tests := []struct {
+		in, out string
+	}{
+		{
+			in:  "F declaration.\n",
+			out: "F declaration\\.\n",
+		},
+		{
+			in: `
+F declaration. Lorem ipsum dolor sit amet.
+Etiam mattis eros at orci mollis molestie.
+`,
+			out: `
+F declaration\. Lorem ipsum dolor sit amet\.
+Etiam mattis eros at orci mollis molestie\.
+`,
+		},
+		{
+			in: `
+F declaration.
+
+Lorem ipsum dolor sit amet.
+Sed id dui turpis.
+
+
+
+
+Aenean tempus velit non auctor eleifend.
+Aenean efficitur a sem id ultricies.
+
+
+Phasellus efficitur mauris et viverra bibendum.
+`,
+			out: `
+F declaration\.
+
+Lorem ipsum dolor sit amet\.
+Sed id dui turpis\.
+
+Aenean tempus velit non auctor eleifend\.
+Aenean efficitur a sem id ultricies\.
+
+Phasellus efficitur mauris et viverra bibendum\.
+`,
+		},
+		{
+			in: `
+F declaration.
+
+Aenean tempus velit non auctor eleifend.
+
+Section
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+
+  func foo() {}
+
+
+  func bar() {}
+
+Fusce lorem lacus.
+
+    func foo() {}
+
+    func bar() {}
+
+Maecenas in lobortis lectus.
+
+	func foo() {}
+
+	func bar() {}
+
+Phasellus efficitur mauris et viverra bibendum.
+`,
+			out: `
+F declaration\.
+
+Aenean tempus velit non auctor eleifend\.
+
+### Section
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit\.
+
+    func foo() {}
+
+
+    func bar() {}
+
+Fusce lorem lacus\.
+
+    func foo() {}
+
+    func bar() {}
+
+Maecenas in lobortis lectus\.
+
+    func foo() {}
+
+    func bar() {}
+
+Phasellus efficitur mauris et viverra bibendum\.
+`,
+		},
+		{
+			in: `
+F declaration.
+
+	func foo() {
+		fmt.Println("foo")
+	}
+	func bar() {
+		fmt.Println("bar")
+	}
+`,
+			out: `
+F declaration\.
+
+    func foo() {
+    	fmt.Println("foo")
+    }
+    func bar() {
+    	fmt.Println("bar")
+    }
+`,
+		},
+	}
+	for i, tt := range tests {
+		// Comments start with new lines for better readability. So, we should trim them.
+		tt.in = strings.TrimPrefix(tt.in, "\n")
+		tt.out = strings.TrimPrefix(tt.out, "\n")
+
+		if out := CommentToMarkdown(tt.in); out != tt.out {
+			t.Errorf("#%d: mismatch\nhave: %q\nwant: %q", i, out, tt.out)
+		}
+	}
+}


### PR DESCRIPTION
This change simplifies the code and fixes the issue with
extra new lines. It also adds unit tests.

Fixes golang/go#43257