### PR TITLE
go/packages: do not nullify Fset when NeedSyntax is set

### DIFF
--- a/go/packages/packages.go
+++ b/go/packages/packages.go
@@ -76,7 +76,7 @@ const (
 	// NeedTypes adds Types, Fset, and IllTyped.
 	NeedTypes
 
-	// NeedSyntax adds Syntax.
+	// NeedSyntax adds Syntax and Fset.
 	NeedSyntax
 
 	// NeedTypesInfo adds TypesInfo.
@@ -961,11 +961,13 @@ func (ld *loader) refine(response *DriverResponse) ([]*Package, error) {
 		}
 		if ld.requestedMode&NeedTypes == 0 {
 			ld.pkgs[i].Types = nil
-			ld.pkgs[i].Fset = nil
 			ld.pkgs[i].IllTyped = false
 		}
 		if ld.requestedMode&NeedSyntax == 0 {
 			ld.pkgs[i].Syntax = nil
+		}
+		if ld.requestedMode&NeedTypes == 0 && ld.requestedMode&NeedSyntax == 0 {
+			ld.pkgs[i].Fset = nil
 		}
 		if ld.requestedMode&NeedTypesInfo == 0 {
 			ld.pkgs[i].TypesInfo = nil

--- a/go/packages/packages.go
+++ b/go/packages/packages.go
@@ -46,7 +46,6 @@ import (
 //
 // Unfortunately there are a number of open bugs related to
 // interactions among the LoadMode bits:
-// - https://github.com/golang/go/issues/48226
 // - https://github.com/golang/go/issues/56633
 // - https://github.com/golang/go/issues/56677
 // - https://github.com/golang/go/issues/58726


### PR DESCRIPTION
Currently, Fset is initialized when either NeedTypes or NeedSyntax are set in newLoader().

However, later in refine() it is nullified using a different condition that doesn't take NeedSyntax into account.

Use the inverse condition to that of in newLoader() when deciding on whether to nullify Fset or not.

Resolves https://github.com/golang/go/issues/48226.