### PR TITLE
gopls/doc/release: fix the order of the code block

### DIFF
--- a/gopls/doc/release/v0.16.0.md
+++ b/gopls/doc/release/v0.16.0.md
@@ -1,12 +1,12 @@
 # gopls/v0.16.0
 
+This release includes several features and bug fixes, and is the first
+version of gopls to support Go 1.23. To install it, run:
+
 <!-- TODO: update this instruction once v0.16.0 is released -->
 ```
 go install golang.org/x/tools/gopls@v0.16.0-pre.1
 ```
-
-This release includes several features and bug fixes, and is the first
-version of gopls to support Go 1.23. To install it, run:
 
 ## New support policy; end of support for Go 1.19 and Go 1.20
 


### PR DESCRIPTION
Update the v0.16.0 release notes to correct the order of the code block
describes how to install.