### PR TITLE
internal/lsp: skip signature help within a string literal

### DIFF
--- a/internal/lsp/source/signature_help.go
+++ b/internal/lsp/source/signature_help.go
@@ -51,7 +51,12 @@ FindCall:
 			// which may be the parameter to the *ast.CallExpr.
 			// Don't show signature help in this case.
 			return nil, 0, errors.Errorf("no signature help within a function declaration")
+		case *ast.BasicLit:
+			if node.Kind == token.STRING {
+				return nil, 0, errors.Errorf("no signature help within a string literal")
+			}
 		}
+
 	}
 	if callExpr == nil || callExpr.Fun == nil {
 		return nil, 0, errors.Errorf("cannot find an enclosing function")

--- a/internal/lsp/testdata/signature/signature.go
+++ b/internal/lsp/testdata/signature/signature.go
@@ -47,11 +47,12 @@ func Qux() {
 		return func(int) rune { return 0 }
 	}
 
-	fn("hi", "there")    //@signature("hi", "fn(hi string, there string) func(i int) rune", 0)
+	fn("hi", "there")    //@signature("hi", "", 0)
+	fn("hi", "there")    //@signature(",", "fn(hi string, there string) func(i int) rune", 0)
 	fn("hi", "there")(1) //@signature("1", "func(i int) rune", 0)
 
 	fnPtr := &fn
-	(*fnPtr)("hi", "there") //@signature("hi", "func(hi string, there string) func(i int) rune", 0)
+	(*fnPtr)("hi", "there") //@signature(",", "func(hi string, there string) func(i int) rune", 0)
 
 	var fnIntf interface{} = Foo
 	fnIntf.(func(string, int) bool)("hi", 123) //@signature("123", "func(string, int) bool", 1)
@@ -69,8 +70,8 @@ func Qux() {
 	Foo(myFunc(123), 456) //@signature("myFunc", "Foo(a string, b int) (c bool)", 0)
 	Foo(myFunc(123), 456) //@signature("123", "myFunc(foo int) string", 0)
 
-	panic("oops!")            //@signature("oops", "panic(v interface{})", 0)
-	println("hello", "world") //@signature("world", "println(args ...Type)", 0)
+	panic("oops!")            //@signature(")", "panic(v interface{})", 0)
+	println("hello", "world") //@signature(",", "println(args ...Type)", 0)
 
 	Hello(func() {
 		//@signature("//", "", 0)

--- a/internal/lsp/testdata/summary.txt.golden
+++ b/internal/lsp/testdata/summary.txt.golden
@@ -23,7 +23,7 @@ RenamesCount = 33
 PrepareRenamesCount = 7
 SymbolsCount = 5
 WorkspaceSymbolsCount = 20
-SignaturesCount = 32
+SignaturesCount = 33
 LinksCount = 7
 ImplementationsCount = 14
 


### PR DESCRIPTION
Currently the `SignatureHelp` function provides signature help even when the
requested range lies within a string literal. Let's suppress this behavior and
return an error when someone requests signature help from within a string
literal.

Fixes golang/go#43397

Signed-off-by: Karthik Nayak <karthik.188@gmail.com>