### PR TITLE
internal/lsp: include function literals in outgoing call hierarchy

### DIFF
--- a/internal/lsp/source/call_hierarchy.go
+++ b/internal/lsp/source/call_hierarchy.go
@@ -223,6 +223,10 @@ func collectCallExpressions(fset *token.FileSet, mapper *protocol.ColumnMapper, 
 				start, end = n.Sel.NamePos, call.Lparen
 			case *ast.Ident:
 				start, end = n.NamePos, call.Lparen
+			case *ast.FuncLit:
+				// while we don't add the function literal as an 'outgoing' call
+				// we still want to traverse into it
+				return true
 			default:
 				// ignore any other kind of call expressions
 				// for ex: direct function literal calls since that's not an 'outgoing' call

--- a/internal/lsp/testdata/callhierarchy/callhierarchy.go
+++ b/internal/lsp/testdata/callhierarchy/callhierarchy.go
@@ -30,10 +30,13 @@ func D() { //@mark(hierarchyD, "D"),incomingcalls(hierarchyD, hierarchyA, hierar
 	e()
 	x()
 	F()
-	g()
 	outgoing.B()
 	foo := func() {} //@mark(hierarchyFoo, "foo"),incomingcalls(hierarchyFoo, hierarchyD),outgoingcalls(hierarchyFoo)
 	foo()
+
+	func() {
+		g()
+	}()
 
 	var i Interface = impl{}
 	i.H()


### PR DESCRIPTION
internal/lsp: include function literals in outgoing call hierarchy

Currently we don't consider function literals in outgoing call
hierarchy, because we only consider expressions of type
`ast.SelectorExpr` and `ast.Ident`. So function literals are skipped.
Fix this by ensuring we traverse through other types even if we
don't add the type itself as an outgoing call hierarchy.

Fixes golang/go#43438

Signed-off-by: Karthik Nayak <karthik.188@gmail.com>