### PR TITLE
x/tools/go/callgraph: incorrect document in type Edge struct

### DIFF
--- a/go/callgraph/callgraph.go
+++ b/go/callgraph/callgraph.go
@@ -89,7 +89,7 @@ func (n *Node) String() string {
 // A Edge represents an edge in the call graph.
 //
 // Site is nil for edges originating in synthetic or intrinsic
-// functions, e.g. reflect.Call or the root of the call graph.
+// functions, e.g. reflect.Value.Call or the root of the call graph.
 type Edge struct {
 	Caller *Node
 	Site   ssa.CallInstruction


### PR DESCRIPTION
https://github.com/golang/go/issues/46973
This pull request fixes incorrect document related to above.
I believe that this works well.