### PR TITLE
gopls/doc: update neovim examples for nvim 0.7

### DIFF
--- a/gopls/doc/vim.md
+++ b/gopls/doc/vim.md
@@ -182,7 +182,7 @@ lua <<EOF
     for _, res in pairs(result or {}) do
       for _, r in pairs(res.result or {}) do
         if r.edit then
-          vim.lsp.util.apply_workspace_edit(r.edit)
+          vim.lsp.util.apply_workspace_edit(r.edit, "UTF-8")
         else
           vim.lsp.buf.execute_command(r.command)
         end


### PR DESCRIPTION
On neovim 0.7-dev `apply_workspace_edit` needs the encoding.

This PR updates the organize imports documentation example.

This does not break neovim v0.6+. Haven't tested in <=v0.5.

refs https://github.com/neovim/neovim/issues/14090
