### PR TITLE
go/analysis/passes/loopclosure: avoid panic in new parallel subtest check when t.Run has single argument

### DIFF
--- a/go/analysis/passes/loopclosure/loopclosure.go
+++ b/go/analysis/passes/loopclosure/loopclosure.go
@@ -303,6 +303,11 @@ func parallelSubtest(info *types.Info, call *ast.CallExpr) []ast.Stmt {
 		return nil
 	}
 
+	if len(call.Args) != 2 {
+		// Ignore calls such as t.Run(fn()).
+		return nil
+	}
+
 	lit, _ := call.Args[1].(*ast.FuncLit)
 	if lit == nil {
 		return nil

--- a/go/analysis/passes/loopclosure/testdata/src/subtests/subtest.go
+++ b/go/analysis/passes/loopclosure/testdata/src/subtests/subtest.go
@@ -140,6 +140,10 @@ func _(t *testing.T) {
 			t.Parallel()
 			println(test) // want "loop variable test captured by func literal"
 		})
+
+		// Check that we do not have problems when t.Run has a single argument.
+		fn := func() (string, func(t *testing.T)) { return "", nil }
+		t.Run(fn())
 	}
 }
 


### PR DESCRIPTION
The new Go 1.20 parallel subtest check in the loopclosure pass
can panic in the rare case of t.Run with a single argument:

    fn := func() (string, func(t *testing.T)) { return "", nil }
    t.Run(fn())

A real-world example:

https://github.com/go-spatial/geom/blob/3cd2f5a9a082dd4f827c9f9b69ba5d736d2dcb12/planar/planar_test.go#L118

This has been present for multiple months without seeming to
be reported, so presumably this is a rare pattern.

Avoid that panic by checking t.Run has an expected number 
of arguments.

Fixes golang/go#57908