### PR TITLE
x/tools/go/analysis/passes/copylock: detect copylock in multi-assignment

### DIFF
--- a/go/analysis/passes/copylock/copylock.go
+++ b/go/analysis/passes/copylock/copylock.go
@@ -282,6 +282,17 @@ func lockPath(tpkg *types.Package, typ types.Type) typePath {
 		typ = atyp.Elem()
 	}
 
+	ttyp, ok := typ.Underlying().(*types.Tuple)
+	if ok {
+		for i := 0; i < ttyp.Len(); i++ {
+			subpath := lockPath(tpkg, ttyp.At(i).Type())
+			if subpath != nil {
+				return append(subpath, typ.String())
+			}
+		}
+		return nil
+	}
+
 	// We're only interested in the case in which the underlying
 	// type is a struct. (Interfaces and pointers are safe to copy.)
 	styp, ok := typ.Underlying().(*types.Struct)

--- a/go/analysis/passes/copylock/testdata/src/a/copylock.go
+++ b/go/analysis/passes/copylock/testdata/src/a/copylock.go
@@ -89,6 +89,14 @@ func BadFunc() {
 	fmuB := fmuA        // OK
 	fmuA = fmuB         // OK
 	fmuSlice := fmuA[:] // OK
+
+	// map access by single and tuple copies prohibited
+	type mut struct{ mu sync.Mutex }
+	muM := map[string]mut{
+		"a": mut{},
+	}
+	mumA := muM["a"]    // want "assignment copies lock value to mumA: a.mut contains sync.Mutex"
+	mumB, _ := muM["a"] // want "assignment copies lock value to mumB: \\(a.mut, bool\\) contains a.mut contains sync.Mutex"
 }
 
 func LenAndCapOnLockArrays() {


### PR DESCRIPTION
The existing implementation does not identify lock copies when doing
multi-assignment, i.e. foo, ok := someMap["key"]

Currently, it will find issue with similar code foo := someMap["key"].

This discrepency is because a return type of Tuple was not considered
when resolving the type of the right hand side of the assignment.

Fixes #45896