### PR TITLE
gopls: add `maxUnimportedPackageNames` option that makes the number of completion candidates for unimported packages configurable

### DIFF
--- a/gopls/doc/settings.md
+++ b/gopls/doc/settings.md
@@ -233,6 +233,12 @@ fields in completion responses.
 
 Default: `false`.
 
+##### **maxUnimportedPackageNames** *int*
+
+max number of completion candidates for unimported packages.
+
+Default: `5`.
+
 ##### **completionBudget** *time.Duration*
 
 **This setting is for debugging purposes only.**

--- a/gopls/internal/lsp/protocol/generate/main.go
+++ b/gopls/internal/lsp/protocol/generate/main.go
@@ -132,6 +132,7 @@ func writeserver() {
 	fmt.Fprintln(out, fileHdr)
 	out.WriteString(
 		`import (
+	"bytes"
 	"context"
 	"encoding/json"
 

--- a/gopls/internal/lsp/protocol/generate/output.go
+++ b/gopls/internal/lsp/protocol/generate/output.go
@@ -101,7 +101,9 @@ func genCase(method string, param, result *Type, dir string) {
 			nm = "ParamConfiguration" // gopls compatibility
 		}
 		fmt.Fprintf(out, "\t\tvar params %s\n", nm)
-		fmt.Fprintf(out, "\t\tif err := json.Unmarshal(r.Params(), &params); err != nil {\n")
+		fmt.Fprintf(out, "\t\tdecoder := json.NewDecoder(bytes.NewReader(r.Params()))\n")
+		fmt.Fprintf(out, "\t\tdecoder.UseNumber()\n")
+		fmt.Fprintf(out, "\t\tif err := decoder.Decode(&params); err != nil {\n")
 		fmt.Fprintf(out, "\t\t\treturn true, sendParseError(ctx, reply, err)\n\t\t}\n")
 		p = ", &params"
 	}

--- a/gopls/internal/lsp/protocol/tsserver.go
+++ b/gopls/internal/lsp/protocol/tsserver.go
@@ -11,6 +11,7 @@ package protocol
 // LSP metaData.version = 3.17.0.
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 
@@ -96,21 +97,27 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 	switch r.Method() {
 	case "$/progress":
 		var params ProgressParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		err := server.Progress(ctx, &params)
 		return true, reply(ctx, nil, err)
 	case "$/setTrace":
 		var params SetTraceParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		err := server.SetTrace(ctx, &params)
 		return true, reply(ctx, nil, err)
 	case "callHierarchy/incomingCalls":
 		var params CallHierarchyIncomingCallsParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.IncomingCalls(ctx, &params)
@@ -120,7 +127,9 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "callHierarchy/outgoingCalls":
 		var params CallHierarchyOutgoingCallsParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.OutgoingCalls(ctx, &params)
@@ -130,7 +139,9 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "codeAction/resolve":
 		var params CodeAction
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.ResolveCodeAction(ctx, &params)
@@ -140,7 +151,9 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "codeLens/resolve":
 		var params CodeLens
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.ResolveCodeLens(ctx, &params)
@@ -150,7 +163,9 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "completionItem/resolve":
 		var params CompletionItem
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.ResolveCompletionItem(ctx, &params)
@@ -160,7 +175,9 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "documentLink/resolve":
 		var params DocumentLink
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.ResolveDocumentLink(ctx, &params)
@@ -173,7 +190,9 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, nil, err)
 	case "initialize":
 		var params ParamInitialize
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.Initialize(ctx, &params)
@@ -183,14 +202,18 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "initialized":
 		var params InitializedParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		err := server.Initialized(ctx, &params)
 		return true, reply(ctx, nil, err)
 	case "inlayHint/resolve":
 		var params InlayHint
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.Resolve(ctx, &params)
@@ -200,28 +223,36 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "notebookDocument/didChange":
 		var params DidChangeNotebookDocumentParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		err := server.DidChangeNotebookDocument(ctx, &params)
 		return true, reply(ctx, nil, err)
 	case "notebookDocument/didClose":
 		var params DidCloseNotebookDocumentParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		err := server.DidCloseNotebookDocument(ctx, &params)
 		return true, reply(ctx, nil, err)
 	case "notebookDocument/didOpen":
 		var params DidOpenNotebookDocumentParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		err := server.DidOpenNotebookDocument(ctx, &params)
 		return true, reply(ctx, nil, err)
 	case "notebookDocument/didSave":
 		var params DidSaveNotebookDocumentParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		err := server.DidSaveNotebookDocument(ctx, &params)
@@ -231,7 +262,9 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, nil, err)
 	case "textDocument/codeAction":
 		var params CodeActionParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.CodeAction(ctx, &params)
@@ -241,7 +274,9 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "textDocument/codeLens":
 		var params CodeLensParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.CodeLens(ctx, &params)
@@ -251,7 +286,9 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "textDocument/colorPresentation":
 		var params ColorPresentationParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.ColorPresentation(ctx, &params)
@@ -261,7 +298,9 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "textDocument/completion":
 		var params CompletionParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.Completion(ctx, &params)
@@ -271,7 +310,9 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "textDocument/declaration":
 		var params DeclarationParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.Declaration(ctx, &params)
@@ -281,7 +322,9 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "textDocument/definition":
 		var params DefinitionParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.Definition(ctx, &params)
@@ -291,7 +334,9 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "textDocument/diagnostic":
 		var params string
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.Diagnostic(ctx, &params)
@@ -301,35 +346,45 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "textDocument/didChange":
 		var params DidChangeTextDocumentParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		err := server.DidChange(ctx, &params)
 		return true, reply(ctx, nil, err)
 	case "textDocument/didClose":
 		var params DidCloseTextDocumentParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		err := server.DidClose(ctx, &params)
 		return true, reply(ctx, nil, err)
 	case "textDocument/didOpen":
 		var params DidOpenTextDocumentParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		err := server.DidOpen(ctx, &params)
 		return true, reply(ctx, nil, err)
 	case "textDocument/didSave":
 		var params DidSaveTextDocumentParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		err := server.DidSave(ctx, &params)
 		return true, reply(ctx, nil, err)
 	case "textDocument/documentColor":
 		var params DocumentColorParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.DocumentColor(ctx, &params)
@@ -339,7 +394,9 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "textDocument/documentHighlight":
 		var params DocumentHighlightParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.DocumentHighlight(ctx, &params)
@@ -349,7 +406,9 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "textDocument/documentLink":
 		var params DocumentLinkParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.DocumentLink(ctx, &params)
@@ -359,7 +418,9 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "textDocument/documentSymbol":
 		var params DocumentSymbolParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.DocumentSymbol(ctx, &params)
@@ -369,7 +430,9 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "textDocument/foldingRange":
 		var params FoldingRangeParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.FoldingRange(ctx, &params)
@@ -379,7 +442,9 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "textDocument/formatting":
 		var params DocumentFormattingParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.Formatting(ctx, &params)
@@ -389,7 +454,9 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "textDocument/hover":
 		var params HoverParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.Hover(ctx, &params)
@@ -399,7 +466,9 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "textDocument/implementation":
 		var params ImplementationParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.Implementation(ctx, &params)
@@ -409,7 +478,9 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "textDocument/inlayHint":
 		var params InlayHintParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.InlayHint(ctx, &params)
@@ -419,7 +490,9 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "textDocument/inlineValue":
 		var params InlineValueParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.InlineValue(ctx, &params)
@@ -429,7 +502,9 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "textDocument/linkedEditingRange":
 		var params LinkedEditingRangeParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.LinkedEditingRange(ctx, &params)
@@ -439,7 +514,9 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "textDocument/moniker":
 		var params MonikerParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.Moniker(ctx, &params)
@@ -449,7 +526,9 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "textDocument/onTypeFormatting":
 		var params DocumentOnTypeFormattingParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.OnTypeFormatting(ctx, &params)
@@ -459,7 +538,9 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "textDocument/prepareCallHierarchy":
 		var params CallHierarchyPrepareParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.PrepareCallHierarchy(ctx, &params)
@@ -469,7 +550,9 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "textDocument/prepareRename":
 		var params PrepareRenameParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.PrepareRename(ctx, &params)
@@ -479,7 +562,9 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "textDocument/prepareTypeHierarchy":
 		var params TypeHierarchyPrepareParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.PrepareTypeHierarchy(ctx, &params)
@@ -489,7 +574,9 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "textDocument/rangeFormatting":
 		var params DocumentRangeFormattingParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.RangeFormatting(ctx, &params)
@@ -499,7 +586,9 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "textDocument/references":
 		var params ReferenceParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.References(ctx, &params)
@@ -509,7 +598,9 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "textDocument/rename":
 		var params RenameParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.Rename(ctx, &params)
@@ -519,7 +610,9 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "textDocument/selectionRange":
 		var params SelectionRangeParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.SelectionRange(ctx, &params)
@@ -529,7 +622,9 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "textDocument/semanticTokens/full":
 		var params SemanticTokensParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.SemanticTokensFull(ctx, &params)
@@ -539,7 +634,9 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "textDocument/semanticTokens/full/delta":
 		var params SemanticTokensDeltaParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.SemanticTokensFullDelta(ctx, &params)
@@ -549,7 +646,9 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "textDocument/semanticTokens/range":
 		var params SemanticTokensRangeParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.SemanticTokensRange(ctx, &params)
@@ -559,7 +658,9 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "textDocument/signatureHelp":
 		var params SignatureHelpParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.SignatureHelp(ctx, &params)
@@ -569,7 +670,9 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "textDocument/typeDefinition":
 		var params TypeDefinitionParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.TypeDefinition(ctx, &params)
@@ -579,14 +682,18 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "textDocument/willSave":
 		var params WillSaveTextDocumentParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		err := server.WillSave(ctx, &params)
 		return true, reply(ctx, nil, err)
 	case "textDocument/willSaveWaitUntil":
 		var params WillSaveTextDocumentParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.WillSaveWaitUntil(ctx, &params)
@@ -596,7 +703,9 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "typeHierarchy/subtypes":
 		var params TypeHierarchySubtypesParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.Subtypes(ctx, &params)
@@ -606,7 +715,9 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "typeHierarchy/supertypes":
 		var params TypeHierarchySupertypesParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.Supertypes(ctx, &params)
@@ -616,14 +727,18 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "window/workDoneProgress/cancel":
 		var params WorkDoneProgressCancelParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		err := server.WorkDoneProgressCancel(ctx, &params)
 		return true, reply(ctx, nil, err)
 	case "workspace/diagnostic":
 		var params WorkspaceDiagnosticParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.DiagnosticWorkspace(ctx, &params)
@@ -633,49 +748,63 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "workspace/didChangeConfiguration":
 		var params DidChangeConfigurationParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		err := server.DidChangeConfiguration(ctx, &params)
 		return true, reply(ctx, nil, err)
 	case "workspace/didChangeWatchedFiles":
 		var params DidChangeWatchedFilesParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		err := server.DidChangeWatchedFiles(ctx, &params)
 		return true, reply(ctx, nil, err)
 	case "workspace/didChangeWorkspaceFolders":
 		var params DidChangeWorkspaceFoldersParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		err := server.DidChangeWorkspaceFolders(ctx, &params)
 		return true, reply(ctx, nil, err)
 	case "workspace/didCreateFiles":
 		var params CreateFilesParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		err := server.DidCreateFiles(ctx, &params)
 		return true, reply(ctx, nil, err)
 	case "workspace/didDeleteFiles":
 		var params DeleteFilesParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		err := server.DidDeleteFiles(ctx, &params)
 		return true, reply(ctx, nil, err)
 	case "workspace/didRenameFiles":
 		var params RenameFilesParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		err := server.DidRenameFiles(ctx, &params)
 		return true, reply(ctx, nil, err)
 	case "workspace/executeCommand":
 		var params ExecuteCommandParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.ExecuteCommand(ctx, &params)
@@ -685,7 +814,9 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "workspace/symbol":
 		var params WorkspaceSymbolParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.Symbol(ctx, &params)
@@ -695,7 +826,9 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "workspace/willCreateFiles":
 		var params CreateFilesParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.WillCreateFiles(ctx, &params)
@@ -705,7 +838,9 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "workspace/willDeleteFiles":
 		var params DeleteFilesParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.WillDeleteFiles(ctx, &params)
@@ -715,7 +850,9 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "workspace/willRenameFiles":
 		var params RenameFilesParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.WillRenameFiles(ctx, &params)
@@ -725,7 +862,9 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		return true, reply(ctx, resp, nil)
 	case "workspaceSymbol/resolve":
 		var params WorkspaceSymbol
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(r.Params()))
+		decoder.UseNumber()
+		if err := decoder.Decode(&params); err != nil {
 			return true, sendParseError(ctx, reply, err)
 		}
 		resp, err := server.ResolveWorkspaceSymbol(ctx, &params)


### PR DESCRIPTION
- Add a new option: `maxUnimportedPackageNames` that makes the number of completion candidates for unimported packages configurable
    - This PR fixes: https://github.com/golang/go/issues/60988



