### PR TITLE
x/tools/cmd/deadcode: return an end code.

### DIFF
--- a/cmd/deadcode/deadcode.go
+++ b/cmd/deadcode/deadcode.go
@@ -348,6 +348,9 @@ func main() {
 		format = *formatFlag
 	}
 	printObjects(format, packages)
+	if len(packages) > 0 {
+		os.Exit(1)
+	}
 }
 
 // prettyName is a fork of Function.String designed to reduce


### PR DESCRIPTION
return an end code when an unreachable code is detected.

For: [#66027](https://github.com/golang/go/issues/66027)