### PR TITLE
Allow go modules in analysis

### DIFF
--- a/go/analysis/analysistest/analysistest.go
+++ b/go/analysis/analysistest/analysistest.go
@@ -322,7 +322,6 @@ func loadPackages(a *analysis.Analyzer, dir string, patterns ...string) ([]*pack
 		Mode:  mode,
 		Dir:   dir,
 		Tests: true,
-		Env:   append(os.Environ(), "GOPATH="+dir, "GO111MODULE=off", "GOPROXY=off"),
 	}
 	pkgs, err := packages.Load(cfg, patterns...)
 	if err != nil {


### PR DESCRIPTION
As mentioned in  https://github.com/golang/go/issues/37054 , the current analyzer forces a GOPATH environment set-up.
Changing this to default to modules (while still allowing environment variable to revert to GOPATH is needed).