### PR TITLE
internal/imports: use first quote when matching import path

### DIFF
--- a/internal/imports/fix_test.go
+++ b/internal/imports/fix_test.go
@@ -659,6 +659,37 @@ var _, _, _, _, _ = fmt.Errorf, io.Copy, strings.Contains, renamed_packagea.A, B
 `,
 	},
 
+	// Blank line can be added even when first import of group has comment with quote
+	{
+		name: "new_section_where_trailing_comment_has_quote",
+		in: `package main
+
+import (
+	"context"
+	bar "local.com/bar"
+	baz "local.com/baz"
+	buzz "local.com/buzz"
+	"github.com/golang/snappy" // this is a "typical" import
+)
+
+var _, _, _, _, _ = context.Background, bar.B, baz.B, buzz.B, snappy.ErrCorrupt
+`,
+		out: `package main
+
+import (
+	"context"
+
+	"github.com/golang/snappy" // this is a "typical" import
+
+	bar "local.com/bar"
+	baz "local.com/baz"
+	buzz "local.com/buzz"
+)
+
+var _, _, _, _, _ = context.Background, bar.B, baz.B, buzz.B, snappy.ErrCorrupt
+`,
+	},
+
 	// Non-idempotent comment formatting
 	// golang.org/issue/8035
 	{

--- a/internal/imports/imports.go
+++ b/internal/imports/imports.go
@@ -306,7 +306,7 @@ func matchSpace(orig []byte, src []byte) []byte {
 	return b.Bytes()
 }
 
-var impLine = regexp.MustCompile(`^\s+(?:[\w\.]+\s+)?"(.+)"`)
+var impLine = regexp.MustCompile(`^\s+(?:[\w\.]+\s+)?"(.+?)"`)
 
 func addImportSpaces(r io.Reader, breaks []string) ([]byte, error) {
 	var out bytes.Buffer


### PR DESCRIPTION
This fixes the regexp used to extract the import path from a line of code
when inserting newlines to split a sequence of imports into groups.

By using a non-greedy match, the regexp now functions correctly in the
face of an extra quote after the import path (such as when there is a
trailing comment that includes a quote).

Fixes golang/go#51671