### PR TITLE
internal/lsp: foldable multiline strings

### DIFF
--- a/internal/lsp/source/folding_range.go
+++ b/internal/lsp/source/folding_range.go
@@ -106,6 +106,11 @@ func foldingRangeFunc(fset *token.FileSet, m *protocol.ColumnMapper, n ast.Node,
 			startSpecs, endSpecs = n.Specs[0].Pos(), n.Specs[num-1].End()
 		}
 		start, end = validLineFoldingRange(fset, n.Lparen, n.Rparen, startSpecs, endSpecs, lineFoldingOnly)
+	case *ast.BasicLit:
+		// Fold raw string literals from position of "`" to position of "`".
+		if n.Kind == token.STRING && len(n.Value) >= 2 && n.Value[0] == '`' && n.Value[len(n.Value)-1] == '`' {
+			start, end = n.Pos(), n.End()
+		}
 	case *ast.CompositeLit:
 		// Fold between positions of or lines between "{" and "}".
 		var startElts, endElts token.Pos

--- a/internal/lsp/testdata/folding/a.go.golden
+++ b/internal/lsp/testdata/folding/a.go.golden
@@ -34,9 +34,7 @@ func bar() string {
 	x, y := make(<>), make(<>)
 	select {<>}
 	// This is a multiline comment<>
-	return `
-this string
-is not indented`
+	return <>
 }
 
 -- foldingRange-2 --
@@ -283,6 +281,7 @@ is not indented`
 67:10-68:24
 68:15-68:23
 70:32-71:30
+72:9-74:16
 
 -- foldingRange-comment-0 --
 package folding //@fold("package")
@@ -474,9 +473,7 @@ func bar() string {
 	select {<>
 	}
 	// This is a multiline comment<>
-	return `
-this string
-is not indented`
+	return <>
 }
 
 -- foldingRange-lineFolding-2 --


### PR DESCRIPTION
This commit adds support for detecting multiline strings for folding
ranges.

Fixes golang/go#49554