### PR TITLE
Newline to separate text from previous item in settings.md

### DIFF
--- a/gopls/doc/settings.md
+++ b/gopls/doc/settings.md
@@ -228,6 +228,7 @@ Must be one of:
 * `"CaseInsensitive"`
 * `"CaseSensitive"`
 * `"Fuzzy"`
+
 Default: `"Fuzzy"`.
 
 ##### **experimentalPostfixCompletions** *bool*
@@ -319,6 +320,7 @@ can do more manipulation of these fields.\
 This should only be used by clients that support this behavior.
 
 * `"SynopsisDocumentation"`
+
 Default: `"FullDocumentation"`.
 
 ##### **linkTarget** *string*
@@ -351,6 +353,7 @@ Must be one of:
 * `"Both"`
 * `"Definition"`
 * `"Link"`
+
 Default: `"Both"`.
 
 ##### **symbolMatcher** *enum*
@@ -364,6 +367,7 @@ Must be one of:
 * `"CaseInsensitive"`
 * `"CaseSensitive"`
 * `"Fuzzy"`
+
 Default: `"Fuzzy"`.
 
 ##### **symbolStyle** *enum*


### PR DESCRIPTION
If there is no empty newline between the last item in a list and a line of text not in the list, Github will render them as a single line in the last list item.