### PR TITLE
fix the argument of the goimports example

### DIFF
--- a/gopls/doc/vim.md
+++ b/gopls/doc/vim.md
@@ -164,7 +164,7 @@ a helper function in Lua:
 lua <<EOF
   -- …
 
-  function goimports(timeoutms)
+  function goimports(timeout_ms)
     local context = { source = { organizeImports = true } }
     vim.validate { context = { context, "t", true } }
 


### PR DESCRIPTION
After the last code correction, the name of the argument is different from the name used in the code.
Was "timeoutms" became "timeout_ms"