### PR TITLE
internal/lsp/source: add an option to keep original comment line breaks in hover

### DIFF
--- a/gopls/doc/settings.md
+++ b/gopls/doc/settings.md
@@ -359,6 +359,12 @@ linksInHover toggles the presence of links to documentation in hover.
 
 Default: `true`.
 
+##### **keepOriginalLineBreaks** *bool*
+
+keepOriginalLineBreaks can be used to keep the original comment line breaks in hover.
+
+Default: `false`.
+
 #### Navigation
 
 ##### **importShortcut** *enum*

--- a/internal/lsp/source/api_json.go
+++ b/internal/lsp/source/api_json.go
@@ -218,6 +218,19 @@ var GeneratedAPIJSON = &APIJSON{
 				Hierarchy:  "ui.documentation",
 			},
 			{
+				Name: "keepOriginalLineBreaks",
+				Type: "bool",
+				Doc:  "keepOriginalLineBreaks can be used to keep the original comment line breaks in hover.\n",
+				EnumKeys: EnumKeys{
+					ValueType: "",
+					Keys:      nil,
+				},
+				EnumValues: nil,
+				Default:    "false",
+				Status:     "",
+				Hierarchy:  "ui.documentation",
+			},
+			{
 				Name: "usePlaceholders",
 				Type: "bool",
 				Doc:  "placeholders enables placeholders for function parameters or struct\nfields in completion responses.\n",

--- a/internal/lsp/source/comment.go
+++ b/internal/lsp/source/comment.go
@@ -26,9 +26,9 @@ import (
 // prefix removed unless empty, in which case it will be converted to a newline.
 //
 // URLs in the comment text are converted into links.
-func CommentToMarkdown(text string) string {
+func CommentToMarkdown(text string, keepOriginalLineBreaks bool) string {
 	buf := &bytes.Buffer{}
-	commentToMarkdown(buf, text)
+	commentToMarkdown(buf, text, keepOriginalLineBreaks)
 	return buf.String()
 }
 
@@ -41,12 +41,15 @@ var (
 	mdLinkEnd   = []byte(")")
 )
 
-func commentToMarkdown(w io.Writer, text string) {
+func commentToMarkdown(w io.Writer, text string, keepOriginalLineBreaks bool) {
 	blocks := blocks(text)
 	for i, b := range blocks {
 		switch b.op {
 		case opPara:
-			for _, line := range b.lines {
+			for j, line := range b.lines {
+				if keepOriginalLineBreaks && j < len(b.lines)-1 {
+					line = strings.Replace(line, "\n", "  \n", 1)
+				}
 				emphasize(w, line, true)
 			}
 		case opHead:

--- a/internal/lsp/source/comment_test.go
+++ b/internal/lsp/source/comment_test.go
@@ -231,7 +231,8 @@ func TestCommentEscape(t *testing.T) {
 
 func TestCommentToMarkdown(t *testing.T) {
 	tests := []struct {
-		in, out string
+		in, out        string
+		keepLineBreaks bool
 	}{
 		{
 			in:  "F declaration.\n",
@@ -355,13 +356,26 @@ F declaration\.
     }
 `,
 		},
+		{
+			in: `
+F declaration. Lorem ipsum dolor sit amet.
+Aenean tempus velit non auctor eleifend.
+Etiam mattis eros at orci mollis molestie.
+`,
+			out: `
+F declaration\. Lorem ipsum dolor sit amet\.  
+Aenean tempus velit non auctor eleifend\.  
+Etiam mattis eros at orci mollis molestie\.
+`,
+			keepLineBreaks: true,
+		},
 	}
 	for i, tt := range tests {
 		// Comments start with new lines for better readability. So, we should trim them.
 		tt.in = strings.TrimPrefix(tt.in, "\n")
 		tt.out = strings.TrimPrefix(tt.out, "\n")
 
-		if out := CommentToMarkdown(tt.in); out != tt.out {
+		if out := CommentToMarkdown(tt.in, tt.keepLineBreaks); out != tt.out {
 			t.Errorf("#%d: mismatch\nhave: %q\nwant: %q", i, out, tt.out)
 		}
 	}

--- a/internal/lsp/source/hover.go
+++ b/internal/lsp/source/hover.go
@@ -551,7 +551,7 @@ func BuildLink(target, path, anchor string) string {
 
 func formatDoc(doc string, options *Options) string {
 	if options.PreferredContentFormat == protocol.Markdown {
-		return CommentToMarkdown(doc)
+		return CommentToMarkdown(doc, options.KeepOriginalLineBreaks)
 	}
 	return doc
 }

--- a/internal/lsp/source/options.go
+++ b/internal/lsp/source/options.go
@@ -121,9 +121,10 @@ func DefaultOptions() *Options {
 						},
 					},
 					DocumentationOptions: DocumentationOptions{
-						HoverKind:    FullDocumentation,
-						LinkTarget:   "pkg.go.dev",
-						LinksInHover: true,
+						HoverKind:              FullDocumentation,
+						LinkTarget:             "pkg.go.dev",
+						LinksInHover:           true,
+						KeepOriginalLineBreaks: false,
 					},
 					NavigationOptions: NavigationOptions{
 						ImportShortcut: Both,
@@ -339,6 +340,9 @@ type DocumentationOptions struct {
 
 	// LinksInHover toggles the presence of links to documentation in hover.
 	LinksInHover bool
+
+	// KeepOriginalLineBreaks can be used to keep the original comment line breaks in hover.
+	KeepOriginalLineBreaks bool
 }
 
 type FormattingOptions struct {


### PR DESCRIPTION
Add a new documentation option `KeepOriginalLineBreaks` to keep original
comment line breaks in hover. When the option is set to `true`, we add
2 spaces just before newline characters. This logic doesn't apply to
code blocks and headers.

Fixes golang/go#44684