### PR TITLE
x/tools/cmd/goimports: support workspace vendoring

### DIFF
--- a/internal/imports/mod.go
+++ b/internal/imports/mod.go
@@ -125,7 +125,7 @@ func newModuleResolver(e *ProcessEnv, moduleCacheCache *DirInfoCache) (*ModuleRe
 			return nil, err
 		}
 	} else {
-		vendorEnabled, mainModsVendor, err = gocommand.WorkspaceVendorEnabled(context.TODO(), inv, r.env.GocmdRunner)
+		vendorEnabled, mainModsVendor, err = gocommand.WorkspaceVendorEnabled(context.Background(), inv, r.env.GocmdRunner)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/imports/mod.go
+++ b/internal/imports/mod.go
@@ -112,11 +112,11 @@ func newModuleResolver(e *ProcessEnv, moduleCacheCache *DirInfoCache) (*ModuleRe
 	}
 
 	vendorEnabled := false
-	var mainModVendor *gocommand.ModuleJSON
+	var mainModVendor *gocommand.ModuleJSON    // for module vendoring
+	var mainModsVendor []*gocommand.ModuleJSON // for workspace vendoring
 
-	// Module vendor directories are ignored in workspace mode:
-	// https://go.googlesource.com/proposal/+/master/design/45713-workspace.md
-	if len(r.env.Env["GOWORK"]) == 0 {
+	goWork := r.env.Env["GOWORK"]
+	if len(goWork) == 0 {
 		// TODO(rfindley): VendorEnabled runs the go command to get GOFLAGS, but
 		// they should be available from the ProcessEnv. Can we avoid the redundant
 		// invocation?
@@ -124,18 +124,35 @@ func newModuleResolver(e *ProcessEnv, moduleCacheCache *DirInfoCache) (*ModuleRe
 		if err != nil {
 			return nil, err
 		}
+	} else {
+		vendorEnabled, mainModsVendor, err = gocommand.WorkspaceVendorEnabled(context.TODO(), inv, r.env.GocmdRunner)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	if mainModVendor != nil && vendorEnabled {
-		// Vendor mode is on, so all the non-Main modules are irrelevant,
-		// and we need to search /vendor for everything.
-		r.mains = []*gocommand.ModuleJSON{mainModVendor}
-		r.dummyVendorMod = &gocommand.ModuleJSON{
-			Path: "",
-			Dir:  filepath.Join(mainModVendor.Dir, "vendor"),
+	if vendorEnabled {
+		if mainModVendor != nil {
+			// Module vendor mode is on, so all the non-Main modules are irrelevant,
+			// and we need to search /vendor for everything.
+			r.mains = []*gocommand.ModuleJSON{mainModVendor}
+			r.dummyVendorMod = &gocommand.ModuleJSON{
+				Path: "",
+				Dir:  filepath.Join(mainModVendor.Dir, "vendor"),
+			}
+			r.modsByModPath = []*gocommand.ModuleJSON{mainModVendor, r.dummyVendorMod}
+			r.modsByDir = []*gocommand.ModuleJSON{mainModVendor, r.dummyVendorMod}
+		} else {
+			// Workspace vendor mode is on, so all the non-Main modules are irrelevant,
+			// and we need to search /vendor for everything.
+			r.mains = mainModsVendor
+			r.dummyVendorMod = &gocommand.ModuleJSON{
+				Path: "",
+				Dir:  filepath.Join(filepath.Dir(goWork), "vendor"),
+			}
+			r.modsByModPath = append(append([]*gocommand.ModuleJSON{}, mainModsVendor...), r.dummyVendorMod)
+			r.modsByDir = append(append([]*gocommand.ModuleJSON{}, mainModsVendor...), r.dummyVendorMod)
 		}
-		r.modsByModPath = []*gocommand.ModuleJSON{mainModVendor, r.dummyVendorMod}
-		r.modsByDir = []*gocommand.ModuleJSON{mainModVendor, r.dummyVendorMod}
 	} else {
 		// Vendor mode is off, so run go list -m ... to find everything.
 		err := r.initAllMods()

--- a/internal/imports/mod_go122_test.go
+++ b/internal/imports/mod_go122_test.go
@@ -1,0 +1,58 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build go1.22
+// +build go1.22
+
+package imports
+
+import (
+	"context"
+	"testing"
+)
+
+// Tests that go.work files and vendor directory are respected.
+func TestModWorkspaceVendoring(t *testing.T) {
+	mt := setup(t, nil, `
+-- go.work --
+go 1.22
+
+use (
+	./a
+	./b
+)
+-- a/go.mod --
+module example.com/a
+
+go 1.22
+
+require rsc.io/sampler v1.3.1
+-- a/a.go --
+package a
+
+import _ "rsc.io/sampler"
+-- b/go.mod --
+module example.com/b
+
+go 1.22
+-- b/b.go --
+package b
+`, "")
+	defer mt.cleanup()
+
+	// generate vendor directory
+	if _, err := mt.env.invokeGo(context.Background(), "work", "vendor"); err != nil {
+		t.Fatal(err)
+	}
+
+	// update module resolver
+	mt.env.ClearModuleInfo()
+	mt.env.UpdateResolver(mt.env.resolver.ClearForNewScan())
+
+	mt.assertModuleFoundInDir("example.com/a", "a", `main/a$`)
+	mt.assertScanFinds("example.com/a", "a")
+	mt.assertModuleFoundInDir("example.com/b", "b", `main/b$`)
+	mt.assertScanFinds("example.com/b", "b")
+	mt.assertModuleFoundInDir("rsc.io/sampler", "sampler", `/vendor/`)
+}

--- a/internal/imports/mod_test.go
+++ b/internal/imports/mod_test.go
@@ -879,51 +879,6 @@ package z
 	mt.assertModuleFoundInDir("example.com/z", "z", "main/z1_1_0$")
 }
 
-// Tests that go.work files and vendor directory are respected.
-func TestModWorkspaceVendoring(t *testing.T) {
-	mt := setup(t, nil, `
--- go.work --
-go 1.22
-
-use (
-	./a
-	./b
-)
--- a/go.mod --
-module example.com/a
-
-go 1.22
-
-require rsc.io/sampler v1.3.1
--- a/a.go --
-package a
-
-import _ "rsc.io/sampler"
--- b/go.mod --
-module example.com/b
-
-go 1.22
--- b/b.go --
-package b
-`, "")
-	defer mt.cleanup()
-
-	// generate vendor directory
-	if _, err := mt.env.invokeGo(context.Background(), "work", "vendor"); err != nil {
-		t.Fatal(err)
-	}
-
-	// update module resolver
-	mt.env.ClearModuleInfo()
-	mt.env.UpdateResolver(mt.env.resolver.ClearForNewScan())
-
-	mt.assertModuleFoundInDir("example.com/a", "a", `main/a$`)
-	mt.assertScanFinds("example.com/a", "a")
-	mt.assertModuleFoundInDir("example.com/b", "b", `main/b$`)
-	mt.assertScanFinds("example.com/b", "b")
-	mt.assertModuleFoundInDir("rsc.io/sampler", "sampler", `/vendor/`)
-}
-
 // Tests that we handle GO111MODULE=on with no go.mod file. See #30855.
 func TestNoMainModule(t *testing.T) {
 	mt := setup(t, map[string]string{"GO111MODULE": "on"}, `

--- a/internal/imports/mod_test.go
+++ b/internal/imports/mod_test.go
@@ -879,6 +879,51 @@ package z
 	mt.assertModuleFoundInDir("example.com/z", "z", "main/z1_1_0$")
 }
 
+// Tests that go.work files and vendor directory are respected.
+func TestModWorkspaceVendoring(t *testing.T) {
+	mt := setup(t, nil, `
+-- go.work --
+go 1.22
+
+use (
+	./a
+	./b
+)
+-- a/go.mod --
+module example.com/a
+
+go 1.22
+
+require rsc.io/sampler v1.3.1
+-- a/a.go --
+package a
+
+import _ "rsc.io/sampler"
+-- b/go.mod --
+module example.com/b
+
+go 1.22
+-- b/b.go --
+package b
+`, "")
+	defer mt.cleanup()
+
+	// generate vendor directory
+	if _, err := mt.env.invokeGo(context.Background(), "work", "vendor"); err != nil {
+		t.Fatal(err)
+	}
+
+	// update module resolver
+	mt.env.ClearModuleInfo()
+	mt.env.UpdateResolver(mt.env.resolver.ClearForNewScan())
+
+	mt.assertModuleFoundInDir("example.com/a", "a", `main/a$`)
+	mt.assertScanFinds("example.com/a", "a")
+	mt.assertModuleFoundInDir("example.com/b", "b", `main/b$`)
+	mt.assertScanFinds("example.com/b", "b")
+	mt.assertModuleFoundInDir("rsc.io/sampler", "sampler", `/vendor/`)
+}
+
 // Tests that we handle GO111MODULE=on with no go.mod file. See #30855.
 func TestNoMainModule(t *testing.T) {
 	mt := setup(t, map[string]string{"GO111MODULE": "on"}, `


### PR DESCRIPTION
Fixes golang/go#65744

This also fixes gopls imports.