### PR TITLE
added "wrap" postfix snippet to wrap an error with fmt.Errorf

### DIFF
--- a/gopls/internal/lsp/source/completion/postfix_snippets.go
+++ b/gopls/internal/lsp/source/completion/postfix_snippets.go
@@ -194,6 +194,12 @@ for {{.VarName .ElemType "e"}} := range {{.X}} {
 	body: `{{if and (eq .Kind "slice") (eq (.TypeName .ElemType) "string") -}}
 {{.Import "strings"}}.Join({{.X}}, "{{.Cursor}}")
 {{- end}}`,
+}, {
+	label:   "wrap",
+	details: "wrap error with fmt.Errorf()",
+	body: `{{if (eq (.TypeName .Type) "error") -}}
+	{{.Import "fmt"}}.Errorf("{{.Cursor}}: %w", {{.X}})
+{{- end}}`,
 }}
 
 // Cursor indicates where the client's cursor should end up after the


### PR DESCRIPTION
Added the postfix completion to the templates in postfix_snippets.go. I was a bit undecided whether to use the label "wrap" or "errorf" - happy to change to the latter.