### PR TITLE
go/ssa: fix build.expr0 ast.SliceExpr Low and High expr sequence

### DIFF
--- a/go/ssa/builder.go
+++ b/go/ssa/builder.go
@@ -654,11 +654,11 @@ func (b *builder) expr0(fn *Function, e ast.Expr, tv types.TypeAndValue) Value {
 		default:
 			panic("unreachable")
 		}
-		if e.High != nil {
-			high = b.expr(fn, e.High)
-		}
 		if e.Low != nil {
 			low = b.expr(fn, e.Low)
+		}
+		if e.High != nil {
+			high = b.expr(fn, e.High)
 		}
 		if e.Slice3 {
 			max = b.expr(fn, e.Max)

--- a/go/ssa/interp/interp_test.go
+++ b/go/ssa/interp/interp_test.go
@@ -92,7 +92,8 @@ var gorootTestTests = []string{
 	"convT2X.go",
 	"switch.go",
 	"ddd.go",
-	"blank.go", // partly disabled
+	"blank.go",            // partly disabled
+	"fixedbugs/bug261.go", // slice evaluation order
 	"closedchan.go",
 	"divide.go",
 	"rename.go",


### PR DESCRIPTION
fix go/ssa Instruction slice low:high expr sequence

slice[low():high()] 
```
low()
high()
```