### PR TITLE
gopls: add range over channel postfix completion

### DIFF
--- a/gopls/internal/regtest/completion/postfix_snippet_test.go
+++ b/gopls/internal/regtest/completion/postfix_snippet_test.go
@@ -268,6 +268,27 @@ for k := range foo {
 `,
 		},
 		{
+			name: "channel_range",
+			before: `
+package foo
+
+func _() {
+	foo := make(chan int)
+	foo.range
+}
+`,
+			after: `
+package foo
+
+func _() {
+	foo := make(chan int)
+	for e := range foo {
+	$0
+}
+}
+`,
+		},
+		{
 			name: "var",
 			before: `
 package foo

--- a/internal/lsp/source/completion/postfix_snippets.go
+++ b/internal/lsp/source/completion/postfix_snippets.go
@@ -150,6 +150,14 @@ for {{.VarName .KeyType "k"}}, {{.VarName .ElemType "v"}} := range {{.X}} {
 }
 {{end}}`,
 }, {
+	label:   "range",
+	details: "range over channel",
+	body: `{{if and (eq .Kind "chan") .StmtOK -}}
+for {{.VarName .ElemType "e"}} := range {{.X}} {
+	{{.Cursor}}
+}
+{{- end}}`,
+}, {
 	label:   "var",
 	details: "assign to variables",
 	body: `{{if and (eq .Kind "tuple") .StmtOK -}}


### PR DESCRIPTION
This adds a snippet that applies to variables of type chan.

When used, it replaces `channel.range!` with the following snippet:
```
for e := range channel {
   |
}
```
Where `|` indicates the location of the cursor.