### PR TITLE
use the clear function for the clear postfix and add slices support

### DIFF
--- a/gopls/internal/golang/completion/postfix_snippets.go
+++ b/gopls/internal/golang/completion/postfix_snippets.go
@@ -175,10 +175,8 @@ for {{.VarName .KeyType "k" | .Placeholder}}, {{.VarName .ElemType "v" | .Placeh
 	label:   "clear",
 	details: "clear map contents",
 	body: `{{if and (eq .Kind "map") .StmtOK -}}
-{{$k := (.VarName .KeyType "k")}}for {{$k}} := range {{.X}} {
-	delete({{.X}}, {{$k}})
-}
-{{end}}`,
+clear({{.X}})
+{{- end}}`,
 }, {
 	label:   "keys",
 	details: "create slice of keys",

--- a/gopls/internal/golang/completion/postfix_snippets.go
+++ b/gopls/internal/golang/completion/postfix_snippets.go
@@ -173,8 +173,8 @@ for {{.VarName .KeyType "k" | .Placeholder}}, {{.VarName .ElemType "v" | .Placeh
 {{- end}}`,
 }, {
 	label:   "clear",
-	details: "clear map contents",
-	body: `{{if and (eq .Kind "map") .StmtOK -}}
+	details: "clear contents",
+	body: `{{if and (eq .Kind "map" "slice") .StmtOK -}}
 clear({{.X}})
 {{- end}}`,
 }, {

--- a/gopls/internal/test/integration/completion/postfix_snippet_test.go
+++ b/gopls/internal/test/integration/completion/postfix_snippet_test.go
@@ -234,10 +234,7 @@ package foo
 
 func _() {
 	var foo map[string]int
-	for k := range foo {
-	delete(foo, k)
-}
-
+	clear(foo)
 }
 `,
 		},

--- a/gopls/internal/test/integration/completion/postfix_snippet_test.go
+++ b/gopls/internal/test/integration/completion/postfix_snippet_test.go
@@ -239,6 +239,25 @@ func _() {
 `,
 		},
 		{
+			name: "slice_clear",
+			before: `
+package foo
+
+func _() {
+	var foo []int
+	foo.clear
+}
+`,
+			after: `
+package foo
+
+func _() {
+	var foo []int
+	clear(foo)
+}
+`,
+		},
+		{
 			name: "map_keys",
 			before: `
 package foo

--- a/gopls/internal/test/marker/testdata/completion/postfix.txt
+++ b/gopls/internal/test/marker/testdata/completion/postfix.txt
@@ -39,6 +39,7 @@ func _() {
 
 func _() {
 	/* append! */ //@item(postfixAppend, "append!", "append and re-assign slice", "snippet")
+	/* clear! */ //@item(postfixClearSlice, "clear!", "clear contents", "snippet")
 	/* copy! */ //@item(postfixCopy, "copy!", "duplicate slice", "snippet")
 	/* for! */ //@item(postfixFor, "for!", "range over slice by index", "snippet")
 	/* forr! */ //@item(postfixForr, "forr!", "range over slice by index and value", "snippet")
@@ -52,10 +53,11 @@ func _() {
 	/* ifnotnil! */ //@item(postfixIfNotNil, "ifnotnil!", "if expr != nil", "snippet")
 
 	var foo []int
-	foo. //@complete(" //", postfixAppend, postfixCopy, postfixFor, postfixForr, postfixIfNotNil, postfixLast, postfixLen, postfixPrint, postfixRange, postfixReverse, postfixSort, postfixVar)
+	foo. //@complete(" //", postfixAppend, postfixClearSlice, postfixCopy, postfixFor, postfixForr, postfixIfNotNil, postfixLast, postfixLen, postfixPrint, postfixRange, postfixReverse, postfixSort, postfixVar)
 	foo = nil
 
 	foo.append //@snippet(" //", postfixAppend, "foo = append(foo, $0)")
+	foo.clear //@snippet(" //", postfixClearSlice, "clear(foo)")
 	foo.copy //snippet(" //", postfixCopy, "fooCopy := make([]int, len(foo))\ncopy($fooCopy, foo)\n")
 	foo.fo //@snippet(" //", postfixFor, "for ${1:} := range foo {\n\t$0\n}")
 	foo.forr //@snippet(" //", postfixForr, "for ${1:}, ${2:} := range foo {\n\t$0\n}")
@@ -73,7 +75,7 @@ func _() {
 	/* for! */ //@item(postfixForMap, "for!", "range over map by key", "snippet")
 	/* forr! */ //@item(postfixForrMap, "forr!", "range over map by key and value", "snippet")
 	/* range! */ //@item(postfixRangeMap, "range!", "range over map", "snippet")
-	/* clear! */ //@item(postfixClear, "clear!", "clear map contents", "snippet")
+	/* clear! */ //@item(postfixClear, "clear!", "clear contents", "snippet")
 	/* keys! */ //@item(postfixKeys, "keys!", "create slice of keys", "snippet")
 
 	var foo map[int]int

--- a/gopls/internal/test/marker/testdata/completion/postfix.txt
+++ b/gopls/internal/test/marker/testdata/completion/postfix.txt
@@ -84,7 +84,7 @@ func _() {
 	foo.fo //@snippet(" //", postfixFor, "for ${1:} := range foo {\n\t$0\n}")
 	foo.forr //@snippet(" //", postfixForr, "for ${1:}, ${2:} := range foo {\n\t$0\n}")
 	foo.rang //@snippet(" //", postfixRange, "for ${1:}, ${2:} := range foo {\n\t$0\n}")
-	foo.clear //@snippet(" //", postfixClear, "for k := range foo {\n\tdelete(foo, k)\n}\n")
+	foo.clear //@snippet(" //", postfixClear, "clear(foo)")
 	foo.keys //@snippet(" //", postfixKeys, "keys := make([]int, 0, len(foo))\nfor k := range foo {\n\tkeys = append(keys, k)\n}\n")
 }
 


### PR DESCRIPTION
- Changes the clear postfix to use the clear function introduced in Go 1.21
- Add support for slices for the clear postfix
