### PR TITLE
internal/diff: unified: match diff delete for empty file

### DIFF
--- a/internal/diff/difftest/difftest.go
+++ b/internal/diff/difftest/difftest.go
@@ -120,6 +120,17 @@ var TestCases = []struct {
 `[1:],
 	Edits: []diff.Edit{{Start: 0, End: 1, New: "B"}},
 }, {
+	Name: "delete_empty",
+	In:   "meow",
+	Out:  "", // GNU diff -u special case: +0,0
+	Unified: UnifiedPrefix + `
+@@ -1 +0,0 @@
+-meow
+\ No newline at end of file
+`[1:],
+	Edits:     []diff.Edit{{Start: 0, End: 4, New: ""}},
+	LineEdits: []diff.Edit{{Start: 0, End: 4, New: ""}},
+}, {
 	Name: "append_empty",
 	In:   "", // GNU diff -u special case: -0,0
 	Out:  "AB\nC",

--- a/internal/diff/unified.go
+++ b/internal/diff/unified.go
@@ -226,6 +226,9 @@ func (u unified) String() string {
 		}
 		if toCount > 1 {
 			fmt.Fprintf(b, " +%d,%d", hunk.ToLine, toCount)
+		} else if hunk.ToLine == 1 && toCount == 0 {
+			// Match odd GNU diff -u behavior adding to empty file.
+			fmt.Fprintf(b, " +0,0")
 		} else {
 			fmt.Fprintf(b, " +%d", hunk.ToLine)
 		}


### PR DESCRIPTION
GNU diff -u prints +0,0 for the special case of deleting into an empty file.
This also adds a test for this case.

What version of Go are you using (go version)? `go version go1.20.3 darwin/amd64`

What operating system and processor architecture are you using? MacOS/amd64

What did you do?
```sh
echo -n "test" >src
touch dst
diff -u src dst
```

What did you expect to see?
```
--- src	2023-04-20 18:04:23
+++ dst	2023-04-20 18:04:23
@@ -1 +0,0 @@
-test
\ No newline at end of file
```

What did you see instead?
internal/diff prints the wrong unified diff, it should be `@@ -1 +0,0 @@` instead of `@@ -1 +1 @@`.
```
--- src
+++ dst
@@ -1 +1 @@
-test
\ No newline at end of file
```