### PR TITLE
gopls/internal: add code action "extract declarations to new file"

### DIFF
--- a/gopls/doc/commands.md
+++ b/gopls/doc/commands.md
@@ -291,6 +291,28 @@ Args:
 }
 ```
 
+## `gopls.extract_to_new_file`: **Move selected declarations to a new file**
+
+Used by the code action of the same name.
+
+Args:
+
+```
+{
+	"uri": string,
+	"range": {
+		"start": {
+			"line": uint32,
+			"character": uint32,
+		},
+		"end": {
+			"line": uint32,
+			"character": uint32,
+		},
+	},
+}
+```
+
 ## `gopls.fetch_vulncheck_result`: **Get known vulncheck result**
 
 Fetch the result of latest vulnerability check (`govulncheck`).

--- a/gopls/doc/release/v0.17.0.md
+++ b/gopls/doc/release/v0.17.0.md
@@ -5,3 +5,20 @@
 The `fieldalignment` analyzer, previously disabled by default, has
 been removed: it is redundant with the hover size/offset information
 displayed by v0.16.0 and its diagnostics were confusing.
+
+
+# New features
+
+## Extract declarations to new file
+Gopls now offers another code action, "Extract declarations to new file",
+which moves selected code sections to a newly created file within the
+same package. The created filename is chosen as the first {function, type, 
+const, var} name encountered. In addition, import declarations are added or
+removed as needed.
+
+The user can invoke this code action by selecting a function name, the keywords
+`func`, `const`, `var`, `type`, or by placing the caret on them without selecting,
+or by selecting a whole declaration or multiple declrations.
+
+In order to avoid ambiguity and surprise about what to extract, some kinds
+of paritial selection of a declration cannot invoke this code action.

--- a/gopls/internal/doc/api.json
+++ b/gopls/internal/doc/api.json
@@ -1011,6 +1011,13 @@
 			"ResultDoc": ""
 		},
 		{
+			"Command": "gopls.extract_to_new_file",
+			"Title": "Move selected declarations to a new file",
+			"Doc": "Used by the code action of the same name.",
+			"ArgDoc": "{\n\t\"uri\": string,\n\t\"range\": {\n\t\t\"start\": {\n\t\t\t\"line\": uint32,\n\t\t\t\"character\": uint32,\n\t\t},\n\t\t\"end\": {\n\t\t\t\"line\": uint32,\n\t\t\t\"character\": uint32,\n\t\t},\n\t},\n}",
+			"ResultDoc": ""
+		},
+		{
 			"Command": "gopls.fetch_vulncheck_result",
 			"Title": "Get known vulncheck result",
 			"Doc": "Fetch the result of latest vulnerability check (`govulncheck`).",

--- a/gopls/internal/golang/codeaction.go
+++ b/gopls/internal/golang/codeaction.go
@@ -285,7 +285,7 @@ func getExtractCodeActions(pgf *parsego.File, rng protocol.Range, options *setti
 	if canExtractToNewFile(pgf, start, end) {
 		cmd, err := command.NewExtractToNewFileCommand(
 			"Extract declarations to new file",
-			command.ExtractToNewFileArgs{URI: pgf.URI, Range: rng},
+			protocol.Location{URI: pgf.URI, Range: rng},
 		)
 		if err != nil {
 			return nil, err

--- a/gopls/internal/golang/codeaction.go
+++ b/gopls/internal/golang/codeaction.go
@@ -240,10 +240,6 @@ func fixedByImportFix(fix *imports.ImportFix, diagnostics []protocol.Diagnostic)
 
 // getExtractCodeActions returns any refactor.extract code actions for the selection.
 func getExtractCodeActions(pgf *parsego.File, rng protocol.Range, options *settings.Options) ([]protocol.CodeAction, error) {
-	if rng.Start == rng.End {
-		return nil, nil
-	}
-
 	start, end, err := pgf.RangePos(rng)
 	if err != nil {
 		return nil, err
@@ -281,6 +277,16 @@ func getExtractCodeActions(pgf *parsego.File, rng protocol.Range, options *setti
 			Range:        rng,
 			ResolveEdits: supportsResolveEdits(options),
 		})
+		if err != nil {
+			return nil, err
+		}
+		commands = append(commands, cmd)
+	}
+	if canExtractToNewFile(pgf, start, end) {
+		cmd, err := command.NewExtractToNewFileCommand(
+			"Extract declarations to new file",
+			command.ExtractToNewFileArgs{URI: pgf.URI, Range: rng},
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/gopls/internal/golang/extracttofile.go
+++ b/gopls/internal/golang/extracttofile.go
@@ -152,7 +152,8 @@ func ExtractToNewFile(ctx context.Context, snapshot *cache.Snapshot, fh file.Han
 		return nil, fmt.Errorf("%s: %w", errorPrefix, err)
 	}
 
-	buf.Write(pgf.Src[start-pgf.File.FileStart : end-pgf.File.FileStart])
+	fileStart := pgf.Tok.Pos(0) // TODO(adonovan): use go1.20 pgf.File.FileStart
+	buf.Write(pgf.Src[start-fileStart : end-fileStart])
 
 	// TODO: attempt to duplicate the copyright header, if any.
 	newFileContent, err := format.Source(buf.Bytes())

--- a/gopls/internal/golang/extracttofile.go
+++ b/gopls/internal/golang/extracttofile.go
@@ -24,6 +24,7 @@ import (
 	"golang.org/x/tools/gopls/internal/file"
 	"golang.org/x/tools/gopls/internal/protocol"
 	"golang.org/x/tools/gopls/internal/util/bug"
+	"golang.org/x/tools/gopls/internal/util/safetoken"
 	"golang.org/x/tools/gopls/internal/util/typesutil"
 )
 
@@ -99,7 +100,11 @@ func ExtractToNewFile(ctx context.Context, snapshot *cache.Snapshot, fh file.Han
 	}
 
 	// select trailing empty lines
-	rest := pgf.Src[pgf.Tok.Offset(end):]
+	offset, err := safetoken.Offset(pgf.Tok, end)
+	if err != nil {
+		return nil, err
+	}
+	rest := pgf.Src[offset:]
 	end += token.Pos(len(rest) - len(bytes.TrimLeft(rest, " \t\n")))
 
 	replaceRange, err := pgf.PosRange(start, end)

--- a/gopls/internal/golang/extracttofile.go
+++ b/gopls/internal/golang/extracttofile.go
@@ -1,0 +1,316 @@
+// Copyright 2024 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package golang
+
+// This file defines the code action "Extract declarations to new file".
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/format"
+	"go/token"
+	"go/types"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/tools/gopls/internal/cache"
+	"golang.org/x/tools/gopls/internal/cache/parsego"
+	"golang.org/x/tools/gopls/internal/file"
+	"golang.org/x/tools/gopls/internal/protocol"
+	"golang.org/x/tools/gopls/internal/util/bug"
+	"golang.org/x/tools/gopls/internal/util/typesutil"
+)
+
+// canExtractToNewFile reports whether the code in the given range can be extracted to a new file.
+func canExtractToNewFile(pgf *parsego.File, start, end token.Pos) bool {
+	_, _, _, ok := selectedToplevelDecls(pgf, start, end)
+	return ok
+}
+
+// findImportEdits finds imports specs that needs to be added to the new file
+// or deleted from the old file if the range is extracted to a new file.
+//
+// TODO: handle dot imports
+func findImportEdits(file *ast.File, info *types.Info, start, end token.Pos) (adds []*ast.ImportSpec, deletes []*ast.ImportSpec) {
+	// make a map from a pkgName to its references
+	pkgNameReferences := make(map[*types.PkgName][]*ast.Ident)
+	for ident, use := range info.Uses {
+		if pkgName, ok := use.(*types.PkgName); ok {
+			pkgNameReferences[pkgName] = append(pkgNameReferences[pkgName], ident)
+		}
+	}
+
+	// PkgName referenced in the extracted selection must be
+	// imported in the new file.
+	// PkgName only refereced in the extracted selection must be
+	// deleted from the original file.
+	for _, spec := range file.Imports {
+		pkgName, ok := typesutil.ImportedPkgName(info, spec)
+		if !ok {
+			continue
+		}
+		usedInSelection := false
+		usedInNonSelection := false
+		for _, ident := range pkgNameReferences[pkgName] {
+			if contain(start, end, ident.Pos(), ident.End()) {
+				usedInSelection = true
+			} else {
+				usedInNonSelection = true
+			}
+		}
+		if usedInSelection {
+			adds = append(adds, spec)
+		}
+		if usedInSelection && !usedInNonSelection {
+			deletes = append(deletes, spec)
+		}
+	}
+
+	return adds, deletes
+}
+
+// ExtractToNewFile moves selected declarations into a new file.
+func ExtractToNewFile(
+	ctx context.Context,
+	snapshot *cache.Snapshot,
+	fh file.Handle,
+	rng protocol.Range,
+) (*protocol.WorkspaceEdit, error) {
+	errorPrefix := "ExtractToNewFile"
+
+	pkg, pgf, err := NarrowestPackageForFile(ctx, snapshot, fh.URI())
+	if err != nil {
+		return nil, err
+	}
+
+	start, end, err := pgf.RangePos(rng)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", errorPrefix, err)
+	}
+
+	start, end, filename, ok := selectedToplevelDecls(pgf, start, end)
+	if !ok {
+		return nil, bug.Errorf("precondition unmet")
+	}
+
+	end = skipWhiteSpaces(pgf, end)
+
+	replaceRange, err := pgf.PosRange(start, end)
+	if err != nil {
+		return nil, bug.Errorf("findRangeAndFilename returned invalid range: %v", err)
+	}
+
+	adds, deletes := findImportEdits(pgf.File, pkg.TypesInfo(), start, end)
+
+	var importDeletes []protocol.TextEdit
+	// For unparenthesised declarations like `import "fmt"` we remove
+	// the whole declaration because simply removing importSpec leaves
+	// `import \n`, which does not compile.
+	// For parenthesised declarations like `import ("fmt"\n "log")`
+	// we only remove the ImportSpec, because removing the whole declaration
+	// might remove other ImportsSpecs we don't want to touch.
+	parenthesisFreeImports := findParenthesisFreeImports(pgf)
+	for _, importSpec := range deletes {
+		if decl := parenthesisFreeImports[importSpec]; decl != nil {
+			importDeletes = append(importDeletes, removeNode(pgf, decl))
+		} else {
+			importDeletes = append(importDeletes, removeNode(pgf, importSpec))
+		}
+	}
+
+	importAdds := ""
+	if len(adds) > 0 {
+		importAdds += "import ("
+		for _, importSpec := range adds {
+			if importSpec.Name != nil {
+				importAdds += importSpec.Name.Name + " " + importSpec.Path.Value + "\n"
+			} else {
+				importAdds += importSpec.Path.Value + "\n"
+			}
+		}
+		importAdds += ")"
+	}
+
+	newFileURI, err := resolveNewFileURI(ctx, snapshot, pgf.URI.Dir().Path(), filename)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", errorPrefix, err)
+	}
+
+	// TODO: attempt to duplicate the copyright header, if any.
+	newFileContent, err := format.Source([]byte(
+		"package " + pgf.File.Name.Name + "\n" +
+			importAdds + "\n" +
+			string(pgf.Src[start-pgf.File.FileStart:end-pgf.File.FileStart]),
+	))
+	if err != nil {
+		return nil, err
+	}
+
+	return protocol.NewWorkspaceEdit(
+		// original file edits
+		protocol.DocumentChangeEdit(fh, append(importDeletes, protocol.TextEdit{Range: replaceRange, NewText: ""})),
+		protocol.DocumentChangeCreate(newFileURI),
+		// created file edits
+		protocol.DocumentChangeEdit(&uriVersion{uri: newFileURI, version: 0}, []protocol.TextEdit{
+			{Range: protocol.Range{}, NewText: string(newFileContent)},
+		})), nil
+}
+
+// uriVersion implements protocol.fileHandle
+type uriVersion struct {
+	uri     protocol.DocumentURI
+	version int32
+}
+
+func (fh *uriVersion) URI() protocol.DocumentURI {
+	return fh.uri
+}
+func (fh *uriVersion) Version() int32 {
+	return fh.version
+}
+
+// resolveNewFileURI checks that basename.go does not exists in dir, otherwise
+// select basename.{1,2,3,4,5}.go as filename.
+func resolveNewFileURI(ctx context.Context, snapshot *cache.Snapshot, dir string, basename string) (protocol.DocumentURI, error) {
+	basename = strings.ToLower(basename)
+	newPath := protocol.URIFromPath(filepath.Join(dir, basename+".go"))
+	for count := 1; ; count++ {
+		fh, err := snapshot.ReadFile(ctx, newPath)
+		if err != nil {
+			return "", nil
+		}
+		if _, err := fh.Content(); errors.Is(err, os.ErrNotExist) {
+			break
+		}
+		if count >= 5 {
+			return "", fmt.Errorf("resolveNewFileURI: exceeded retry limit")
+		}
+		filename := fmt.Sprintf("%s.%d.go", basename, count)
+		newPath = protocol.URIFromPath(filepath.Join(dir, filename))
+	}
+	return newPath, nil
+}
+
+// selectedToplevelDecls returns the lexical extent of the top-level
+// declarations enclosed by [start, end), along with the name of the
+// first declaration. The returned boolean reports whether the selection
+// should be offered code action.
+func selectedToplevelDecls(pgf *parsego.File, start, end token.Pos) (token.Pos, token.Pos, string, bool) {
+	// selection cannot intersect a package declaration
+	if intersect(start, end, pgf.File.Package, pgf.File.Name.End()) {
+		return 0, 0, "", false
+	}
+	firstName := ""
+	for _, decl := range pgf.File.Decls {
+		if intersect(start, end, decl.Pos(), decl.End()) {
+			var id *ast.Ident
+			switch v := decl.(type) {
+			case *ast.BadDecl:
+				return 0, 0, "", false
+			case *ast.FuncDecl:
+				// if only selecting keyword "func" or function name, extend selection to the
+				// whole function
+				if contain(v.Pos(), v.Name.End(), start, end) {
+					start, end = v.Pos(), v.End()
+				}
+				id = v.Name
+			case *ast.GenDecl:
+				// selection cannot intersect an import declaration
+				if v.Tok == token.IMPORT {
+					return 0, 0, "", false
+				}
+				// if only selecting keyword "type", "const", or "var", extend selection to the
+				// whole declaration
+				if v.Tok == token.TYPE && contain(v.Pos(), v.Pos()+4, start, end) ||
+					v.Tok == token.CONST && contain(v.Pos(), v.Pos()+5, start, end) ||
+					v.Tok == token.VAR && contain(v.Pos(), v.Pos()+3, start, end) {
+					start, end = v.Pos(), v.End()
+				}
+				if len(v.Specs) > 0 {
+					switch spec := v.Specs[0].(type) {
+					case *ast.TypeSpec:
+						id = spec.Name
+					case *ast.ValueSpec:
+						id = spec.Names[0]
+					}
+				}
+			}
+			// selection cannot partially intersect a node
+			if !contain(start, end, decl.Pos(), decl.End()) {
+				return 0, 0, "", false
+			}
+			if id != nil && firstName == "" {
+				firstName = id.Name
+			}
+			// extends selection to docs comments
+			var c *ast.CommentGroup
+			switch decl := decl.(type) {
+			case *ast.GenDecl:
+				c = decl.Doc
+			case *ast.FuncDecl:
+				c = decl.Doc
+			}
+			if c != nil && c.Pos() < start {
+				start = c.Pos()
+			}
+		}
+	}
+	for _, comment := range pgf.File.Comments {
+		if intersect(start, end, comment.Pos(), comment.End()) {
+			if !contain(start, end, comment.Pos(), comment.End()) {
+				// selection cannot partially intersect a comment
+				return 0, 0, "", false
+			}
+		}
+	}
+	if firstName == "" {
+		return 0, 0, "", false
+	}
+	return start, end, firstName, true
+}
+
+func skipWhiteSpaces(pgf *parsego.File, pos token.Pos) token.Pos {
+	i := pos
+	for ; i-pgf.File.FileStart < token.Pos(len(pgf.Src)); i++ {
+		c := pgf.Src[i-pgf.File.FileStart]
+		if !(c == ' ' || c == '\t' || c == '\n') {
+			break
+		}
+	}
+	return i
+}
+
+func findParenthesisFreeImports(pgf *parsego.File) map[*ast.ImportSpec]*ast.GenDecl {
+	decls := make(map[*ast.ImportSpec]*ast.GenDecl)
+	for _, decl := range pgf.File.Decls {
+		if g, ok := decl.(*ast.GenDecl); ok {
+			if !g.Lparen.IsValid() && len(g.Specs) > 0 {
+				if v, ok := g.Specs[0].(*ast.ImportSpec); ok {
+					decls[v] = g
+				}
+			}
+		}
+	}
+	return decls
+}
+
+// removeNode returns a TextEdit that removes the node
+func removeNode(pgf *parsego.File, node ast.Node) protocol.TextEdit {
+	rng, _ := pgf.PosRange(node.Pos(), node.End())
+	return protocol.TextEdit{Range: rng, NewText: ""}
+}
+
+// intersect checks if [a, b) and [c, d) intersect, assuming a <= b and c <= d
+func intersect(a, b, c, d token.Pos) bool {
+	return !(b <= c || d <= a)
+}
+
+// contain checks if [a, b) contains [c, d), assuming a <= b and c <= d
+func contain(a, b, c, d token.Pos) bool {
+	return a <= c && d <= b
+}

--- a/gopls/internal/protocol/command/command_gen.go
+++ b/gopls/internal/protocol/command/command_gen.go
@@ -170,7 +170,7 @@ func Dispatch(ctx context.Context, params *protocol.ExecuteCommandParams, s Inte
 		}
 		return nil, s.EditGoDirective(ctx, a0)
 	case ExtractToNewFile:
-		var a0 ExtractToNewFileArgs
+		var a0 protocol.Location
 		if err := UnmarshalArgs(params.Arguments, &a0); err != nil {
 			return nil, err
 		}
@@ -444,7 +444,7 @@ func NewEditGoDirectiveCommand(title string, a0 EditGoDirectiveArgs) (protocol.C
 	}, nil
 }
 
-func NewExtractToNewFileCommand(title string, a0 ExtractToNewFileArgs) (protocol.Command, error) {
+func NewExtractToNewFileCommand(title string, a0 protocol.Location) (protocol.Command, error) {
 	args, err := MarshalArgs(a0)
 	if err != nil {
 		return protocol.Command{}, err

--- a/gopls/internal/protocol/command/command_gen.go
+++ b/gopls/internal/protocol/command/command_gen.go
@@ -34,6 +34,7 @@ const (
 	DiagnoseFiles           Command = "gopls.diagnose_files"
 	Doc                     Command = "gopls.doc"
 	EditGoDirective         Command = "gopls.edit_go_directive"
+	ExtractToNewFile        Command = "gopls.extract_to_new_file"
 	FetchVulncheckResult    Command = "gopls.fetch_vulncheck_result"
 	FreeSymbols             Command = "gopls.free_symbols"
 	GCDetails               Command = "gopls.gc_details"
@@ -74,6 +75,7 @@ var Commands = []Command{
 	DiagnoseFiles,
 	Doc,
 	EditGoDirective,
+	ExtractToNewFile,
 	FetchVulncheckResult,
 	FreeSymbols,
 	GCDetails,
@@ -167,6 +169,12 @@ func Dispatch(ctx context.Context, params *protocol.ExecuteCommandParams, s Inte
 			return nil, err
 		}
 		return nil, s.EditGoDirective(ctx, a0)
+	case ExtractToNewFile:
+		var a0 ExtractToNewFileArgs
+		if err := UnmarshalArgs(params.Arguments, &a0); err != nil {
+			return nil, err
+		}
+		return nil, s.ExtractToNewFile(ctx, a0)
 	case FetchVulncheckResult:
 		var a0 URIArg
 		if err := UnmarshalArgs(params.Arguments, &a0); err != nil {
@@ -432,6 +440,18 @@ func NewEditGoDirectiveCommand(title string, a0 EditGoDirectiveArgs) (protocol.C
 	return protocol.Command{
 		Title:     title,
 		Command:   EditGoDirective.String(),
+		Arguments: args,
+	}, nil
+}
+
+func NewExtractToNewFileCommand(title string, a0 ExtractToNewFileArgs) (protocol.Command, error) {
+	args, err := MarshalArgs(a0)
+	if err != nil {
+		return protocol.Command{}, err
+	}
+	return protocol.Command{
+		Title:     title,
+		Command:   ExtractToNewFile.String(),
 		Arguments: args,
 	}, nil
 }

--- a/gopls/internal/protocol/command/interface.go
+++ b/gopls/internal/protocol/command/interface.go
@@ -160,6 +160,11 @@ type Interface interface {
 	// themselves.
 	AddImport(context.Context, AddImportArgs) error
 
+	// ExtractToNewFile: Move selected declarations to a new file
+	//
+	// Used by the code action of the same name.
+	ExtractToNewFile(context.Context, ExtractToNewFileArgs) error
+
 	// StartDebugging: Start the gopls debug server
 	//
 	// Start the gopls debug server if it isn't running, and return the debug
@@ -365,6 +370,12 @@ type AddImportArgs struct {
 	// URI is the file that the ImportPath should be
 	// added to
 	URI protocol.DocumentURI
+}
+
+type ExtractToNewFileArgs struct {
+	// URI of the file
+	URI   protocol.DocumentURI
+	Range protocol.Range
 }
 
 type ListKnownPackagesResult struct {

--- a/gopls/internal/protocol/command/interface.go
+++ b/gopls/internal/protocol/command/interface.go
@@ -163,7 +163,7 @@ type Interface interface {
 	// ExtractToNewFile: Move selected declarations to a new file
 	//
 	// Used by the code action of the same name.
-	ExtractToNewFile(context.Context, ExtractToNewFileArgs) error
+	ExtractToNewFile(context.Context, protocol.Location) error
 
 	// StartDebugging: Start the gopls debug server
 	//
@@ -370,12 +370,6 @@ type AddImportArgs struct {
 	// URI is the file that the ImportPath should be
 	// added to
 	URI protocol.DocumentURI
-}
-
-type ExtractToNewFileArgs struct {
-	// URI of the file
-	URI   protocol.DocumentURI
-	Range protocol.Range
 }
 
 type ListKnownPackagesResult struct {

--- a/gopls/internal/protocol/edits.go
+++ b/gopls/internal/protocol/edits.go
@@ -129,6 +129,16 @@ func DocumentChangeEdit(fh fileHandle, textedits []TextEdit) DocumentChange {
 	}
 }
 
+// DocumentChangeCreate constructs a DocumentChange that creates a file.
+func DocumentChangeCreate(uri DocumentURI) DocumentChange {
+	return DocumentChange{
+		CreateFile: &CreateFile{
+			Kind: "create",
+			URI:  uri,
+		},
+	}
+}
+
 // DocumentChangeRename constructs a DocumentChange that renames a file.
 func DocumentChangeRename(src, dst DocumentURI) DocumentChange {
 	return DocumentChange{

--- a/gopls/internal/server/command.go
+++ b/gopls/internal/server/command.go
@@ -940,6 +940,22 @@ func (c *commandHandler) AddImport(ctx context.Context, args command.AddImportAr
 	})
 }
 
+func (c *commandHandler) ExtractToNewFile(ctx context.Context, args command.ExtractToNewFileArgs) error {
+	return c.run(ctx, commandConfig{
+		progress: "Extract to a new file",
+		forURI:   args.URI,
+	}, func(ctx context.Context, deps commandDeps) error {
+		edit, err := golang.ExtractToNewFile(ctx, deps.snapshot, deps.fh, args.Range)
+		if err != nil {
+			return err
+		}
+		if _, err := c.s.client.ApplyEdit(ctx, &protocol.ApplyWorkspaceEditParams{Edit: *edit}); err != nil {
+			return fmt.Errorf("could not apply edits: %v", err)
+		}
+		return nil
+	})
+}
+
 func (c *commandHandler) StartDebugging(ctx context.Context, args command.DebuggingArgs) (result command.DebuggingResult, _ error) {
 	addr := args.Addr
 	if addr == "" {

--- a/gopls/internal/server/command.go
+++ b/gopls/internal/server/command.go
@@ -940,17 +940,13 @@ func (c *commandHandler) AddImport(ctx context.Context, args command.AddImportAr
 	})
 }
 
-func (c *commandHandler) ExtractToNewFile(ctx context.Context, args command.ExtractToNewFileArgs) error {
+func (c *commandHandler) ExtractToNewFile(ctx context.Context, args protocol.Location) error {
 	return c.run(ctx, commandConfig{
 		progress: "Extract to a new file",
 		forURI:   args.URI,
 	}, func(ctx context.Context, deps commandDeps) error {
 		edit, err := golang.ExtractToNewFile(ctx, deps.snapshot, deps.fh, args.Range)
 		if err != nil {
-			if errors.Is(err, golang.ErrDotImport) {
-				showMessage(ctx, c.s.client, protocol.Info, err.Error())
-				return nil
-			}
 			return err
 		}
 		resp, err := c.s.client.ApplyEdit(ctx, &protocol.ApplyWorkspaceEditParams{Edit: *edit})

--- a/gopls/internal/test/integration/wrappers.go
+++ b/gopls/internal/test/integration/wrappers.go
@@ -117,9 +117,8 @@ func (e *Env) SetBufferContent(name string, content string) {
 }
 
 // FileContent returns the file content for name that applies to the current
-// editing session: if the file is open, it returns its buffer content,
-// otherwise it returns on disk content, if the file does not exist,
-// it returns an empty string.
+// editing session: it returns the buffer content for an open file, the
+// on-disk content for an unopened file, or "" for a non-existent file.
 func (e *Env) FileContent(name string) string {
 	e.T.Helper()
 	text, ok := e.Editor.BufferText(name)

--- a/gopls/internal/test/marker/testdata/codeaction/extracttofile.txt
+++ b/gopls/internal/test/marker/testdata/codeaction/extracttofile.txt
@@ -16,6 +16,8 @@ func fn() {} //@codeactionedit("func", "refactor.extract", function_declaration)
 
 func fn2() {} //@codeactionedit("fn2", "refactor.extract", only_select_func_name)
 
+func fn3() {} //@codeactionedit(re`()fn3`, "refactor.extract", zero_width_selection_on_func_name)
+
 // docs
 type T int //@codeactionedit("type", "refactor.extract", type_declaration)
 
@@ -58,12 +60,16 @@ package main
 import (
     "fmt"
     "log"
+    time1 "time"
 )
 func init(){
     log.Println()
 }
 func F() { //@codeactionedit("func", "refactor.extract", multiple_imports)
     fmt.Println()
+}
+func g() string{ //@codeactionedit("func", "refactor.extract", renamed_import)
+    return time1.Now().string()
 }
 
 -- blank_import.go --
@@ -83,7 +89,7 @@ func F() {} //@codeactionedit("func", "refactor.extract", blank_import)
 +
 +func F() {}
 -- @const_declaration/a.go --
-@@ -14,2 +14 @@
+@@ -16,2 +16 @@
 -// docs
 -const K = "" //@codeactionedit("const", "refactor.extract", const_declaration)
 +//@codeactionedit("const", "refactor.extract", const_declaration)
@@ -94,7 +100,7 @@ func F() {} //@codeactionedit("func", "refactor.extract", blank_import)
 +// docs
 +const K = ""
 -- @const_declaration_multiple_specs/a.go --
-@@ -17,6 +17 @@
+@@ -19,6 +19 @@
 -const ( //@codeactionedit("const", "refactor.extract", const_declaration_multiple_specs)
 -    P = iota
 -    Q
@@ -147,6 +153,8 @@ func fn() {} //@codeactionedit("func", "refactor.extract", function_declaration)
 
 func fn2() {} //@codeactionedit("fn2", "refactor.extract", only_select_func_name)
 
+func fn3() {} //@codeactionedit(re`()fn3`, "refactor.extract", zero_width_selection_on_func_name)
+
 // docs
 type T int //@codeactionedit("type", "refactor.extract", type_declaration)
 
@@ -188,11 +196,10 @@ func fnB() {}
 @@ -3 +3 @@
 -    "fmt"
 +    
-@@ -9,4 +9 @@
+@@ -10,3 +10 @@
 -func F() { //@codeactionedit("func", "refactor.extract", multiple_imports)
 -    fmt.Println()
 -}
--
 -- @only_select_func_name/a.go --
 @@ -6 +6 @@
 -func fn2() {} //@codeactionedit("fn2", "refactor.extract", only_select_func_name)
@@ -220,7 +227,7 @@ func fnB() {}
 -    fmt.Println()
 -}
 -- @type_declaration/a.go --
-@@ -8,2 +8 @@
+@@ -10,2 +10 @@
 -// docs
 -type T int //@codeactionedit("type", "refactor.extract", type_declaration)
 +//@codeactionedit("type", "refactor.extract", type_declaration)
@@ -231,7 +238,7 @@ func fnB() {}
 +// docs
 +type T int
 -- @var_declaration/a.go --
-@@ -11,2 +11 @@
+@@ -13,2 +13 @@
 -// docs
 -var V int //@codeactionedit("var", "refactor.extract", var_declaration)
 +//@codeactionedit("var", "refactor.extract", var_declaration)
@@ -241,3 +248,32 @@ func fnB() {}
 +
 +// docs
 +var V int
+-- @zero_width_selection_on_func_name/a.go --
+@@ -8 +8 @@
+-func fn3() {} //@codeactionedit(re`()fn3`, "refactor.extract", zero_width_selection_on_func_name)
++//@codeactionedit(re`()fn3`, "refactor.extract", zero_width_selection_on_func_name)
+-- @zero_width_selection_on_func_name/fn3.go --
+@@ -0,0 +1,3 @@
++package main
++
++func fn3() {}
+-- @renamed_import/g.go --
+@@ -0,0 +1,9 @@
++package main
++
++import (
++	time1 "time"
++)
++
++func g() string { //@codeactionedit("func", "refactor.extract", renamed_import)
++	return time1.Now().string()
++}
+-- @renamed_import/multiple_imports.go --
+@@ -5 +5 @@
+-    time1 "time"
++    
+@@ -13,4 +13 @@
+-func g() string{ //@codeactionedit("func", "refactor.extract", renamed_import)
+-    return time1.Now().string()
+-}
+-

--- a/gopls/internal/test/marker/testdata/codeaction/extracttofile.txt
+++ b/gopls/internal/test/marker/testdata/codeaction/extracttofile.txt
@@ -1,0 +1,249 @@
+This test checks the behavior of the 'extract to a new file' code action.
+
+-- flags --
+-ignore_extra_diags
+
+-- go.mod --
+module golang.org/lsptests/extracttofile
+
+go 1.18
+
+-- a.go --
+package main
+
+// docs
+func fn() {} //@codeactionedit("func", "refactor.extract", function_declaration)
+
+func fn2() {} //@codeactionedit("fn2", "refactor.extract", only_select_func_name)
+
+// docs
+type T int //@codeactionedit("type", "refactor.extract", type_declaration)
+
+// docs
+var V int //@codeactionedit("var", "refactor.extract", var_declaration)
+
+// docs
+const K = "" //@codeactionedit("const", "refactor.extract", const_declaration)
+
+const ( //@codeactionedit("const", "refactor.extract", const_declaration_multiple_specs)
+    P = iota
+    Q
+    R
+)
+
+func fnA () {} //@codeaction("func", mdEnd,  "refactor.extract", multiple_declarations)
+
+// unattached comment
+
+func fnB () {} //@loc(mdEnd, "}")
+
+
+-- existing.go --
+-- existing2.go --
+-- existing2.1.go --
+-- b.go --
+package main
+func existing() {} //@codeactionedit("func", "refactor.extract", file_name_conflict)
+func existing2() {} //@codeactionedit("func", "refactor.extract", file_name_conflict_again)
+
+-- single_import.go --
+package main
+import "fmt"
+func F() { //@codeactionedit("func", "refactor.extract", single_import)
+    fmt.Println()
+}
+
+-- multiple_imports.go --
+package main
+import (
+    "fmt"
+    "log"
+)
+func init(){
+    log.Println()
+}
+func F() { //@codeactionedit("func", "refactor.extract", multiple_imports)
+    fmt.Println()
+}
+
+-- blank_import.go --
+package main
+import _ "fmt"
+func F() {} //@codeactionedit("func", "refactor.extract", blank_import)
+
+-- dot_import.go --
+// This case is not yet implemented, it aborts and shows a message to the client. 
+package main
+import . "fmt"
+func F() { Println() } //@codeactionedit("func", "refactor.extract", dot_import)
+
+
+
+-- @blank_import/blank_import.go --
+@@ -3 +3 @@
+-func F() {} //@codeactionedit("func", "refactor.extract", blank_import)
++//@codeactionedit("func", "refactor.extract", blank_import)
+-- @blank_import/f.go --
+@@ -0,0 +1,3 @@
++package main
++
++func F() {}
+-- @const_declaration/a.go --
+@@ -14,2 +14 @@
+-// docs
+-const K = "" //@codeactionedit("const", "refactor.extract", const_declaration)
++//@codeactionedit("const", "refactor.extract", const_declaration)
+-- @const_declaration/k.go --
+@@ -0,0 +1,4 @@
++package main
++
++// docs
++const K = ""
+-- @const_declaration_multiple_specs/a.go --
+@@ -17,6 +17 @@
+-const ( //@codeactionedit("const", "refactor.extract", const_declaration_multiple_specs)
+-    P = iota
+-    Q
+-    R
+-)
+-
+-- @const_declaration_multiple_specs/p.go --
+@@ -0,0 +1,7 @@
++package main
++
++const ( //@codeactionedit("const", "refactor.extract", const_declaration_multiple_specs)
++	P = iota
++	Q
++	R
++)
+-- @file_name_conflict/b.go --
+@@ -2 +2 @@
+-func existing() {} //@codeactionedit("func", "refactor.extract", file_name_conflict)
++//@codeactionedit("func", "refactor.extract", file_name_conflict)
+-- @file_name_conflict/existing.1.go --
+@@ -0,0 +1,3 @@
++package main
++
++func existing() {}
+-- @file_name_conflict_again/b.go --
+@@ -3 +3 @@
+-func existing2() {} //@codeactionedit("func", "refactor.extract", file_name_conflict_again)
++//@codeactionedit("func", "refactor.extract", file_name_conflict_again)
+-- @file_name_conflict_again/existing2.2.go --
+@@ -0,0 +1,3 @@
++package main
++
++func existing2() {}
+-- @function_declaration/a.go --
+@@ -3,2 +3 @@
+-// docs
+-func fn() {} //@codeactionedit("func", "refactor.extract", function_declaration)
++//@codeactionedit("func", "refactor.extract", function_declaration)
+-- @function_declaration/fn.go --
+@@ -0,0 +1,4 @@
++package main
++
++// docs
++func fn() {}
+-- @multiple_declarations/a.go --
+package main
+
+// docs
+func fn() {} //@codeactionedit("func", "refactor.extract", function_declaration)
+
+func fn2() {} //@codeactionedit("fn2", "refactor.extract", only_select_func_name)
+
+// docs
+type T int //@codeactionedit("type", "refactor.extract", type_declaration)
+
+// docs
+var V int //@codeactionedit("var", "refactor.extract", var_declaration)
+
+// docs
+const K = "" //@codeactionedit("const", "refactor.extract", const_declaration)
+
+const ( //@codeactionedit("const", "refactor.extract", const_declaration_multiple_specs)
+    P = iota
+    Q
+    R
+)
+
+//@loc(mdEnd, "}")
+
+
+-- @multiple_declarations/fna.go --
+package main
+
+func fnA() {} //@codeaction("func", mdEnd,  "refactor.extract", multiple_declarations)
+
+// unattached comment
+
+func fnB() {}
+-- @multiple_imports/f.go --
+@@ -0,0 +1,9 @@
++package main
++
++import (
++	"fmt"
++)
++
++func F() { //@codeactionedit("func", "refactor.extract", multiple_imports)
++	fmt.Println()
++}
+-- @multiple_imports/multiple_imports.go --
+@@ -3 +3 @@
+-    "fmt"
++    
+@@ -9,4 +9 @@
+-func F() { //@codeactionedit("func", "refactor.extract", multiple_imports)
+-    fmt.Println()
+-}
+-
+-- @only_select_func_name/a.go --
+@@ -6 +6 @@
+-func fn2() {} //@codeactionedit("fn2", "refactor.extract", only_select_func_name)
++//@codeactionedit("fn2", "refactor.extract", only_select_func_name)
+-- @only_select_func_name/fn2.go --
+@@ -0,0 +1,3 @@
++package main
++
++func fn2() {}
+-- @single_import/f.go --
+@@ -0,0 +1,9 @@
++package main
++
++import (
++	"fmt"
++)
++
++func F() { //@codeactionedit("func", "refactor.extract", single_import)
++	fmt.Println()
++}
+-- @single_import/single_import.go --
+@@ -2,4 +2 @@
+-import "fmt"
+-func F() { //@codeactionedit("func", "refactor.extract", single_import)
+-    fmt.Println()
+-}
+-- @type_declaration/a.go --
+@@ -8,2 +8 @@
+-// docs
+-type T int //@codeactionedit("type", "refactor.extract", type_declaration)
++//@codeactionedit("type", "refactor.extract", type_declaration)
+-- @type_declaration/t.go --
+@@ -0,0 +1,4 @@
++package main
++
++// docs
++type T int
+-- @var_declaration/a.go --
+@@ -11,2 +11 @@
+-// docs
+-var V int //@codeactionedit("var", "refactor.extract", var_declaration)
++//@codeactionedit("var", "refactor.extract", var_declaration)
+-- @var_declaration/v.go --
+@@ -0,0 +1,4 @@
++package main
++
++// docs
++var V int

--- a/gopls/internal/test/marker/testdata/codeaction/extracttofile.txt
+++ b/gopls/internal/test/marker/testdata/codeaction/extracttofile.txt
@@ -71,12 +71,6 @@ package main
 import _ "fmt"
 func F() {} //@codeactionedit("func", "refactor.extract", blank_import)
 
--- dot_import.go --
-// This case is not yet implemented, it aborts and shows a message to the client. 
-package main
-import . "fmt"
-func F() { Println() } //@codeactionedit("func", "refactor.extract", dot_import)
-
 
 
 -- @blank_import/blank_import.go --


### PR DESCRIPTION
This code action moves selected code sections to a newly created file within the same package. The created filename is chosen as the first {function, type, const, var} name encountered. In addition, import declarations are added or removed as needed.

Fixes golang/go#65707