### PR TITLE
gopls/internal/lsp/cache: request EmbedFiles from go/packages

### DIFF
--- a/gopls/internal/lsp/cache/snapshot.go
+++ b/gopls/internal/lsp/cache/snapshot.go
@@ -385,6 +385,7 @@ func (s *snapshot) config(ctx context.Context, inv *gocommand.Invocation) *packa
 			packages.NeedDeps |
 			packages.NeedTypesSizes |
 			packages.NeedModule |
+			packages.NeedEmbedFiles |
 			packages.LoadMode(packagesinternal.DepsErrors) |
 			packages.LoadMode(packagesinternal.ForTest),
 		Fset:    nil, // we do our own parsing


### PR DESCRIPTION
Gopls attempts to diagnose incorrect embed patterns. The logic to
do so relies on 'go list' to actually resolve those patterns and to
propagate an error in case the pattern is incorrect, see also [1].

Gopls explicitly specifies the needed JSON fields towards
'go list -json' which internally skips evaluation steps for unneeded
fields. Currently, the embed patterns are always evaluated but there
is plans to only run pattern evaluation if needed [2].

So, explicitly ask for EmbedFiles to prepare for [2].

[1]: https://github.com/golang/tools/blob/193023cca0b707b4d668e5d332649cba285e99f7/gopls/internal/regtest/misc/embed_test.go#L26-L40
[2]: https://github.com/golang/go/pull/58522