### PR TITLE
Add a test runner in module mode

### DIFF
--- a/go/analysis/analysistest/analysistest.go
+++ b/go/analysis/analysistest/analysistest.go
@@ -322,7 +322,6 @@ func loadPackages(a *analysis.Analyzer, dir string, patterns ...string) ([]*pack
 		Mode:  mode,
 		Dir:   dir,
 		Tests: true,
-		Env:   append(os.Environ(), "GOPATH="+dir, "GO111MODULE=off", "GOPROXY=off"),
 	}
 	pkgs, err := packages.Load(cfg, patterns...)
 	if err != nil {

--- a/go/analysis/analysistest/analysistest_test.go
+++ b/go/analysis/analysistest/analysistest_test.go
@@ -6,32 +6,30 @@ package analysistest_test
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"reflect"
 	"strings"
 	"testing"
 
+	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/analysistest"
 	"golang.org/x/tools/go/analysis/passes/findcall"
 	"golang.org/x/tools/internal/testenv"
 )
 
-func init() {
+// TestTheTest tests the analysistest testing infrastructure.
+func TestTheTest(t *testing.T) {
+	testenv.NeedsTool(t, "go")
+
 	// This test currently requires GOPATH mode.
 	// Explicitly disabling module mode should suffice, but
 	// we'll also turn off GOPROXY just for good measure.
 	if err := os.Setenv("GO111MODULE", "off"); err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 	if err := os.Setenv("GOPROXY", "off"); err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
-}
-
-// TestTheTest tests the analysistest testing infrastructure.
-func TestTheTest(t *testing.T) {
-	testenv.NeedsTool(t, "go")
 
 	// We'll simulate a partly failing test of the findcall analysis,
 	// which (by default) reports calls to functions named 'println'.
@@ -159,4 +157,13 @@ type errorfunc func(string)
 
 func (f errorfunc) Errorf(format string, args ...interface{}) {
 	f(fmt.Sprintf(format, args...))
+}
+
+func TestModule(t *testing.T) {
+	// the analyzer does nothing, but it will fail if the module cannot be loaded
+	var happyAnalyzer = &analysis.Analyzer{
+		Name: "happy",
+		Run:  func(p *analysis.Pass) (interface{}, error) { return nil, nil }}
+
+	analysistest.RunModule(t, analysistest.TestData(), happyAnalyzer, "golang.org/x/tools/go/analysis/analysistest/testdata/mod")
 }

--- a/go/analysis/analysistest/testdata/mod/mod.go
+++ b/go/analysis/analysistest/testdata/mod/mod.go
@@ -1,0 +1,1 @@
+package mod


### PR DESCRIPTION
The current analyzer only support GOPATH-style set-up.

As highlighted in https://github.com/golang/go/issues/37054, this is an issue especially when writing modules against local packages.

This changes introduces a new function that does not force a GOPATH set-up.