### PR TITLE
gopls/internal/util/maps: optimize Keys when greater than or equal to go1.21

### DIFF
--- a/gopls/internal/util/maps/go121.go
+++ b/gopls/internal/util/maps/go121.go
@@ -8,11 +8,12 @@ package maps
 
 import "unsafe"
 
-//go:linkname keys runtime.keys
+//go:linkname keys maps.keys
+//go:noescape
 func keys(m any, p unsafe.Pointer)
 
 func keyS[M ~map[K]V, K comparable, V any](m M) []K {
 	r := make([]K, 0, len(m))
-	keys(m, unsafe.Pointer(&r[0]))
+	keys(m, unsafe.Pointer(&r))
 	return r
 }

--- a/gopls/internal/util/maps/go121.go
+++ b/gopls/internal/util/maps/go121.go
@@ -1,0 +1,18 @@
+// Copyright 2024 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build go1.21
+
+package maps
+
+import "unsafe"
+
+//go:linkname keys runtime.keys
+func keys(m any, p unsafe.Pointer)
+
+func keyS[M ~map[K]V, K comparable, V any](m M) []K {
+	r := make([]K, 0, len(m))
+	keys(m, unsafe.Pointer(&r[0]))
+	return r
+}

--- a/gopls/internal/util/maps/maps.go
+++ b/gopls/internal/util/maps/maps.go
@@ -17,11 +17,7 @@ func Group[K comparable, V any](s []V, key func(V) K) map[K][]V {
 
 // Keys returns the keys of the map M.
 func Keys[M ~map[K]V, K comparable, V any](m M) []K {
-	r := make([]K, 0, len(m))
-	for k := range m {
-		r = append(r, k)
-	}
-	return r
+	return keyS(m)
 }
 
 // SameKeys reports whether x and y have equal sets of keys.

--- a/gopls/internal/util/maps/nogo121.go
+++ b/gopls/internal/util/maps/nogo121.go
@@ -1,0 +1,17 @@
+// Copyright 2024 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !go1.21
+
+package maps
+
+// TODO: remove when no support go1.21
+
+func keyS[M ~map[K]V, K comparable, V any](m M) []K {
+	r := make([]K, 0, len(m))
+	for k := range m {
+		r = append(r, k)
+	}
+	return r
+}


### PR DESCRIPTION
Use maps.keys(Implemented in runtime/map.go) optimize Keys when greater than or equal to go1.21.