### PR TITLE
go/ssa: pop targets stack on range-over-func

### DIFF
--- a/go/ssa/builder.go
+++ b/go/ssa/builder.go
@@ -2566,6 +2566,8 @@ func (b *builder) rangeFunc(fn *Function, x Value, tk, tv types.Type, rng *ast.R
 
 	emitJump(fn, done)
 	fn.currentBlock = done
+	// pop the stack for the range-over-func
+	fn.targets = fn.targets.tail
 }
 
 // buildYieldResume emits to fn code for how to resume execution once a call to
@@ -2998,6 +3000,7 @@ func (b *builder) buildYieldFunc(fn *Function) {
 		}
 	}
 	fn.targets = &targets{
+		tail:      fn.targets,
 		_continue: ycont,
 		// `break` statement targets fn.parent.targets._break.
 	}
@@ -3075,6 +3078,8 @@ func (b *builder) buildYieldFunc(fn *Function) {
 		// unreachable.
 		emitJump(fn, ycont)
 	}
+	// pop the stack for the yield function
+	fn.targets = fn.targets.tail
 
 	// Clean up exits and promote any unresolved exits to fn.parent.
 	for _, e := range fn.exits {

--- a/go/ssa/interp/interp_go122_test.go
+++ b/go/ssa/interp/interp_go122_test.go
@@ -39,6 +39,18 @@ func TestExperimentRange(t *testing.T) {
 	run(t, filepath.Join(cwd, "testdata", "rangeoverint.go"), goroot)
 }
 
+func TestIssue69298(t *testing.T) {
+	testenv.NeedsGo1Point(t, 23)
+
+	// TODO: Is cwd actually needed here?
+	goroot := makeGoroot(t)
+	cwd, err := os.Getwd()
+	if err != nil {
+		log.Fatal(err)
+	}
+	run(t, filepath.Join(cwd, "testdata", "fixedbugs/issue69298.go"), goroot)
+}
+
 // TestRangeFunc tests range-over-func in a subprocess.
 func TestRangeFunc(t *testing.T) {
 	testenv.NeedsGo1Point(t, 23)

--- a/go/ssa/interp/interp_test.go
+++ b/go/ssa/interp/interp_test.go
@@ -135,7 +135,6 @@ var testdataTests = []string{
 	"fixedbugs/issue52835.go",
 	"fixedbugs/issue55086.go",
 	"fixedbugs/issue66783.go",
-	"fixedbugs/issue69298.go",
 	"typeassert.go",
 	"zeros.go",
 }

--- a/go/ssa/interp/interp_test.go
+++ b/go/ssa/interp/interp_test.go
@@ -135,6 +135,7 @@ var testdataTests = []string{
 	"fixedbugs/issue52835.go",
 	"fixedbugs/issue55086.go",
 	"fixedbugs/issue66783.go",
+	"fixedbugs/issue69298.go",
 	"typeassert.go",
 	"zeros.go",
 }

--- a/go/ssa/interp/testdata/fixedbugs/issue69298.go
+++ b/go/ssa/interp/testdata/fixedbugs/issue69298.go
@@ -1,0 +1,31 @@
+// Copyright 2024 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"fmt"
+)
+
+type Seq[V any] func(yield func(V) bool)
+
+func AppendSeq[Slice ~[]E, E any](s Slice, seq Seq[E]) Slice {
+	for v := range seq {
+		s = append(s, v)
+	}
+	return s
+}
+
+func main() {
+	seq := func(yield func(int) bool) {
+		for i := 0; i < 10; i += 2 {
+			if !yield(i) {
+				return
+			}
+		}
+	}
+
+	s := AppendSeq([]int{1, 2}, seq)
+	fmt.Println(s)
+}

--- a/go/ssa/sanity.go
+++ b/go/ssa/sanity.go
@@ -438,12 +438,53 @@ func (s *sanity) checkFunctionParams(fn *Function) {
 	}
 }
 
+// checkTransientFields checks whether all transient fields of Function are cleared.
+func (s *sanity) checkTransientFields(fn *Function) {
+	if fn.build != nil {
+		s.errorf("function transient field 'build' is not nil")
+	}
+	if fn.currentBlock != nil {
+		s.errorf("function transient field 'currentBlock' is not nil")
+	}
+	if fn.vars != nil {
+		s.errorf("function transient field 'vars' is not nil")
+	}
+	if fn.results != nil {
+		s.errorf("function transient field 'results' is not nil")
+	}
+	if fn.returnVars != nil {
+		s.errorf("function transient field 'returnVars' is not nil")
+	}
+	if fn.targets != nil {
+		s.errorf("function transient field 'targets' is not nil")
+	}
+	if fn.lblocks != nil {
+		s.errorf("function transient field 'lblocks' is not nil")
+	}
+	if fn.subst != nil {
+		s.errorf("function transient field 'subst' is not nil")
+	}
+	if fn.jump != nil {
+		s.errorf("function transient field 'jump' is not nil")
+	}
+	if fn.deferstack != nil {
+		s.errorf("function transient field 'deferstack' is not nil")
+	}
+	if fn.source != nil {
+		s.errorf("function transient field 'source' is not nil")
+	}
+	if fn.exits != nil {
+		s.errorf("function transient field 'exits' is not nil")
+	}
+	if fn.uniq != 0 {
+		s.errorf("function transient field 'uniq' is not zero")
+	}
+}
+
 func (s *sanity) checkFunction(fn *Function) bool {
 	s.fn = fn
-	// TODO(yuchen): fix the bug caught on fn.targets when checking transient fields
-	// see https://go-review.googlesource.com/c/tools/+/610059/comment/4287a123_dc6cbc44/
-
 	s.checkFunctionParams(fn)
+	s.checkTransientFields(fn)
 
 	// TODO(taking): Sanity check origin, typeparams, and typeargs.
 	if fn.Prog == nil {

--- a/go/ssa/sanity.go
+++ b/go/ssa/sanity.go
@@ -439,7 +439,8 @@ func (s *sanity) checkFunctionParams(fn *Function) {
 }
 
 // checkTransientFields checks whether all transient fields of Function are cleared.
-func (s *sanity) checkTransientFields(fn *Function) {
+func (s *sanity) checkTransientFields() {
+	fn := s.fn
 	if fn.build != nil {
 		s.errorf("function transient field 'build' is not nil")
 	}
@@ -484,7 +485,7 @@ func (s *sanity) checkTransientFields(fn *Function) {
 func (s *sanity) checkFunction(fn *Function) bool {
 	s.fn = fn
 	s.checkFunctionParams(fn)
-	s.checkTransientFields(fn)
+	s.checkTransientFields()
 
 	// TODO(taking): Sanity check origin, typeparams, and typeargs.
 	if fn.Prog == nil {

--- a/go/ssa/sanity.go
+++ b/go/ssa/sanity.go
@@ -407,9 +407,9 @@ func (s *sanity) checkReferrerList(v Value) {
 	}
 }
 
-func (s *sanity) checkFunctionParams(fn *Function) {
-	signature := fn.Signature
-	params := fn.Params
+func (s *sanity) checkFunctionParams() {
+	signature := s.fn.Signature
+	params := s.fn.Params
 
 	// startSigParams is the start of signature.Params() within params.
 	startSigParams := 0
@@ -484,7 +484,7 @@ func (s *sanity) checkTransientFields() {
 
 func (s *sanity) checkFunction(fn *Function) bool {
 	s.fn = fn
-	s.checkFunctionParams(fn)
+	s.checkFunctionParams()
 	s.checkTransientFields()
 
 	// TODO(taking): Sanity check origin, typeparams, and typeargs.


### PR DESCRIPTION
Pop Function.targets when building a call to a range-over-func yield function and when building the yield function.
    
Also adds sanity checks to ensure all function transient fields are cleared.
    
Fixes golang/go#69298