### PR TITLE
gopls: replace `directory` directive with `use` for `go.work`

### DIFF
--- a/gopls/internal/regtest/workspace/workspace_test.go
+++ b/gopls/internal/regtest/workspace/workspace_test.go
@@ -14,12 +14,11 @@ import (
 	"testing"
 
 	"golang.org/x/tools/gopls/internal/hooks"
-	. "golang.org/x/tools/internal/lsp/regtest"
-	"golang.org/x/tools/internal/lsp/source"
-
 	"golang.org/x/tools/internal/lsp/command"
 	"golang.org/x/tools/internal/lsp/fake"
 	"golang.org/x/tools/internal/lsp/protocol"
+	. "golang.org/x/tools/internal/lsp/regtest"
+	"golang.org/x/tools/internal/lsp/source"
 	"golang.org/x/tools/internal/testenv"
 )
 
@@ -684,7 +683,7 @@ func Hello() int {
 -- go.work --
 go 1.17
 
-directory (
+use (
 	./moda/a
 )
 `
@@ -717,7 +716,7 @@ directory (
 		env.WriteWorkspaceFile("go.work", `
 go 1.17
 
-directory (
+use (
 	./moda/a
 	./modb
 )
@@ -748,7 +747,7 @@ directory (
 		env.Await(env.DoneWithOpen())
 		env.SetBufferContent("go.work", `go 1.17
 
-directory (
+use (
 	./moda/a
 )`)
 
@@ -1148,7 +1147,7 @@ func main() {}
 		)
 		env.WriteWorkspaceFile("go.work", `go 1.16
 
-directory (
+use (
 	a
 	b
 )

--- a/internal/lsp/cache/workspace.go
+++ b/internal/lsp/cache/workspace.go
@@ -14,12 +14,13 @@ import (
 	"sync"
 
 	"golang.org/x/mod/modfile"
+	errors "golang.org/x/xerrors"
+
 	"golang.org/x/tools/internal/event"
 	"golang.org/x/tools/internal/lsp/source"
 	workfile "golang.org/x/tools/internal/mod/modfile"
 	"golang.org/x/tools/internal/span"
 	"golang.org/x/tools/internal/xcontext"
-	errors "golang.org/x/xerrors"
 )
 
 type workspaceSource int
@@ -489,7 +490,7 @@ func parseGoWork(ctx context.Context, root, uri span.URI, contents []byte, fs so
 		return nil, nil, errors.Errorf("parsing go.work: %w", err)
 	}
 	modFiles := make(map[span.URI]struct{})
-	for _, dir := range workFile.Directory {
+	for _, dir := range workFile.Use {
 		// The resulting modfile must use absolute paths, so that it can be
 		// written to a temp directory.
 		dir.DiskPath = absolutePath(root, dir.DiskPath)

--- a/internal/mod/modfile/rule.go
+++ b/internal/mod/modfile/rule.go
@@ -29,20 +29,21 @@ import (
 
 	"golang.org/x/mod/modfile"
 	"golang.org/x/mod/module"
+
 	"golang.org/x/tools/internal/mod/lazyregexp"
 )
 
 // A WorkFile is the parsed, interpreted form of a go.work file.
 type WorkFile struct {
-	Go        *modfile.Go
-	Directory []*Directory
-	Replace   []*modfile.Replace
+	Go      *modfile.Go
+	Use     []*Use
+	Replace []*modfile.Replace
 
 	Syntax *modfile.FileSyntax
 }
 
-// A Directory is a single directory statement.
-type Directory struct {
+// A Use is a single use statement.
+type Use struct {
 	DiskPath   string // TODO(matloob): Replace uses module.Version for new. Do that here?
 	ModulePath string // Module path in the comment.
 	Syntax     *modfile.Line
@@ -99,7 +100,7 @@ func parseToWorkFile(file string, data []byte, fix modfile.VersionFixer, strict 
 					})
 				}
 				continue
-			case "module", "directory", "replace":
+			case "module", "use", "replace":
 				for _, l := range x.Line {
 					f.add(&errs, x, l, x.Token[0], l.Token, fix, strict)
 				}
@@ -169,7 +170,7 @@ func (f *WorkFile) add(errs *modfile.ErrorList, block *modfile.LineBlock, line *
 		f.Go = &modfile.Go{Syntax: line}
 		f.Go.Version = args[0]
 
-	case "directory":
+	case "use":
 		if len(args) != 1 {
 			errorf("usage: %s ../local/directory", verb) // TODO(matloob) better example; most directories will be subdirectories of go.work dir
 			return
@@ -179,7 +180,7 @@ func (f *WorkFile) add(errs *modfile.ErrorList, block *modfile.LineBlock, line *
 			errorf("invalid quoted string: %v", err)
 			return
 		}
-		f.Directory = append(f.Directory, &Directory{
+		f.Use = append(f.Use, &Use{
 			DiskPath: s,
 			Syntax:   line,
 		})


### PR DESCRIPTION
### gopls

- Replace `directory` directive with `use` directive in order to make `gopls` follow the latest specification of the [`workspace`](https://go.googlesource.com/proposal/+/master/design/45713-workspace.md)

After this [CL](https://go-review.googlesource.com/c/mod/+/359412/) has been introduced on the gotip, now `directory` directive for `go.work` has been renamed to `use`. Due to this change, current `gopls` does not treat `go.work` file correctly (e.g. `textDocument/definition` does not indicate proper files). So, this PR just renames `directory` directive to `use`.