### PR TITLE
Proof of concept for supporting the gotype annotation

### DIFF
--- a/gopls/internal/lsp/template/implementations.go
+++ b/gopls/internal/lsp/template/implementations.go
@@ -108,7 +108,14 @@ func Hover(ctx context.Context, snapshot source.Snapshot, fh file.Handle, positi
 	case protocol.Constant:
 		ans.Contents.Value = fmt.Sprintf("constant %s", sym.name)
 	case protocol.Method: // field or method
-		ans.Contents.Value = fmt.Sprintf("%s: field or method", sym.name)
+		// ans.Contents.Kind = protocol.Markdown
+		metadata := snapshot.Metadata("github.com/snippetsolver/awaysync/src/templates")
+		if metadata != nil {
+			ans.Contents.Value = metadata.CompiledGoFiles[0].Path()
+		} else {
+			ans.Contents.Value = "fuck"
+		}
+		// ans.Contents.Value = fmt.Sprintf("%s: field or method", sym.name)
 	case protocol.Package: // template use, template def (PJW: do we want two?)
 		ans.Contents.Value = fmt.Sprintf("template %s\n(add definition)", sym.name)
 	case protocol.Namespace:

--- a/gopls/internal/lsp/template/parse.go
+++ b/gopls/internal/lsp/template/parse.go
@@ -113,8 +113,11 @@ func parseBuffer(buf []byte) *Parsed {
 	t := template.New("")
 	tr := parse.New("")
 	tr.Mode = parse.SkipFuncCheck | parse.ParseComments
-	tree, _ := tr.Parse(string(ans.buf), "", "", make(map[string]*parse.Tree))
-	t.AddParseTree("", tree)
+	trees := make(map[string]*parse.Tree)
+	tr.Parse(string(ans.buf), "", "", trees)
+	for name, tree := range trees {
+		t.AddParseTree(name, tree)
+	}
 	ans.named = t.Templates()
 	// set the symbols
 	for _, t := range ans.named {

--- a/gopls/internal/lsp/template/parse_test.go
+++ b/gopls/internal/lsp/template/parse_test.go
@@ -237,7 +237,7 @@ func TestQuotes(t *testing.T) {
 	}
 }
 
-func TestVariables(t *testing.T) {
+func TestGoTypeAnnotation(t *testing.T) {
 	tsts := []string{"{{- /*gotype: golang.org/x/tools/gopls/internal/template.MyType */ -}}{{ .Foo }}"}
 	for _, s := range tsts {
 		p := parseBuffer([]byte(s))

--- a/gopls/internal/lsp/template/parse_test.go
+++ b/gopls/internal/lsp/template/parse_test.go
@@ -236,3 +236,13 @@ func TestQuotes(t *testing.T) {
 		}
 	}
 }
+
+func TestVariables(t *testing.T) {
+	tsts := []string{"{{- /*gotype: golang.org/x/tools/gopls/internal/template.MyType */ -}}{{ .Foo }}"}
+	for _, s := range tsts {
+		p := parseBuffer([]byte(s))
+		if p.goTypePackage != "golang.org/x/tools/gopls/internal/template" || p.goTypeName != "MyType" {
+			t.Errorf("%q: gotype comment not parsed", s)
+		}
+	}
+}

--- a/gopls/internal/lsp/template/symbols.go
+++ b/gopls/internal/lsp/template/symbols.go
@@ -97,7 +97,7 @@ func (p *Parsed) fields(flds []string, x parse.Node) []symbol {
 	return ans
 }
 
-var goTypeRegex = regexp.MustCompile(`gotype: (.+)\.([^.\s]+)`)
+var goTypeRegex = regexp.MustCompile(`gotype:\s*(.+)\.([^.\s]+)`)
 
 func (p *Parsed) findSymbols() {
 	if len(p.stack) == 0 {


### PR DESCRIPTION
See https://github.com/golang/go/issues/64385 for details, this PR is a bit of work I started to implement [GoLand's](https://www.jetbrains.com/help/go/integration-with-go-templates.html) `{{- /*gotype: pkg.com/packagename.TypeName */ -}}` functionality in gopls.

It's super rough as I've never worked in this codebase before, but I got it to output one "nesting level" for highlighting:


<img width="530" alt="Screenshot 2023-11-26 at 9 32 51 AM" src="https://github.com/golang/tools/assets/2091002/8935e66b-d7fd-44da-a047-19e723cdb7f2">


If anyone thinks it's worth finishing, I'd like help on referencing deeply nested fields (ex: `{{ .StructOne.FieldToStructTwo.FieldFromStructTwo }}`), and implementing autocomplete.