### PR TITLE
toolstash: errors output should match errors guarded

### DIFF
--- a/cmd/toolstash/main.go
+++ b/cmd/toolstash/main.go
@@ -423,7 +423,7 @@ func sameObject(file1, file2 string) bool {
 			log.Fatalf("reading %s: %v", file1, err1)
 		}
 		if err2 != nil {
-			log.Fatalf("reading %s: %v", file2, err1)
+			log.Fatalf("reading %s: %v", file2, err2)
 		}
 		if c1 != c2 {
 			return false
@@ -450,7 +450,7 @@ func skipVersion(b1, b2 *bufio.Reader, file1, file2 string) bool {
 			log.Fatalf("reading %s: %v", file1, err1)
 		}
 		if err2 != nil {
-			log.Fatalf("reading %s: %v", file2, err1)
+			log.Fatalf("reading %s: %v", file2, err2)
 		}
 		if c1 != c2 {
 			return false
@@ -473,7 +473,7 @@ func skipVersion(b1, b2 *bufio.Reader, file1, file2 string) bool {
 			log.Fatalf("reading %s: %v", file1, err1)
 		}
 		if err2 != nil {
-			log.Fatalf("reading %s: %v", file2, err1)
+			log.Fatalf("reading %s: %v", file2, err2)
 		}
 		if c1 != c2 {
 			return false


### PR DESCRIPTION
The errors guarded against in the `if` conditions are not the errors printed with`log.Fatalf()` — instead, they are the same errors copied from the immediately-preceding error checks. Maybe some sort of copy-paste mistake.

Reasoning: 
- The error printed is always `nil` at the changed lines (`err1`).
- The error printed should be a non-`nil` error (`err2`).