### PR TITLE
gopls/doc: Fix broken links

### DIFF
--- a/gopls/doc/design/implementation.md
+++ b/gopls/doc/design/implementation.md
@@ -37,12 +37,12 @@ Package | Description
 
 [gopls]: https://github.com/golang/tools/tree/master/gopls
 [internal/jsonrpc2]: https://github.com/golang/tools/tree/master/internal/jsonrpc2
-[internal/lsp]: https://github.com/golang/tools/tree/master/internal/lsp
-[internal/lsp/cache]: https://github.com/golang/tools/tree/master/internal/lsp/cache
-[internal/lsp/cmd]: https://github.com/golang/tools/tree/master/internal/lsp/cmd
-[internal/lsp/debug]: https://github.com/golang/tools/tree/master/internal/lsp/debug
-[internal/lsp/protocol]: https://github.com/golang/tools/tree/master/internal/lsp/protocol
-[internal/lsp/source]: https://github.com/golang/tools/tree/master/internal/lsp/source
+[internal/lsp]: https://github.com/golang/tools/tree/master/gopls/internal/lsp
+[internal/lsp/cache]: https://github.com/golang/tools/tree/master/gopls/internal/lsp/cache
+[internal/lsp/cmd]: https://github.com/golang/tools/tree/master/gopls/internal/lsp/cmd
+[internal/lsp/debug]: https://github.com/golang/tools/tree/master/gopls/internal/lsp/debug
+[internal/lsp/protocol]: https://github.com/golang/tools/tree/master/gopls/internal/lsp/protocol
+[internal/lsp/source]: https://github.com/golang/tools/tree/master/gopls/internal/lsp/source
 [internal/memoize]: https://github.com/golang/tools/tree/master/internal/memoize
-[internal/span]: https://github.com/golang/tools/tree/master/internal/span
+[internal/span]: https://github.com/golang/tools/tree/master/gopls/internal/span
 [x/tools]: https://github.com/golang/tools


### PR DESCRIPTION
Stumbled upon several broken links while looking at the gopls docs implementation.md. This fixes those.