### PR TITLE
update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ Selected commands:
 
 These commands may be fetched with a command such as
 ```
-go install golang.org/x/tools/cmd/goimports@latest
+go install golang.org/x/tools/cmd/goimports@v0.11.0
 ```
+(replace `v0.11.0` with the latest version if it is different - do not use `@latest`)
 
 Selected packages:
 


### PR DESCRIPTION
update installation instructions to use the specific release tag such as `v0.11.0` instead of `@latest` which is not maintained / not updated and leads to failed builds:
```
$ go install golang.org/x/tools/gopls@latest
go: golang.org/x/tools/gopls@latest (in golang.org/x/tools/gopls@v0.4.1):
	The go.mod file for the module providing named packages contains one or
	more replace directives. It must not contain directives that would cause
	it to be interpreted differently than if it were the main module.
```

The install with the specific recent tag like `@v0.11.0` does work:
```
$ go install golang.org/x/tools/gopls@v0.11.0
go: downloading golang.org/x/tools/gopls v0.11.0
go: downloading golang.org/x/tools v0.3.1-0.20221213193459-ca17b2c27ca8
go: downloading github.com/sergi/go-diff v1.1.0
go: downloading honnef.co/go/tools v0.3.3
go: downloading mvdan.cc/gofumpt v0.4.0
go: downloading mvdan.cc/xurls/v2 v2.4.0
go: downloading golang.org/x/sys v0.2.0
go: downloading golang.org/x/mod v0.7.0
go: downloading golang.org/x/sync v0.1.0
go: downloading golang.org/x/text v0.4.0
go: downloading golang.org/x/vuln v0.0.0-20221109205719-3af8368ee4fe
go: downloading github.com/google/go-cmp v0.5.9
go: downloading golang.org/x/exp/typeparams v0.0.0-20221031165847-c99f073a8326
go: downloading github.com/BurntSushi/toml v1.2.1
go: downloading golang.org/x/exp v0.0.0-20221031165847-c99f073a8326
```