### PR TITLE
internal/lsp: fix incorrect line and start of semantic tokens

### DIFF
--- a/internal/lsp/semantic.go
+++ b/internal/lsp/semantic.go
@@ -828,20 +828,23 @@ func (e *encoded) Data() []uint32 {
 	// each semantic token needs five values
 	// (see Integer Encoding for Tokens in the LSP spec)
 	x := make([]uint32, 5*len(e.items))
-	var j int
+	var (
+		j    int
+		last semItem
+	)
 	for i := 0; i < len(e.items); i++ {
 		typ, ok := typeMap[e.items[i].typeStr]
 		if !ok {
 			continue // client doesn't want typeStr
 		}
-		if i == 0 {
+		if j == 0 {
 			x[0] = e.items[0].line
 		} else {
-			x[j] = e.items[i].line - e.items[i-1].line
+			x[j] = e.items[i].line - last.line
 		}
 		x[j+1] = e.items[i].start
-		if i > 0 && e.items[i].line == e.items[i-1].line {
-			x[j+1] = e.items[i].start - e.items[i-1].start
+		if j > 0 && x[j] == 0 {
+			x[j+1] = e.items[i].start - last.start
 		}
 		x[j+2] = e.items[i].len
 		x[j+3] = uint32(typ)
@@ -852,6 +855,7 @@ func (e *encoded) Data() []uint32 {
 		}
 		x[j+4] = uint32(mask)
 		j += 5
+		last = e.items[i]
 	}
 	return x[:j]
 }

--- a/internal/lsp/semantic.go
+++ b/internal/lsp/semantic.go
@@ -828,10 +828,8 @@ func (e *encoded) Data() []uint32 {
 	// each semantic token needs five values
 	// (see Integer Encoding for Tokens in the LSP spec)
 	x := make([]uint32, 5*len(e.items))
-	var (
-		j    int
-		last semItem
-	)
+	var j int
+	var last semItem
 	for i := 0; i < len(e.items); i++ {
 		typ, ok := typeMap[e.items[i].typeStr]
 		if !ok {


### PR DESCRIPTION
Current implementation returns incorrect result when some of the items are skipped, because positions could be relative to a skipped item. Instead, each position must be relative to the previous item added to the result.