### PR TITLE
gopls/internal/lsp: add selection range request

### DIFF
--- a/gopls/internal/lsp/cmd/test/cmdtest.go
+++ b/gopls/internal/lsp/cmd/test/cmdtest.go
@@ -118,9 +118,7 @@ func (r *runner) InlayHints(t *testing.T, spn span.Span) {
 	// TODO: inlayHints not supported on command line
 }
 
-func (r *runner) SelectionRanges(t *testing.T, spn span.Span) {
-	// TODO: selectionRanges not supported on command line
-}
+func (r *runner) SelectionRanges(t *testing.T, spn span.Span) {}
 
 func (r *runner) runGoplsCmd(t testing.TB, args ...string) (string, string) {
 	rStdout, wStdout, err := os.Pipe()

--- a/gopls/internal/lsp/cmd/test/cmdtest.go
+++ b/gopls/internal/lsp/cmd/test/cmdtest.go
@@ -118,7 +118,7 @@ func (r *runner) InlayHints(t *testing.T, spn span.Span) {
 	// TODO: inlayHints not supported on command line
 }
 
-func (r *runner) SelectionRanges(t *testing.T, spn span.Span, exp span.Span) {
+func (r *runner) SelectionRanges(t *testing.T, spn span.Span) {
 	// TODO: selectionRanges not supported on command line
 }
 

--- a/gopls/internal/lsp/cmd/test/cmdtest.go
+++ b/gopls/internal/lsp/cmd/test/cmdtest.go
@@ -118,6 +118,10 @@ func (r *runner) InlayHints(t *testing.T, spn span.Span) {
 	// TODO: inlayHints not supported on command line
 }
 
+func (r *runner) SelectionRanges(t *testing.T, spn span.Span, exp span.Span) {
+	// TODO: selectionRanges not supported on command line
+}
+
 func (r *runner) runGoplsCmd(t testing.TB, args ...string) (string, string) {
 	rStdout, wStdout, err := os.Pipe()
 	if err != nil {

--- a/gopls/internal/lsp/lsp_test.go
+++ b/gopls/internal/lsp/lsp_test.go
@@ -1300,19 +1300,19 @@ func (r *runner) SelectionRanges(t *testing.T, spn span.Span) {
 		Positions: []protocol.Position{loc.Range.Start},
 	})
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	sb := &strings.Builder{}
 	for i, path := range ranges {
 		fmt.Fprintf(sb, "Ranges %d: ", i)
-		r := path
+		rng := path
 		for {
-			s, err := sm.Offset(r.Range.Start)
+			s, err := sm.Offset(rng.Range.Start)
 			if err != nil {
 				t.Error(err)
 			}
-			e, err := sm.Offset(r.Range.End)
+			e, err := sm.Offset(rng.Range.End)
 			if err != nil {
 				t.Error(err)
 			}
@@ -1324,25 +1324,26 @@ func (r *runner) SelectionRanges(t *testing.T, spn span.Span) {
 				snippet = string(sm.Content[s:s+15]) + "..." + string(sm.Content[e-15:e])
 			}
 
-			fmt.Fprintf(sb, "\n\t%v '%s'", r.Range, strings.ReplaceAll(snippet, "\n", "\\n"))
+			fmt.Fprintf(sb, "\n\t%v %q", rng.Range, strings.ReplaceAll(snippet, "\n", "\\n"))
 
-			if r.Parent == nil {
+			if rng.Parent == nil {
 				break
 			}
-			r = *r.Parent
+			rng = *rng.Parent
 		}
 		sb.WriteRune('\n')
 	}
 	got := sb.String()
 
-	want := r.data.Golden(t, "selectionrange_"+tests.SpanName(spn), uri.Filename(), func() ([]byte, error) {
+	testName := "selectionrange_" + tests.SpanName(spn)
+	want := r.data.Golden(t, testName, uri.Filename(), func() ([]byte, error) {
 		return []byte(got), nil
 	})
 	if want == nil {
 		t.Fatalf("golden file %q not found", uri.Filename())
 	}
 	if diff := compare.Text(got, string(want)); diff != "" {
-		t.Errorf("%s mismatch\n%s", command.AddImport, diff)
+		t.Errorf("%s mismatch\n%s", testName, diff)
 	}
 }
 

--- a/gopls/internal/lsp/lsp_test.go
+++ b/gopls/internal/lsp/lsp_test.go
@@ -1282,6 +1282,34 @@ func (r *runner) AddImport(t *testing.T, uri span.URI, expectedImport string) {
 	}
 }
 
+func (r *runner) SelectionRanges(t *testing.T, spn span.Span, exp span.Span) {
+	sm, err := r.data.Mapper(spn.URI())
+	if err != nil {
+		t.Fatal(err)
+	}
+	loc, err := sm.Location(spn)
+
+	ranges, err := r.server.selectionRange(r.ctx, &protocol.SelectionRangeParams{
+		TextDocument: protocol.TextDocumentIdentifier{
+			URI: protocol.URIFromSpanURI(spn.URI()),
+		},
+		Positions: []protocol.Position{loc.Range.Start, loc.Range.End},
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(ranges) != 1 {
+		t.Error(ranges)
+	}
+
+	exploc, err := sm.Location(exp)
+
+	if ranges[0].Range != exploc.Range {
+		t.Errorf("expected %v, actual %v", exploc.Range, ranges[0].Range)
+	}
+}
+
 func TestBytesOffset(t *testing.T) {
 	tests := []struct {
 		text string

--- a/gopls/internal/lsp/selection_range.go
+++ b/gopls/internal/lsp/selection_range.go
@@ -1,0 +1,55 @@
+package lsp
+
+import (
+	"context"
+	"fmt"
+
+	"golang.org/x/tools/go/ast/astutil"
+	"golang.org/x/tools/gopls/internal/lsp/protocol"
+	"golang.org/x/tools/gopls/internal/lsp/source"
+	"golang.org/x/tools/internal/event"
+)
+
+func (s *Server) selectionRange(ctx context.Context, params *protocol.SelectionRangeParams) ([]protocol.SelectionRange, error) {
+	ctx, done := event.Start(ctx, "lsp.Server.documentSymbol")
+	defer done()
+
+	snapshot, fh, ok, release, err := s.beginFileRequest(ctx, params.TextDocument.URI, source.UnknownKind)
+	defer release()
+	if !ok {
+		return nil, err
+	}
+
+	pgf, err := snapshot.ParseGo(ctx, fh, source.ParseFull)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(params.Positions) != 2 {
+		return nil, fmt.Errorf("expected 2 positions, received %d", len(params.Positions))
+	}
+
+	start, err := pgf.Mapper.Pos(params.Positions[0])
+	if err != nil {
+		return nil, err
+	}
+
+	end, err := pgf.Mapper.Pos(params.Positions[1])
+	if err != nil {
+		return nil, err
+	}
+
+	path, _ := astutil.PathEnclosingInterval(pgf.File, start, end)
+
+	n := path[0]
+	if len(path) >= 2 && n.Pos() == start && n.End() == end {
+		n = path[1]
+	}
+
+	newSelection, err := pgf.Mapper.PosRange(n.Pos(), n.End())
+	if err != nil {
+		return nil, err
+	}
+
+	return []protocol.SelectionRange{{Range: newSelection}}, nil
+}

--- a/gopls/internal/lsp/server_gen.go
+++ b/gopls/internal/lsp/server_gen.go
@@ -244,8 +244,8 @@ func (s *Server) ResolveWorkspaceSymbol(context.Context, *protocol.WorkspaceSymb
 	return nil, notImplemented("ResolveWorkspaceSymbol")
 }
 
-func (s *Server) SelectionRange(context.Context, *protocol.SelectionRangeParams) ([]protocol.SelectionRange, error) {
-	return nil, notImplemented("SelectionRange")
+func (s *Server) SelectionRange(ctx context.Context, params *protocol.SelectionRangeParams) ([]protocol.SelectionRange, error) {
+	return s.selectionRange(ctx, params)
 }
 
 func (s *Server) SemanticTokensFull(ctx context.Context, p *protocol.SemanticTokensParams) (*protocol.SemanticTokens, error) {

--- a/gopls/internal/lsp/source/source_test.go
+++ b/gopls/internal/lsp/source/source_test.go
@@ -497,7 +497,7 @@ func (r *runner) SemanticTokens(t *testing.T, spn span.Span) {
 	t.Skip("nothing to test in source")
 }
 
-func (r *runner) SelectionRanges(t *testing.T, spn, exp span.Span) {
+func (r *runner) SelectionRanges(t *testing.T, spn span.Span) {
 	t.Skip("nothing to test in source")
 }
 

--- a/gopls/internal/lsp/source/source_test.go
+++ b/gopls/internal/lsp/source/source_test.go
@@ -497,6 +497,10 @@ func (r *runner) SemanticTokens(t *testing.T, spn span.Span) {
 	t.Skip("nothing to test in source")
 }
 
+func (r *runner) SelectionRanges(t *testing.T, spn, exp span.Span) {
+	t.Skip("nothing to test in source")
+}
+
 func (r *runner) Import(t *testing.T, spn span.Span) {
 	fh, err := r.snapshot.GetFile(r.ctx, spn.URI())
 	if err != nil {

--- a/gopls/internal/lsp/testdata/selectionrange/foo.go
+++ b/gopls/internal/lsp/testdata/selectionrange/foo.go
@@ -1,0 +1,13 @@
+package foo
+
+import "time"
+
+func Bar(x, y int, t time.Time) int {
+	zs := []int{1, 2, 3} //@selectionrange("1, 2", "[]int{1, 2, 3}")
+
+	for _, z := range zs {
+		x = x + z + y + zs[1]
+	}
+
+	return x + y //@selectionrange("x + ", "x + y")
+}

--- a/gopls/internal/lsp/testdata/selectionrange/foo.go
+++ b/gopls/internal/lsp/testdata/selectionrange/foo.go
@@ -3,11 +3,11 @@ package foo
 import "time"
 
 func Bar(x, y int, t time.Time) int {
-	zs := []int{1, 2, 3} //@selectionrange("1, 2", "[]int{1, 2, 3}")
+	zs := []int{1, 2, 3} //@selectionrange("1")
 
 	for _, z := range zs {
-		x = x + z + y + zs[1]
+		x = x + z + y + zs[1] //@selectionrange("1")
 	}
 
-	return x + y //@selectionrange("x + ", "x + y")
+	return x + y //@selectionrange("+")
 }

--- a/gopls/internal/lsp/testdata/selectionrange/foo.go.golden
+++ b/gopls/internal/lsp/testdata/selectionrange/foo.go.golden
@@ -1,0 +1,29 @@
+-- selectionrange_foo_12_11 --
+Ranges 0: 
+	11:8-11:13 'x + y'
+	11:1-11:13 'return x + y'
+	4:36-12:1 '{\n	zs := []int{...ionrange("+")\n}'
+	4:0-12:1 'func Bar(x, y i...ionrange("+")\n}'
+	0:0-12:1 'package foo\n\nim...ionrange("+")\n}'
+
+-- selectionrange_foo_6_14 --
+Ranges 0: 
+	5:13-5:14 '1'
+	5:7-5:21 '[]int{1, 2, 3}'
+	5:1-5:21 'zs := []int{1, 2, 3}'
+	4:36-12:1 '{\n	zs := []int{...ionrange("+")\n}'
+	4:0-12:1 'func Bar(x, y i...ionrange("+")\n}'
+	0:0-12:1 'package foo\n\nim...ionrange("+")\n}'
+
+-- selectionrange_foo_9_22 --
+Ranges 0: 
+	8:21-8:22 '1'
+	8:18-8:23 'zs[1]'
+	8:6-8:23 'x + z + y + zs[1]'
+	8:2-8:23 'x = x + z + y + zs[1]'
+	7:22-9:2 '{\n		x = x + z +...onrange("1")\n	}'
+	7:1-9:2 'for _, z := ran...onrange("1")\n	}'
+	4:36-12:1 '{\n	zs := []int{...ionrange("+")\n}'
+	4:0-12:1 'func Bar(x, y i...ionrange("+")\n}'
+	0:0-12:1 'package foo\n\nim...ionrange("+")\n}'
+

--- a/gopls/internal/lsp/testdata/selectionrange/foo.go.golden
+++ b/gopls/internal/lsp/testdata/selectionrange/foo.go.golden
@@ -1,29 +1,29 @@
 -- selectionrange_foo_12_11 --
 Ranges 0: 
-	11:8-11:13 'x + y'
-	11:1-11:13 'return x + y'
-	4:36-12:1 '{\n	zs := []int{...ionrange("+")\n}'
-	4:0-12:1 'func Bar(x, y i...ionrange("+")\n}'
-	0:0-12:1 'package foo\n\nim...ionrange("+")\n}'
+	11:8-11:13 "x + y"
+	11:1-11:13 "return x + y"
+	4:36-12:1 "{\\n\tzs := []int{...ionrange(\"+\")\\n}"
+	4:0-12:1 "func Bar(x, y i...ionrange(\"+\")\\n}"
+	0:0-12:1 "package foo\\n\\nim...ionrange(\"+\")\\n}"
 
 -- selectionrange_foo_6_14 --
 Ranges 0: 
-	5:13-5:14 '1'
-	5:7-5:21 '[]int{1, 2, 3}'
-	5:1-5:21 'zs := []int{1, 2, 3}'
-	4:36-12:1 '{\n	zs := []int{...ionrange("+")\n}'
-	4:0-12:1 'func Bar(x, y i...ionrange("+")\n}'
-	0:0-12:1 'package foo\n\nim...ionrange("+")\n}'
+	5:13-5:14 "1"
+	5:7-5:21 "[]int{1, 2, 3}"
+	5:1-5:21 "zs := []int{1, 2, 3}"
+	4:36-12:1 "{\\n\tzs := []int{...ionrange(\"+\")\\n}"
+	4:0-12:1 "func Bar(x, y i...ionrange(\"+\")\\n}"
+	0:0-12:1 "package foo\\n\\nim...ionrange(\"+\")\\n}"
 
 -- selectionrange_foo_9_22 --
 Ranges 0: 
-	8:21-8:22 '1'
-	8:18-8:23 'zs[1]'
-	8:6-8:23 'x + z + y + zs[1]'
-	8:2-8:23 'x = x + z + y + zs[1]'
-	7:22-9:2 '{\n		x = x + z +...onrange("1")\n	}'
-	7:1-9:2 'for _, z := ran...onrange("1")\n	}'
-	4:36-12:1 '{\n	zs := []int{...ionrange("+")\n}'
-	4:0-12:1 'func Bar(x, y i...ionrange("+")\n}'
-	0:0-12:1 'package foo\n\nim...ionrange("+")\n}'
+	8:21-8:22 "1"
+	8:18-8:23 "zs[1]"
+	8:6-8:23 "x + z + y + zs[1]"
+	8:2-8:23 "x = x + z + y + zs[1]"
+	7:22-9:2 "{\\n\t\tx = x + z +...onrange(\"1\")\\n\t}"
+	7:1-9:2 "for _, z := ran...onrange(\"1\")\\n\t}"
+	4:36-12:1 "{\\n\tzs := []int{...ionrange(\"+\")\\n}"
+	4:0-12:1 "func Bar(x, y i...ionrange(\"+\")\\n}"
+	0:0-12:1 "package foo\\n\\nim...ionrange(\"+\")\\n}"
 

--- a/gopls/internal/lsp/testdata/summary.txt.golden
+++ b/gopls/internal/lsp/testdata/summary.txt.golden
@@ -28,5 +28,5 @@ WorkspaceSymbolsCount = 20
 SignaturesCount = 33
 LinksCount = 7
 ImplementationsCount = 14
-SelectionRangesCount = 2
+SelectionRangesCount = 3
 

--- a/gopls/internal/lsp/testdata/summary.txt.golden
+++ b/gopls/internal/lsp/testdata/summary.txt.golden
@@ -28,4 +28,5 @@ WorkspaceSymbolsCount = 20
 SignaturesCount = 33
 LinksCount = 7
 ImplementationsCount = 14
+SelectionRangesCount = 2
 

--- a/gopls/internal/lsp/testdata/summary_go1.18.txt.golden
+++ b/gopls/internal/lsp/testdata/summary_go1.18.txt.golden
@@ -28,5 +28,5 @@ WorkspaceSymbolsCount = 20
 SignaturesCount = 33
 LinksCount = 7
 ImplementationsCount = 14
-SelectionRangesCount = 2
+SelectionRangesCount = 3
 

--- a/gopls/internal/lsp/testdata/summary_go1.18.txt.golden
+++ b/gopls/internal/lsp/testdata/summary_go1.18.txt.golden
@@ -28,4 +28,5 @@ WorkspaceSymbolsCount = 20
 SignaturesCount = 33
 LinksCount = 7
 ImplementationsCount = 14
+SelectionRangesCount = 2
 

--- a/gopls/internal/lsp/tests/tests.go
+++ b/gopls/internal/lsp/tests/tests.go
@@ -93,7 +93,7 @@ type Signatures = map[span.Span]*protocol.SignatureHelp
 type Links = map[span.URI][]Link
 type AddImport = map[span.URI]string
 type Hovers = map[span.Span]string
-type SelectionRanges = map[span.Span]span.Span
+type SelectionRanges = []span.Span
 
 type Data struct {
 	Config                   packages.Config
@@ -179,7 +179,7 @@ type Tests interface {
 	Link(*testing.T, span.URI, []Link)
 	AddImport(*testing.T, span.URI, string)
 	Hover(*testing.T, span.Span, string)
-	SelectionRanges(*testing.T, span.Span, span.Span)
+	SelectionRanges(*testing.T, span.Span)
 }
 
 type Definition struct {
@@ -337,7 +337,6 @@ func load(t testing.TB, mode string, dir string) *Data {
 		Links:                    make(Links),
 		AddImport:                make(AddImport),
 		Hovers:                   make(Hovers),
-		SelectionRanges:          make(SelectionRanges),
 
 		dir:       dir,
 		fragments: map[string]string{},
@@ -954,9 +953,9 @@ func Run(t *testing.T, tests Tests, data *Data) {
 
 	t.Run("SelectionRanges", func(t *testing.T) {
 		t.Helper()
-		for span, exp := range data.SelectionRanges {
+		for _, span := range data.SelectionRanges {
 			t.Run(SpanName(span), func(t *testing.T) {
-				tests.SelectionRanges(t, span, exp)
+				tests.SelectionRanges(t, span)
 			})
 		}
 	})
@@ -1255,10 +1254,8 @@ func (data *Data) collectDefinitions(src, target span.Span) {
 	}
 }
 
-func (data *Data) collectSelectionRanges(src, exp span.Span) {
-	if _, ok := data.SelectionRanges[src]; !ok {
-		data.SelectionRanges[src] = exp
-	}
+func (data *Data) collectSelectionRanges(spn span.Span) {
+	data.SelectionRanges = append(data.SelectionRanges, spn)
 }
 
 func (data *Data) collectImplementations(src span.Span, targets []span.Span) {

--- a/gopls/internal/lsp/tests/tests.go
+++ b/gopls/internal/lsp/tests/tests.go
@@ -93,6 +93,7 @@ type Signatures = map[span.Span]*protocol.SignatureHelp
 type Links = map[span.URI][]Link
 type AddImport = map[span.URI]string
 type Hovers = map[span.Span]string
+type SelectionRanges = map[span.Span]span.Span
 
 type Data struct {
 	Config                   packages.Config
@@ -128,6 +129,7 @@ type Data struct {
 	Links                    Links
 	AddImport                AddImport
 	Hovers                   Hovers
+	SelectionRanges          SelectionRanges
 
 	fragments map[string]string
 	dir       string
@@ -177,6 +179,7 @@ type Tests interface {
 	Link(*testing.T, span.URI, []Link)
 	AddImport(*testing.T, span.URI, string)
 	Hover(*testing.T, span.Span, string)
+	SelectionRanges(*testing.T, span.Span, span.Span)
 }
 
 type Definition struct {
@@ -334,6 +337,7 @@ func load(t testing.TB, mode string, dir string) *Data {
 		Links:                    make(Links),
 		AddImport:                make(AddImport),
 		Hovers:                   make(Hovers),
+		SelectionRanges:          make(SelectionRanges),
 
 		dir:       dir,
 		fragments: map[string]string{},
@@ -499,6 +503,7 @@ func load(t testing.TB, mode string, dir string) *Data {
 		"incomingcalls":   datum.collectIncomingCalls,
 		"outgoingcalls":   datum.collectOutgoingCalls,
 		"addimport":       datum.collectAddImports,
+		"selectionrange":  datum.collectSelectionRanges,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -947,6 +952,15 @@ func Run(t *testing.T, tests Tests, data *Data) {
 		}
 	})
 
+	t.Run("SelectionRanges", func(t *testing.T) {
+		t.Helper()
+		for span, exp := range data.SelectionRanges {
+			t.Run(SpanName(span), func(t *testing.T) {
+				tests.SelectionRanges(t, span, exp)
+			})
+		}
+	})
+
 	if *UpdateGolden {
 		for _, golden := range data.golden {
 			if !golden.Modified {
@@ -1039,6 +1053,7 @@ func checkData(t *testing.T, data *Data) {
 	fmt.Fprintf(buf, "SignaturesCount = %v\n", len(data.Signatures))
 	fmt.Fprintf(buf, "LinksCount = %v\n", linksCount)
 	fmt.Fprintf(buf, "ImplementationsCount = %v\n", len(data.Implementations))
+	fmt.Fprintf(buf, "SelectionRangesCount = %v\n", len(data.SelectionRanges))
 
 	want := string(data.Golden(t, "summary", summaryFile, func() ([]byte, error) {
 		return buf.Bytes(), nil
@@ -1237,6 +1252,12 @@ func (data *Data) collectDefinitions(src, target span.Span) {
 	data.Definitions[src] = Definition{
 		Src: src,
 		Def: target,
+	}
+}
+
+func (data *Data) collectSelectionRanges(src, exp span.Span) {
+	if _, ok := data.SelectionRanges[src]; !ok {
+		data.SelectionRanges[src] = exp
 	}
 }
 


### PR DESCRIPTION
selectionRange defines the textDocument/selectionRange feature,
which, given a list of positions within a file,
reports a linked list of enclosing syntactic blocks, innermost first.

See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_selectionRange.

This feature can be used by a client to implement "expand selection" in a
language-aware fashion. Multiple input positions are supported to allow
for multiple cursors, and the entire path up to the whole document is
returned for each cursor to avoid multiple round-trips when the user is
likely to issue this command multiple times in quick succession.

Fixes golang/go#36679