### PR TITLE
Support ChangeInterface instruction Types

### DIFF
--- a/go/callgraph/rta/rta.go
+++ b/go/callgraph/rta/rta.go
@@ -112,7 +112,7 @@ type rta struct {
 
 	// concreteTypes maps each concrete type to the set of interfaces that it implements.
 	// Keys are types.Type, values are unordered []*types.Interface.
-	// Only concrete types used as MakeInterface operands are included.
+	// Concrete types used as MakeInterface and ChangeInterface operands are included.
 	concreteTypes typeutil.Map
 
 	// interfaceTypes maps each interface type to
@@ -246,6 +246,8 @@ func (r *rta) visitFunc(f *ssa.Function) {
 
 			case *ssa.MakeInterface:
 				r.addRuntimeType(instr.X.Type(), false)
+			case *ssa.ChangeInterface:
+				r.addRuntimeType(instr.Type(), false)
 			}
 
 			// Process all address-taken functions.


### PR DESCRIPTION
When using `rta.Analyze` I noticed an issue with reachability that I was surprised that was not detected.

Specifically:

1) A program has a type A concretely implementing interface B and C
2) The program instantiates the type assigning to interface B
3) Later, the program converts interface B to C.
4) Interface type C is not tracked to be concretely implemented by A, so invocations on C do not get tracked to the concrete A type.

I believe this change fixes the issue, with tests, but appreciate your feedback!