### PR TITLE
internal/lsp/cache: improve open out of workspace file full parse.

### DIFF
--- a/internal/lsp/cache/check.go
+++ b/internal/lsp/cache/check.go
@@ -202,6 +202,9 @@ func (s *snapshot) workspaceParseMode(id PackageID) source.ParseMode {
 	defer s.mu.Unlock()
 	_, ws := s.workspacePackages[id]
 	if !ws {
+		if s.view.Options().MemoryMode == source.ModeAll {
+			return source.ParseFull
+		}
 		return source.ParseExported
 	}
 	if s.view.Options().MemoryMode == source.ModeNormal {

--- a/internal/lsp/source/options.go
+++ b/internal/lsp/source/options.go
@@ -583,6 +583,9 @@ const (
 type MemoryMode string
 
 const (
+	// In All mode, include dependent module all information.
+	ModeAll MemoryMode = "All"
+
 	ModeNormal MemoryMode = "Normal"
 	// In DegradeClosed mode, `gopls` will collect less information about
 	// packages without open files. As a result, features like Find


### PR DESCRIPTION
Normal mode solves the problem of excessive memory consumption, but if my machine has enough memory, I still want a complete code prompt experience