### PR TITLE
gopls/internal/cache: more helpful message for non-required modules

### DIFF
--- a/gopls/internal/cache/check.go
+++ b/gopls/internal/cache/check.go
@@ -22,10 +22,10 @@ import (
 	"golang.org/x/mod/module"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/tools/go/ast/astutil"
-	"golang.org/x/tools/gopls/internal/file"
-	"golang.org/x/tools/gopls/internal/filecache"
 	"golang.org/x/tools/gopls/internal/cache/metadata"
 	"golang.org/x/tools/gopls/internal/cache/typerefs"
+	"golang.org/x/tools/gopls/internal/file"
+	"golang.org/x/tools/gopls/internal/filecache"
 	"golang.org/x/tools/gopls/internal/protocol"
 	"golang.org/x/tools/gopls/internal/util/bug"
 	"golang.org/x/tools/gopls/internal/util/safetoken"
@@ -1757,7 +1757,7 @@ func missingPkgError(from PackageID, pkgPath string, moduleMode bool) error {
 			return fmt.Errorf("current file is not included in a workspace module")
 		} else {
 			// Previously, we would present the initialization error here.
-			return fmt.Errorf("no required module provides package %q", pkgPath)
+			return fmt.Errorf("package %q does not exist under go.mod in required modules, try running `go mod tidy`", pkgPath)
 		}
 	} else {
 		// Previously, we would list the directories in GOROOT and GOPATH here.

--- a/gopls/internal/test/integration/diagnostics/diagnostics_test.go
+++ b/gopls/internal/test/integration/diagnostics/diagnostics_test.go
@@ -723,7 +723,10 @@ func main() {
 		env.SaveBuffer("main.go")
 		var d protocol.PublishDiagnosticsParams
 		env.AfterChange(
-			Diagnostics(env.AtRegexp("main.go", `"github.com/ardanlabs/conf"`), WithMessage("no required module")),
+			Diagnostics(
+				env.AtRegexp("main.go", `"github.com/ardanlabs/conf"`),
+				WithMessage("does not exist under go.mod in required modules, try running `go mod tidy`"),
+			),
 			ReadDiagnostics("main.go", &d),
 		)
 		env.ApplyQuickFixes("main.go", d.Diagnostics)
@@ -1711,7 +1714,7 @@ import (
 		Run(t, mod, func(t *testing.T, env *Env) {
 			env.OnceMet(
 				InitialWorkspaceLoad,
-				Diagnostics(env.AtRegexp("main.go", `"nosuchpkg"`), WithMessage(`could not import nosuchpkg (no required module provides package "nosuchpkg"`)),
+				Diagnostics(env.AtRegexp("main.go", `"nosuchpkg"`), WithMessage(`could not import nosuchpkg (package "nosuchpkg" does not exist under go.mod in required modules, try running `+"`go mod tidy`)")),
 			)
 		})
 	})

--- a/gopls/internal/test/integration/modfile/modfile_test.go
+++ b/gopls/internal/test/integration/modfile/modfile_test.go
@@ -1099,7 +1099,7 @@ func main() {
 		env.AfterChange(
 			Diagnostics(
 				env.AtRegexp("main.go", `"example.com/blah"`),
-				WithMessage(`could not import example.com/blah (no required module provides package "example.com/blah")`),
+				WithMessage(`could not import example.com/blah (package "example.com/blah" does not exist under go.mod in required modules, try running `+"`go mod tidy`)"),
 			),
 			ReadDiagnostics("main.go", d),
 		)


### PR DESCRIPTION
rewrite error to be more helpful when a module is not found in the required modules.
`(no required module provides package "nosuchpkg"`)` to `(package "nosuchpkg" does not exist under go.mod in required modules, try running ` +"`go mod tidy`))`

fixes [#65301](https://github.com/golang/go/issues/65301)