### PR TITLE
x/tools/gopls: fix StmtToInsertVarBefore for switch stmts

### DIFF
--- a/gopls/internal/golang/extract.go
+++ b/gopls/internal/golang/extract.go
@@ -58,6 +58,15 @@ func extractVariable(fset *token.FileSet, start, end token.Pos, src []byte, file
 		return nil, nil, fmt.Errorf("cannot extract %T", expr)
 	}
 
+	// TODO: There is a bug here: for a variable declared in a labeled
+	// switch/for statement it returns the for/switch statement itself
+	// which produces the below code which is a compiler error e.g.
+	// label:
+	// switch r1 := r() { ... break label ... }
+	// On extracting "r()" to a variable
+	// label:
+	// x := r()
+	// switch r1 := x { ... break label ... } // compiler error
 	insertBeforeStmt := analysisinternal.StmtToInsertVarBefore(path)
 	if insertBeforeStmt == nil {
 		return nil, nil, fmt.Errorf("cannot find location to insert extraction")

--- a/gopls/internal/test/marker/testdata/codeaction/extract_variable-67905.txt
+++ b/gopls/internal/test/marker/testdata/codeaction/extract_variable-67905.txt
@@ -1,0 +1,38 @@
+This test verifies the fix for golang/go#67905: Extract variable from type
+switch produces invalid code
+
+-- go.mod --
+module mod.test/extract
+
+go 1.18
+
+-- extract_switch.go --
+package extract
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+)
+
+func r() io.Reader {
+	return &bytes.Buffer{}
+}
+
+func main() {
+	switch r := r().(type) { //@codeactionedit("r()", "refactor.extract", type_switch_func_call)
+	case *bytes.Buffer:
+		fmt.Println("buf", r.Available())
+	case *strings.Reader:
+		fmt.Println("str", r.Size())
+	default:
+		fmt.Println("ior")
+	}
+}
+
+-- @type_switch_func_call/extract_switch.go --
+@@ -15 +15,2 @@
+-	switch r := r().(type) { //@codeactionedit("r()", "refactor.extract", type_switch_func_call)
++	x := r()
++	switch r := x.(type) { //@codeactionedit("r()", "refactor.extract", type_switch_func_call)

--- a/gopls/internal/test/marker/testdata/codeaction/extract_variable-67905.txt
+++ b/gopls/internal/test/marker/testdata/codeaction/extract_variable-67905.txt
@@ -10,29 +10,20 @@ go 1.18
 package extract
 
 import (
-	"bytes"
-	"fmt"
 	"io"
-	"strings"
 )
 
-func r() io.Reader {
-	return &bytes.Buffer{}
-}
+func f() io.Reader
 
 func main() {
-	switch r := r().(type) { //@codeactionedit("r()", "refactor.extract", type_switch_func_call)
-	case *bytes.Buffer:
-		fmt.Println("buf", r.Available())
-	case *strings.Reader:
-		fmt.Println("str", r.Size())
+	switch r := f().(type) { //@codeactionedit("f()", "refactor.extract", type_switch_func_call)
 	default:
-		fmt.Println("ior")
+		_ = r
 	}
 }
 
 -- @type_switch_func_call/extract_switch.go --
-@@ -15 +15,2 @@
--	switch r := r().(type) { //@codeactionedit("r()", "refactor.extract", type_switch_func_call)
-+	x := r()
-+	switch r := x.(type) { //@codeactionedit("r()", "refactor.extract", type_switch_func_call)
+@@ -10 +10,2 @@
+-	switch r := f().(type) { //@codeactionedit("f()", "refactor.extract", type_switch_func_call)
++	x := f()
++	switch r := x.(type) { //@codeactionedit("f()", "refactor.extract", type_switch_func_call)

--- a/internal/analysisinternal/analysis.go
+++ b/internal/analysisinternal/analysis.go
@@ -269,6 +269,8 @@ func StmtToInsertVarBefore(path []ast.Node) ast.Stmt {
 		if expr.Init == enclosingStmt || expr.Post == enclosingStmt {
 			return expr
 		}
+	case *ast.SwitchStmt, *ast.TypeSwitchStmt:
+		return expr.(ast.Stmt)
 	}
 	return enclosingStmt.(ast.Stmt)
 }


### PR DESCRIPTION
The function StmtToInsertVarBefore on getting a
variable declaration in switch stmt was returning
the variable declaration statement instead of the
switch statment.

Fixes golang/go#67905