### PR TITLE
gopls: use slices package for reverse slice

### DIFF
--- a/gopls/internal/golang/completion/postfix_snippets.go
+++ b/gopls/internal/golang/completion/postfix_snippets.go
@@ -102,11 +102,8 @@ var postfixTmpls = []postfixTmpl{{
 	label:   "reverse",
 	details: "reverse slice",
 	body: `{{if and (eq .Kind "slice") .StmtOK -}}
-{{$i := .VarName nil "i"}}{{$j := .VarName nil "j" -}}
-for {{$i}}, {{$j}} := 0, len({{.X}})-1; {{$i}} < {{$j}}; {{$i}}, {{$j}} = {{$i}}+1, {{$j}}-1 {
-	{{.X}}[{{$i}}], {{.X}}[{{$j}}] = {{.X}}[{{$j}}], {{.X}}[{{$i}}]
-}
-{{end}}`,
+{{.Import "slices"}}.Reverse({{.X}})
+{{- end}}`,
 }, {
 	label:   "range",
 	details: "range over slice",

--- a/gopls/internal/test/integration/completion/postfix_snippet_test.go
+++ b/gopls/internal/test/integration/completion/postfix_snippet_test.go
@@ -108,12 +108,11 @@ func _() {
 			after: `
 package foo
 
+import "slices"
+
 func _() {
 	var foo []int
-	for i, j := 0, len(foo)-1; i < j; i, j = i+1, j-1 {
-	foo[i], foo[j] = foo[j], foo[i]
-}
-
+	slices.Reverse(foo)
 }
 `,
 		},

--- a/gopls/internal/test/marker/testdata/completion/postfix.txt
+++ b/gopls/internal/test/marker/testdata/completion/postfix.txt
@@ -63,7 +63,7 @@ func _() {
 	foo.len //@snippet(" //", postfixLen, "len(foo)")
 	foo.print //@snippet(" //", postfixPrint, `fmt.Printf("foo: %v\n", foo)`)
 	foo.rang //@snippet(" //", postfixRange, "for ${1:}, ${2:} := range foo {\n\t$0\n}")
-	foo.reverse //@snippet(" //", postfixReverse, "for i, j := 0, len(foo)-1; i < j; i, j = i+1, j-1 {\n\tfoo[i], foo[j] = foo[j], foo[i]\n}\n")
+	foo.reverse //@snippet(" //", postfixReverse, "slices.Reverse(foo)\n")
 	foo.sort //@snippet(" //", postfixSort, "sort.Slice(foo, func(i, j int) bool {\n\t$0\n})")
 	foo.va //@snippet(" //", postfixVar, "${1:} := foo")
 	foo.ifnotnil //@snippet(" //", postfixIfNotNil, "if foo != nil {\n\t$0\n}")

--- a/gopls/internal/test/marker/testdata/completion/postfix.txt
+++ b/gopls/internal/test/marker/testdata/completion/postfix.txt
@@ -63,7 +63,7 @@ func _() {
 	foo.len //@snippet(" //", postfixLen, "len(foo)")
 	foo.print //@snippet(" //", postfixPrint, `fmt.Printf("foo: %v\n", foo)`)
 	foo.rang //@snippet(" //", postfixRange, "for ${1:}, ${2:} := range foo {\n\t$0\n}")
-	foo.reverse //@snippet(" //", postfixReverse, "slices.Reverse(foo)\n")
+	foo.reverse //@snippet(" //", postfixReverse, "slices.Reverse(foo)")
 	foo.sort //@snippet(" //", postfixSort, "sort.Slice(foo, func(i, j int) bool {\n\t$0\n})")
 	foo.va //@snippet(" //", postfixVar, "${1:} := foo")
 	foo.ifnotnil //@snippet(" //", postfixIfNotNil, "if foo != nil {\n\t$0\n}")


### PR DESCRIPTION
slices has been supported in go1.21 and go1.22

Fixes golang/go#66222