### PR TITLE
Features for godoc to show packages

### DIFF
--- a/godoc/pres.go
+++ b/godoc/pres.go
@@ -47,6 +47,9 @@ type Presentation struct {
 	ShowPlayground bool
 	DeclLinks      bool
 
+	// ShowInternalPkg optionally shows the internal packages from GoMod module
+	ShowInternalPkg bool
+
 	// NotesRx optionally specifies a regexp to match
 	// notes to render in the output.
 	NotesRx *regexp.Regexp
@@ -149,6 +152,10 @@ func (p *Presentation) PkgFSRoot() string {
 
 func (p *Presentation) CmdFSRoot() string {
 	return p.cmdHandler.fsRoot
+}
+
+func (p* Presentation) AddPkgExclude(path string) {
+	p.pkgHandler.exclude = append(p.pkgHandler.exclude, path)
 }
 
 // TODO(bradfitz): move this to be a method on Corpus. Just moving code around for now,


### PR DESCRIPTION
This PR does respect and extend the GOMOD mode for `godoc` when having a `go.mod`.

In addition a new flag `-show_internal_pkg` was created to show the internal packages for the _Standard library_ as default without need to set `?m=all`

Also the packages from `/third_party/` path are skipped without showing `m=all`

All tests on `godoc`and `cmd/godoc` have passed.