### PR TITLE
gopls, internal/lsp: allow enabling gofumpt extra rules

### DIFF
--- a/gopls/doc/settings.md
+++ b/gopls/doc/settings.md
@@ -214,6 +214,12 @@ gofumpt indicates if we should run gofumpt formatting.
 
 Default: `false`.
 
+#### **gofumptExtraRules** *bool*
+
+gofumptExtraRules enables gofumpt's extra rules.
+
+Default: `false`.
+
 ### UI
 
 #### **codelenses** *map[string]bool*

--- a/gopls/internal/hooks/hooks.go
+++ b/gopls/internal/hooks/hooks.go
@@ -29,10 +29,11 @@ func Options(options *source.Options) {
 		}
 	}
 	options.URLRegexp = xurls.Relaxed()
-	options.GofumptFormat = func(ctx context.Context, langVersion, modulePath string, src []byte) ([]byte, error) {
+	options.GofumptFormat = func(ctx context.Context, langVersion, modulePath string, extraRules bool, src []byte) ([]byte, error) {
 		return format.Source(src, format.Options{
 			LangVersion: langVersion,
 			ModulePath:  modulePath,
+			ExtraRules:  extraRules,
 		})
 	}
 	updateAnalyzers(options)

--- a/gopls/internal/lsp/source/api_json.go
+++ b/gopls/internal/lsp/source/api_json.go
@@ -658,6 +658,13 @@ var GeneratedAPIJSON = &APIJSON{
 				Hierarchy: "formatting",
 			},
 			{
+				Name:      "gofumptExtraRules",
+				Type:      "bool",
+				Doc:       "gofumptExtraRules enables gofumpt's extra rules.\n",
+				Default:   "false",
+				Hierarchy: "formatting",
+			},
+			{
 				Name:    "verboseOutput",
 				Type:    "bool",
 				Doc:     "verboseOutput enables additional debug logging.\n",

--- a/gopls/internal/lsp/source/format.go
+++ b/gopls/internal/lsp/source/format.go
@@ -80,7 +80,8 @@ func Format(ctx context.Context, snapshot Snapshot, fh FileHandle) ([]protocol.T
 				modulePath = mi.Path
 			}
 		}
-		b, err := format(ctx, langVersion, modulePath, buf.Bytes())
+		extraRules := snapshot.View().Options().GofumptExtraRules
+		b, err := format(ctx, langVersion, modulePath, extraRules, buf.Bytes())
 		if err != nil {
 			return nil, err
 		}

--- a/gopls/internal/lsp/source/options.go
+++ b/gopls/internal/lsp/source/options.go
@@ -409,6 +409,9 @@ type FormattingOptions struct {
 
 	// Gofumpt indicates if we should run gofumpt formatting.
 	Gofumpt bool
+
+	// GofumptExtraRules enables gofumpt's extra rules.
+	GofumptExtraRules bool
 }
 
 type DiagnosticOptions struct {
@@ -548,7 +551,7 @@ type Hooks struct {
 	// GofumptFormat allows the gopls module to wire-in a call to
 	// gofumpt/format.Source. langVersion and modulePath are used for some
 	// Gofumpt formatting rules -- see the Gofumpt documentation for details.
-	GofumptFormat func(ctx context.Context, langVersion, modulePath string, src []byte) ([]byte, error)
+	GofumptFormat func(ctx context.Context, langVersion, modulePath string, extraRules bool, src []byte) ([]byte, error)
 
 	DefaultAnalyzers     map[string]*Analyzer
 	TypeErrorAnalyzers   map[string]*Analyzer
@@ -1062,6 +1065,9 @@ func (o *Options) set(name string, value interface{}, seen map[string]struct{}) 
 
 	case "gofumpt":
 		result.setBool(&o.Gofumpt)
+
+	case "gofumptExtraRules":
+		result.setBool(&o.GofumptExtraRules)
 
 	case "semanticTokens":
 		result.setBool(&o.SemanticTokens)


### PR DESCRIPTION
Add `gopls.formatting.gofumptExtraRules` option to enable `gofumpt`'s extra rules, equivalent to `-extra` on the CLI:
https://github.com/mvdan/gofumpt#extra-rules-behind--extra

Closes golang/go#56403