### PR TITLE
gopls/internal/hooks: respect the default checks of the staticcheck tool

### DIFF
--- a/gopls/internal/regtest/misc/configuration_test.go
+++ b/gopls/internal/regtest/misc/configuration_test.go
@@ -27,8 +27,10 @@ go 1.12
 -- a/a.go --
 package a
 
-// NotThisVariable should really start with ThisVariable.
-const ThisVariable = 7
+import "errors"
+
+// FooErr should be called ErrFoo (ST1012)
+var FooErr = errors.New("foo")
 `
 	Run(t, files, func(t *testing.T, env *Env) {
 		env.OpenFile("a/a.go")
@@ -41,7 +43,7 @@ const ThisVariable = 7
 		cfg.EnableStaticcheck = true
 		env.ChangeConfiguration(t, cfg)
 		env.Await(
-			DiagnosticAt("a/a.go", 2, 0),
+			DiagnosticAt("a/a.go", 5, 4),
 		)
 	})
 }

--- a/internal/lsp/source/options.go
+++ b/internal/lsp/source/options.go
@@ -680,8 +680,8 @@ func (o *Options) Clone() *Options {
 	return result
 }
 
-func (o *Options) AddStaticcheckAnalyzer(a *analysis.Analyzer) {
-	o.StaticcheckAnalyzers[a.Name] = &Analyzer{Analyzer: a, Enabled: true}
+func (o *Options) AddStaticcheckAnalyzer(a *analysis.Analyzer, enabled bool) {
+	o.StaticcheckAnalyzers[a.Name] = &Analyzer{Analyzer: a, Enabled: enabled}
 }
 
 // enableAllExperiments turns on all of the experimental "off-by-default"


### PR DESCRIPTION
Disable non-default checks by default. Also, update the regression
test because the previous version used a non-default check (ST1022).

Fixes golang/go#44712