### PR TITLE
Try to simplify goimports

### DIFF
--- a/internal/imports/sortimports.go
+++ b/internal/imports/sortimports.go
@@ -34,18 +34,7 @@ func sortImports(localPrefix string, fset *token.FileSet, f *ast.File) {
 			continue
 		}
 
-		// Identify and sort runs of specs on successive lines.
-		i := 0
-		specs := d.Specs[:0]
-		for j, s := range d.Specs {
-			if j > i && fset.Position(s.Pos()).Line > 1+fset.Position(d.Specs[j-1].End()).Line {
-				// j begins a new run.  End this one.
-				specs = append(specs, sortSpecs(localPrefix, fset, f, d.Specs[i:j])...)
-				i = j
-			}
-		}
-		specs = append(specs, sortSpecs(localPrefix, fset, f, d.Specs[i:])...)
-		d.Specs = specs
+		d.Specs = sortSpecs(localPrefix, fset, f, d.Specs)
 
 		// Deduping can leave a blank line before the rparen; clean that up.
 		if len(d.Specs) > 0 {


### PR DESCRIPTION
Related to:
- https://github.com/golang/tools/pull/68
- https://github.com/golang/tools/pull/150

It tries to fix:
- https://github.com/golang/go/issues/20818
- https://github.com/golang/go/issues/43193

Appears in:
- https://github.com/golang/go/issues/36140
- https://github.com/golang/go/issues/35879

### Example

the input

```go
package testdata

import (
	_ "net"
	_ "encoding"

	_ "golang.org/x/mod/semver"

	_ "golang.org/x/sync/errgroup"

	_ "golang.org/x/tools/internal/imports"
)
```

#### Current behaviour

```bash
$ goimports testdata/example.go
package testdata

import (
        _ "encoding"
        _ "net"

        _ "golang.org/x/mod/semver"

        _ "golang.org/x/sync/errgroup"

        _ "golang.org/x/tools/internal/imports"
)

$ goimports -local golang.org/x/tools testdata/example.go
package testdata

import (
        _ "encoding"
        _ "net"

        _ "golang.org/x/mod/semver"

        _ "golang.org/x/sync/errgroup"

        _ "golang.org/x/tools/internal/imports"
)

$ goimports -local golang.org/x/tools,golang.org/x/mod testdata/example.go
package testdata

import (
        _ "encoding"
        _ "net"

        _ "golang.org/x/mod/semver"

        _ "golang.org/x/sync/errgroup"

        _ "golang.org/x/tools/internal/imports"
)
```

#### Patched behavior

```bash
$ ./patched testdata/example.go
package testdata

import (
        _ "encoding"
        _ "net"

        _ "golang.org/x/mod/semver"
        _ "golang.org/x/sync/errgroup"
        _ "golang.org/x/tools/internal/imports"
)

$ ./patched -local golang.org/x/tools testdata/example.go
package testdata

import (
        _ "encoding"
        _ "net"

        _ "golang.org/x/mod/semver"
        _ "golang.org/x/sync/errgroup"

        _ "golang.org/x/tools/internal/imports"
)

$ ./patched -local golang.org/x/tools,golang.org/x/mod testdata/example.go
package testdata

import (
	_ "encoding"
	_ "net"

	_ "golang.org/x/sync/errgroup"

	_ "golang.org/x/mod/semver"
	_ "golang.org/x/tools/internal/imports"
)
```
