### PR TITLE
all: replace deprecated egrep with grep -E

### DIFF
--- a/cmd/toolstash/buildall
+++ b/cmd/toolstash/buildall
@@ -38,10 +38,10 @@ if [ "$pattern" = "" ]; then
 fi
 
 targets="$(go tool dist list; echo linux/386/softfloat)"
-targets="$(echo "$targets" | tr '/' '-' | sort | egrep "$pattern" | egrep -v 'android-arm|darwin-arm')"
+targets="$(echo "$targets" | tr '/' '-' | sort | grep -E "$pattern" | grep -E -v 'android-arm|darwin-arm')"
 
 # put linux first in the target list to get all the architectures up front.
-targets="$(echo "$targets" | egrep 'linux') $(echo "$targets" | egrep -v 'linux')"
+targets="$(echo "$targets" | grep -E 'linux') $(echo "$targets" | grep -E -v 'linux')"
 
 if [ "$sete" = true ]; then
 	set -e

--- a/gopls/internal/hooks/gen-licenses.sh
+++ b/gopls/internal/hooks/gen-licenses.sh
@@ -27,7 +27,7 @@ mods=$(go list -deps -f '{{with .Module}}{{.Path}}{{end}}' golang.org/x/tools/go
 for mod in $mods; do
   # Find the license file, either LICENSE or COPYING, and add it to the result.
   dir=$(go list -m -f {{.Dir}} $mod)
-  license=$(ls -1 $dir | egrep -i '^(LICENSE|COPYING)$')
+  license=$(ls -1 $dir | grep -E -i '^(LICENSE|COPYING)$')
   echo "-- $mod $license --" >> $tempfile
   echo >> $tempfile
   sed 's/^-- / &/' $dir/$license >> $tempfile


### PR DESCRIPTION
egrep command is about to be deprecated, use grep -E instead.

Reference: https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_xcu_chap04.html