### PR TITLE
cmd/digraph: use ReadString rather than bufio.Scanner

### DIFF
--- a/cmd/digraph/digraph_test.go
+++ b/cmd/digraph/digraph_test.go
@@ -45,6 +45,7 @@ e e
 		{"scss", g2, "sccs", nil, "c d\ne\n"},
 		{"scc", g2, "scc", []string{"d"}, "c\nd\n"},
 		{"succs", g2, "succs", []string{"a"}, "b\nc\n"},
+		{"succs-long-token", g2 + "x " + strings.Repeat("x", 96*1024), "succs", []string{"x"}, strings.Repeat("x", 96*1024) + "\n"},
 		{"preds", g2, "preds", []string{"c"}, "a\nd\n"},
 		{"preds multiple args", g2, "preds", []string{"c", "d"}, "a\nb\nc\nd\n"},
 	} {


### PR DESCRIPTION
if an input line is too long (more than bufio.MaxScanTokenSize), bufio.Scanner returns bufio.ErrToolong.

Use bufio's ReadString instead.

Fixes golang.org/go#57807