### PR TITLE
Update workspace.md

### DIFF
--- a/gopls/doc/workspace.md
+++ b/gopls/doc/workspace.md
@@ -68,7 +68,7 @@ setting.
 
 If neither of the above solutions work, and your editor allows configuring the
 set of
-["workspace folders"](https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#workspaceFolder)
+["workspace folders"](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspaceFolder)
 used during your LSP session, you can still work on multiple modules by adding
 a workspace folder at each module root (the locations of `go.mod` files). This
 means that each module has its own scope, and features will not work across


### PR DESCRIPTION
Fixed broken link in line 71 from "[“workspace folders"](https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#workspaceFolder)" to ["workspace folders"](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspaceFolder)