### PR TITLE
gopls: report semantic tokens of top-level type constructor modifiers

### DIFF
--- a/gopls/doc/features/passive.md
+++ b/gopls/doc/features/passive.md
@@ -207,7 +207,7 @@ a portion of it.
 The client may use this information to provide syntax highlighting
 that conveys semantic distinctions between, for example, functions and
 types, constants and variables, or library functions and built-ins.
-Gopls also reports a modifier for the top-level constructor of the object's type, one of:
+Gopls also reports a modifier for the top-level constructor of each symbols's type, one of:
 `interface`, `struct`, `signature`, `pointer`, `array`, `map`, `slice`, `chan`, `string`, `number`, `bool`, `invalid`.
 The client specifies the sets of types and modifiers it is interested in.
 

--- a/gopls/doc/features/passive.md
+++ b/gopls/doc/features/passive.md
@@ -207,6 +207,8 @@ a portion of it.
 The client may use this information to provide syntax highlighting
 that conveys semantic distinctions between, for example, functions and
 types, constants and variables, or library functions and built-ins.
+Gopls also reports a modifier for the top-level constructor of the object's type, one of:
+`interface`, `struct`, `signature`, `pointer`, `array`, `map`, `slice`, `chan`, `string`, `number`, `bool`, `invalid`.
 The client specifies the sets of types and modifiers it is interested in.
 
 Settings:

--- a/gopls/doc/release/v0.17.0.md
+++ b/gopls/doc/release/v0.17.0.md
@@ -30,5 +30,8 @@ Go release containing the symbol. For example, hovering over `errors.As` shows
 "Added in go1.13".
 
 ## Semantic token modifiers of top-level constructor of types
-The semantic tokens response now includes additional 12 modifiers for the top-level constructor of the type of each symbol: `interface`, `struct`, `signature`, `pointer`, `array`, `map`, `slice`, `chan`, `string`, `number`, `bool` and `invalid`. Editors may use this for syntax coloring.
+The semantic tokens response now includes additional modifiers for the top-level
+constructor of the type of each symbol:
+`interface`, `struct`, `signature`, `pointer`, `array`, `map`, `slice`, `chan`, `string`, `number`, `bool`, and `invalid`.
+Editors may use this for syntax coloring.
 

--- a/gopls/doc/release/v0.17.0.md
+++ b/gopls/doc/release/v0.17.0.md
@@ -28,3 +28,7 @@ of paritial selection of a declration cannot invoke this code action.
 Hovering over a standard library symbol now displays information about the first
 Go release containing the symbol. For example, hovering over `errors.As` shows
 "Added in go1.13".
+
+## Semantic token modifiers of top-level constructor of types
+The semantic tokens response now includes additional 12 modifiers for the top-level constructor of the type of each symbol: `interface`, `struct`, `signature`, `pointer`, `array`, `map`, `slice`, `chan`, `string`, `number`, `bool` and `invalid`. Editors may use this for syntax coloring.
+

--- a/gopls/doc/semantictokens.md
+++ b/gopls/doc/semantictokens.md
@@ -72,9 +72,14 @@ The references to *object* refer to the
 1. __`keyword`__ All Go [keywords](https://golang.org/ref/spec#Keywords) are marked `keyword`.
 1. __`namespace`__ All package names are marked `namespace`. In an import, if there is an
 alias, it would be marked. Otherwise the last component of the import path is marked.
-1. __`type`__ Objects of type ```types.TypeName``` are marked `type`.
-If they are also ```types.Basic```
+1. __`type`__ Objects of type ```types.TypeName``` are marked `type`, it also reports
+various top-level type constructor modifiers.
+If they are ```types.Basic```
 the modifier is `defaultLibrary`. (And in ```type B struct{C}```, ```B``` has modifier `definition`.)
+If they are ```types.Interface```
+the modifier is `interface`,
+same as `struct`, `signature`, `pointer`, `array`, `map`, `slice`, `chan`,
+together with `interface`, they are the 8 additional modifiers gopls supports.
 1. __`parameter`__ The formal arguments in ```ast.FuncDecl``` and ```ast.FuncType``` nodes are marked `parameter`.
 1. __`variable`__  Identifiers in the
 scope of ```const``` are modified with `readonly`. ```nil``` is usually a `variable` modified with both

--- a/gopls/doc/semantictokens.md
+++ b/gopls/doc/semantictokens.md
@@ -72,14 +72,9 @@ The references to *object* refer to the
 1. __`keyword`__ All Go [keywords](https://golang.org/ref/spec#Keywords) are marked `keyword`.
 1. __`namespace`__ All package names are marked `namespace`. In an import, if there is an
 alias, it would be marked. Otherwise the last component of the import path is marked.
-1. __`type`__ Objects of type ```types.TypeName``` are marked `type`, it also reports
-various top-level type constructor modifiers.
-If they are ```types.Basic```
-the modifier is `defaultLibrary`. (And in ```type B struct{C}```, ```B``` has modifier `definition`.)
-If they are ```types.Interface```
-the modifier is `interface`,
-same as `struct`, `signature`, `pointer`, `array`, `map`, `slice`, `chan`,
-together with `interface`, they are the 8 additional modifiers gopls supports.
+1. __`type`__ Objects of type ```types.TypeName``` are marked `type`. It also reports
+a modifier for the top-level constructor of the object's type, one of:
+`interface`, `struct`, `signature`, `pointer`, `array`, `map`, `slice`, `chan`, `string`, `number`, `bool`, `invalid`.
 1. __`parameter`__ The formal arguments in ```ast.FuncDecl``` and ```ast.FuncType``` nodes are marked `parameter`.
 1. __`variable`__  Identifiers in the
 scope of ```const``` are modified with `readonly`. ```nil``` is usually a `variable` modified with both

--- a/gopls/internal/cmd/integration_test.go
+++ b/gopls/internal/cmd/integration_test.go
@@ -819,7 +819,7 @@ const c = 0
 		want := `
 /*⇒7,keyword,[]*/package /*⇒1,namespace,[]*/a
 /*⇒4,keyword,[]*/func /*⇒1,function,[definition]*/f()
-/*⇒3,keyword,[]*/var /*⇒1,variable,[definition]*/v /*⇒3,type,[defaultLibrary]*/int
+/*⇒3,keyword,[]*/var /*⇒1,variable,[definition]*/v /*⇒3,type,[defaultLibrary number]*/int
 /*⇒5,keyword,[]*/const /*⇒1,variable,[definition readonly]*/c = /*⇒1,number,[]*/0
 `[1:]
 		if got != want {

--- a/gopls/internal/golang/semtok.go
+++ b/gopls/internal/golang/semtok.go
@@ -516,8 +516,7 @@ func appendTypeModifiers(mods []string, obj types.Object) []string {
 		case types.UnsafePointer:
 			mods = append(mods, "pointer")
 		default:
-			info := t.Info()
-			if info == types.IsFloat || info == types.IsComplex || info == types.IsInteger {
+			if t.Info()&types.IsNumeric != 0 {
 				mods = append(mods, "number")
 			}
 		}

--- a/gopls/internal/protocol/semantic.go
+++ b/gopls/internal/protocol/semantic.go
@@ -52,6 +52,7 @@ var (
 	semanticModifiers = [...]string{
 		"declaration", "definition", "readonly", "static",
 		"deprecated", "abstract", "async", "modification", "documentation", "defaultLibrary",
-		"interface", "struct", "signature", "pointer", "array", "map", "slice", "chan",
+		// Additional modifiers
+		"interface", "struct", "signature", "pointer", "array", "map", "slice", "chan", "string", "number", "bool", "invalid",
 	}
 )

--- a/gopls/internal/protocol/semantic.go
+++ b/gopls/internal/protocol/semantic.go
@@ -52,5 +52,6 @@ var (
 	semanticModifiers = [...]string{
 		"declaration", "definition", "readonly", "static",
 		"deprecated", "abstract", "async", "modification", "documentation", "defaultLibrary",
+		"interface", "struct", "signature", "pointer", "array", "map", "slice", "chan",
 	}
 )

--- a/gopls/internal/test/integration/fake/editor.go
+++ b/gopls/internal/test/integration/fake/editor.go
@@ -354,6 +354,8 @@ func clientCapabilities(cfg EditorConfig) (protocol.ClientCapabilities, error) {
 	capabilities.TextDocument.SemanticTokens.TokenModifiers = []string{
 		"declaration", "definition", "readonly", "static",
 		"deprecated", "abstract", "async", "modification", "documentation", "defaultLibrary",
+		// Additional modifiers supported by this client:
+		"interface", "struct", "signature", "pointer", "array", "map", "slice", "chan",
 	}
 	// The LSP tests have historically enabled this flag,
 	// but really we should test both ways for older editors.

--- a/gopls/internal/test/integration/fake/editor.go
+++ b/gopls/internal/test/integration/fake/editor.go
@@ -355,7 +355,7 @@ func clientCapabilities(cfg EditorConfig) (protocol.ClientCapabilities, error) {
 		"declaration", "definition", "readonly", "static",
 		"deprecated", "abstract", "async", "modification", "documentation", "defaultLibrary",
 		// Additional modifiers supported by this client:
-		"interface", "struct", "signature", "pointer", "array", "map", "slice", "chan",
+		"interface", "struct", "signature", "pointer", "array", "map", "slice", "chan", "string", "number", "bool", "invalid",
 	}
 	// The LSP tests have historically enabled this flag,
 	// but really we should test both ways for older editors.

--- a/gopls/internal/test/integration/misc/semantictokens_test.go
+++ b/gopls/internal/test/integration/misc/semantictokens_test.go
@@ -57,7 +57,7 @@ func TestSemantic_2527(t *testing.T) {
 		{Token: "func", TokenType: "keyword"},
 		{Token: "Add", TokenType: "function", Mod: "definition deprecated"},
 		{Token: "T", TokenType: "typeParameter", Mod: "definition"},
-		{Token: "int", TokenType: "type", Mod: "defaultLibrary"},
+		{Token: "int", TokenType: "type", Mod: "defaultLibrary number"},
 		{Token: "target", TokenType: "parameter", Mod: "definition"},
 		{Token: "T", TokenType: "typeParameter"},
 		{Token: "l", TokenType: "parameter", Mod: "definition"},

--- a/gopls/internal/test/marker/testdata/token/comment.txt
+++ b/gopls/internal/test/marker/testdata/token/comment.txt
@@ -21,7 +21,7 @@ var B = 2
 type Foo int
 
 
-// [F] accept a [Foo], and print it. //@token("F", "function", ""),token("Foo", "type", "")
+// [F] accept a [Foo], and print it. //@token("F", "function", ""),token("Foo", "type", "defaultLibrary number")
 func F(v Foo) {
 	println(v)
 
@@ -44,7 +44,7 @@ func F2(s string) {
 -- b.go --
 package p
 
-// [F3] accept [*Foo]	//@token("F3", "function", ""),token("Foo", "type", "")
+// [F3] accept [*Foo]	//@token("F3", "function", ""),token("Foo", "type", "defaultLibrary number")
 func F3(v *Foo) {
 	println(*v)
 }


### PR DESCRIPTION
These new semantic type modifiers will be reported in places of type definition,
type embedding, type alias, variable definition, parameter type,
return type and comments link.

Fixes golang/go#68975

