### PR TITLE
 internal/lsp: do not block on channel when there is an error

### DIFF
--- a/internal/lsp/cmd/cmd.go
+++ b/internal/lsp/cmd/cmd.go
@@ -527,8 +527,13 @@ func (c *connection) diagnoseFiles(ctx context.Context, files []span.URI) error 
 
 	c.Client.diagnosticsDone = make(chan struct{})
 	_, err := c.Server.NonstandardRequest(ctx, "gopls/diagnoseFiles", map[string]interface{}{"files": untypedFiles})
+	if err != nil {
+		close(c.Client.diagnosticsDone)
+		return err
+	}
+
 	<-c.Client.diagnosticsDone
-	return err
+	return nil
 }
 
 func (c *connection) terminate(ctx context.Context) {


### PR DESCRIPTION
In `internal/lsp/cmd.(*connection).diagnoseFiles`, when we request for
`gopls/diagnoseFiles`, we are blocked on the channel even if there is an error.
In such a scenario, we've reach a deadlock since. Avoid this by checking for
error, existing if it exists and also closing the channel while we're at it.

Fixes golang/go#46251

Signed-off-by: Karthik Nayak <karthik.188@gmail.com>