### PR TITLE
internal/lsp/source: fix an infinite loop in Deref function

### DIFF
--- a/gopls/internal/regtest/completion/completion_test.go
+++ b/gopls/internal/regtest/completion/completion_test.go
@@ -374,3 +374,40 @@ type S struct {
 		}
 	})
 }
+
+func TestCompletion_Issue45510(t *testing.T) {
+	const files = `
+-- go.mod --
+module mod.com
+
+go 1.12
+-- main.go --
+package main
+
+func _() {
+	type a *a
+	var aaaa1, aaaa2 a
+	var _ a = aaaa
+
+	type b a
+	var bbbb1, bbbb2 b
+	var _ b = bbbb
+}
+`
+
+	Run(t, files, func(t *testing.T, env *Env) {
+		env.OpenFile("main.go")
+
+		completions := env.Completion("main.go", env.RegexpSearch("main.go", `var _ a = aaaa()`))
+		diff := compareCompletionResults([]string{"aaaa1", "aaaa2"}, completions.Items)
+		if diff != "" {
+			t.Fatal(diff)
+		}
+
+		completions = env.Completion("main.go", env.RegexpSearch("main.go", `var _ b = bbbb()`))
+		diff = compareCompletionResults([]string{"bbbb1", "bbbb2"}, completions.Items)
+		if diff != "" {
+			t.Fatal(diff)
+		}
+	})
+}

--- a/internal/lsp/source/util.go
+++ b/internal/lsp/source/util.go
@@ -221,10 +221,15 @@ func FormatNode(fset *token.FileSet, n ast.Node) string {
 
 // Deref returns a pointer's element type, traversing as many levels as needed.
 // Otherwise it returns typ.
+//
+// It can return a pointer type if the type refers to itself (see golang/go#45510).
 func Deref(typ types.Type) types.Type {
 	for {
 		p, ok := typ.Underlying().(*types.Pointer)
 		if !ok {
+			return typ
+		}
+		if typ == p.Elem() {
 			return typ
 		}
 		typ = p.Elem()


### PR DESCRIPTION
Return a pointer type if the type refers to itself (for example, type a *a).

Fixes golang/go#45510