### PR TITLE
Fix a test related to cyclic import error

### DIFF
--- a/go/packages/packages_test.go
+++ b/go/packages/packages_test.go
@@ -2370,7 +2370,7 @@ func testCycleImportStack(t *testing.T, exporter packagestest.Exporter) {
 	if len(pkg.Errors) != 1 {
 		t.Fatalf("Expected one error in package, got %v", pkg.Errors)
 	}
-	expected := "import cycle not allowed: import stack: [golang.org/fake/a golang.org/fake/b golang.org/fake/a]"
+	expected := "import cycle not allowed: import stack: [golang.org/fake/a golang.org/fake/b from a.go golang.org/fake/a from b.go]"
 	if pkg.Errors[0].Msg != expected {
 		t.Fatalf("Expected error %q, got %q", expected, pkg.Errors[0].Msg)
 	}


### PR DESCRIPTION
TDLR: In the PR https://github.com/golang/go/pull/68337, we added more info in the error stack, it needs a change in x/tools'test too.
Before:
golang.org/fake/a 
golang.org/fake/b 
golang.org/fake/a
After:
golang.org/fake/a 
golang.org/fake/b from a.go 
golang.org/fake/a from b.go
