### PR TITLE
cmd/stringer: streamline test subprocesses

### DIFF
--- a/cmd/stringer/golden_test.go
+++ b/cmd/stringer/golden_test.go
@@ -451,12 +451,7 @@ func (i Token) String() string {
 func TestGolden(t *testing.T) {
 	testenv.NeedsTool(t, "go")
 
-	dir, err := os.MkdirTemp("", "stringer")
-	if err != nil {
-		t.Error(err)
-	}
-	defer os.RemoveAll(dir)
-
+	dir := t.TempDir()
 	for _, test := range golden {
 		g := Generator{
 			trimPrefix:  test.trimPrefix,


### PR DESCRIPTION
- Execute the test binary itself as cmd/stringer instead of invoking (and
cleaning up after) 'go build'.
- Replace os.MkdirTemp with T.TempDir

Changes are similar to https://go.dev/cl/377836.

