### PR TITLE
gopls/internal/golang: show struct tag when hovering over fields

### DIFF
--- a/gopls/internal/golang/hover.go
+++ b/gopls/internal/golang/hover.go
@@ -262,6 +262,11 @@ func hover(ctx context.Context, snapshot *cache.Snapshot, fh file.Handle, pp pro
 	signature := objectString(obj, qf, declPos, declPGF.Tok, spec)
 	singleLineSignature := signature
 
+	// Display struct tag for struct fields at the end of the signature.
+	if field != nil && field.Tag != nil {
+		signature += " " + field.Tag.Value
+	}
+
 	// TODO(rfindley): we could do much better for inferred signatures.
 	// TODO(adonovan): fuse the two calls below.
 	if inferred := inferredSignature(pkg.TypesInfo(), ident); inferred != nil {

--- a/gopls/internal/test/marker/testdata/hover/structfield.txt
+++ b/gopls/internal/test/marker/testdata/hover/structfield.txt
@@ -1,0 +1,29 @@
+This test checks that the complete struct field is
+shown on hover (including struct tags and comments).
+
+-- go.mod --
+module example.com
+
+-- lib/lib.go --
+package lib
+
+type Something struct {
+    // Field with a tag
+    Field int `json:"field"`
+}
+
+func DoSomething() Something {
+    var s Something
+    s.Field = 42  //@hover("i", "Field", field)
+    return s
+}
+
+-- @field --
+```go
+field Field int `json:"field"`
+```
+
+Field with a tag
+
+
+[`(lib.Something).Field` on pkg.go.dev](https://pkg.go.dev/example.com/lib#Something.Field)


### PR DESCRIPTION
When hovering over a field with struct tags, gopls was omitting
struct tags. Fix this by extracting tags from the surrounding syntax.

Fixes golang/go#66176