### PR TITLE
go/ssa: remove outdated doc in CreatePackage and add respective test cases

### DIFF
--- a/go/ssa/create.go
+++ b/go/ssa/create.go
@@ -193,14 +193,11 @@ func membersFromDecl(pkg *Package, decl ast.Decl, goversion string) {
 //
 // The real work of building SSA form for each function is not done
 // until a subsequent call to Package.Build.
-//
-// CreatePackage should not be called after building any package in
-// the program.
 func (prog *Program) CreatePackage(pkg *types.Package, files []*ast.File, info *types.Info, importable bool) *Package {
-	// TODO(adonovan): assert that no package has yet been built.
 	if pkg == nil {
 		panic("nil pkg") // otherwise pkg.Scope below returns types.Universe!
 	}
+
 	p := &Package{
 		Prog:    prog,
 		Members: make(map[string]Member),

--- a/go/ssa/sanity.go
+++ b/go/ssa/sanity.go
@@ -609,6 +609,20 @@ func sanityCheckPackage(pkg *Package) {
 	if pkg.Pkg == nil {
 		panic(fmt.Sprintf("Package %s has no Object", pkg))
 	}
+
+	if pkg.info != nil {
+		panic(fmt.Sprintf("package %s field 'info' is not cleared", pkg))
+	}
+	if pkg.files != nil {
+		panic(fmt.Sprintf("package %s field 'files' is not cleared", pkg))
+	}
+	if pkg.created != nil {
+		panic(fmt.Sprintf("package %s field 'created' is not cleared", pkg))
+	}
+	if pkg.initVersion != nil {
+		panic(fmt.Sprintf("package %s field 'initVersion' is not cleared", pkg))
+	}
+
 	_ = pkg.String() // must not crash
 
 	for name, mem := range pkg.Members {

--- a/go/ssa/ssa.go
+++ b/go/ssa/ssa.go
@@ -66,7 +66,7 @@ type Package struct {
 
 	// The following fields are set transiently, then cleared
 	// after building.
-	buildOnce   sync.Once           // ensures package building occurs once
+	buildOnce   sync.Once           // ensures package building occurs once so it won't be cleared after building
 	ninit       int32               // number of init functions
 	info        *types.Info         // package type information
 	files       []*ast.File         // package ASTs
@@ -342,7 +342,7 @@ type Function struct {
 	// source information
 	Synthetic string      // provenance of synthetic function; "" for true source functions
 	syntax    ast.Node    // *ast.Func{Decl,Lit}, if from syntax (incl. generic instances) or (*ast.RangeStmt if a yield function)
-	info      *types.Info // type annotations (iff syntax != nil)
+	info      *types.Info // type annotations (if syntax != nil)
 	goversion string      // Go version of syntax (NB: init is special)
 
 	parent *Function // enclosing function if anon; nil if global

--- a/go/ssa/testdata/objlookup.txtar
+++ b/go/ssa/testdata/objlookup.txtar
@@ -1,5 +1,8 @@
-// +build ignore
+-- go.mod --
+module example.com
+go 1.18
 
+-- objlookup.go --
 package main
 
 // This file is the input to TestObjValueLookup in source_test.go,

--- a/go/ssa/testdata/structconv.txtar
+++ b/go/ssa/testdata/structconv.txtar
@@ -1,5 +1,8 @@
-// +build ignore
+-- go.mod --
+module example.com
+go 1.18
 
+-- structconv.go --
 // This file is the input to TestValueForExprStructConv in identical_test.go,
 // which uses the same framework as TestValueForExpr does in source_test.go.
 //

--- a/go/ssa/testdata/valueforexpr.txtar
+++ b/go/ssa/testdata/valueforexpr.txtar
@@ -1,6 +1,8 @@
-//go:build ignore
-// +build ignore
+-- go.mod --
+module example.com
+go 1.18
 
+-- valueforexpr.go --
 package main
 
 // This file is the input to TestValueForExpr in source_test.go, which

--- a/go/ssa/testhelper_test.go
+++ b/go/ssa/testhelper_test.go
@@ -4,7 +4,153 @@
 
 package ssa
 
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"testing"
+
+	"golang.org/x/tools/go/packages"
+	"golang.org/x/tools/internal/testfiles"
+	"golang.org/x/tools/txtar"
+)
+
 // SetNormalizeAnyForTesting is exported here for external tests.
 func SetNormalizeAnyForTesting(normalize bool) {
 	normalizeAnyForTesting = normalize
+}
+
+// ArchiveFromSingleFileContent creates a go module named example.com
+// in txtar format and put the given content in main.go file under the module.
+// The package is decided by the package clause in the content.
+// The content should contain no error as a typical go file.
+//
+// It's useful when we want to define a package in a string variable instead of putting it inside a file.
+func ArchiveFromSingleFileContent(content string) string {
+	return fmt.Sprintf(`
+-- go.mod --
+module example.com
+go 1.18
+
+-- main.go --
+%s`, content)
+}
+
+// PackagesFromArchive creates the packages from archive with txtar format.
+func PackagesFromArchive(t *testing.T, archive string) []*packages.Package {
+	ar := txtar.Parse([]byte(archive))
+
+	fs, err := txtar.FS(ar)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dir := testfiles.CopyToTmp(t, fs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var baseConfig = &packages.Config{
+		Mode: packages.NeedSyntax |
+			packages.NeedTypesInfo |
+			packages.NeedDeps |
+			packages.NeedName |
+			packages.NeedFiles |
+			packages.NeedImports |
+			packages.NeedCompiledGoFiles |
+			packages.NeedTypes,
+		Dir: dir,
+	}
+	pkgs, err := packages.Load(baseConfig, "./...")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if num := packages.PrintErrors(pkgs); num > 0 {
+		t.Fatalf("packages contained %d errors", num)
+	}
+	return pkgs
+}
+
+// CreateProgram creates a program with given initial packages for testing,
+// usually the packages are constructed via PackagesFromArchive.
+func CreateProgram(t *testing.T, initial []*packages.Package, mode BuilderMode) *Program {
+	var fset *token.FileSet
+	if len(initial) > 0 {
+		fset = initial[0].Fset
+	}
+
+	prog := NewProgram(fset, mode)
+
+	isInitial := make(map[*packages.Package]bool, len(initial))
+	for _, p := range initial {
+		isInitial[p] = true
+	}
+
+	packages.Visit(initial, nil, func(p *packages.Package) {
+		if p.Types != nil && !p.IllTyped {
+			var files []*ast.File
+			var info *types.Info
+			if isInitial[p] {
+				files = p.Syntax
+				info = p.TypesInfo
+			}
+			prog.CreatePackage(p.Types, files, info, true)
+			return
+		}
+
+		t.Fatalf("package %s or its any dependency contains errors", p.Name)
+	})
+
+	return prog
+}
+
+// PkgInfo is a ssa package with its packages.Package and ast file.
+// We assume the package in test only have one file.
+type PkgInfo struct {
+	SPkg *Package          // ssa representation of a package
+	PPkg *packages.Package // packages representation of a package
+	File *ast.File         // the ast file of the first package file
+}
+
+// GetPkgInfo retrieves the package info from the program with the given name.
+// It's useful when you loaded a package from file instead of defining it directly as a string.
+func GetPkgInfo(prog *Program, pkgs []*packages.Package, pkgname string) *PkgInfo {
+	for _, pkg := range pkgs {
+		if pkg.Name == pkgname {
+			return &PkgInfo{
+				SPkg: prog.Package(pkg.Types),
+				PPkg: pkg,
+				File: pkg.Syntax[0], // we assume the test package has one file
+			}
+		}
+	}
+	return nil
+}
+
+// LoadPackageFromSingleFile is a utility function to creates a package based on the content of a go file,
+// and returns the PkgInfo about the input go file. The package name is retrieved from content after parsing.
+// It's useful when you want to create a ssa package and its packages.Package and ast.File representation.
+func LoadPackageFromSingleFile(t *testing.T, content string, mode BuilderMode) *PkgInfo {
+	ar := ArchiveFromSingleFileContent(content)
+	pkgs := PackagesFromArchive(t, ar)
+	prog := CreateProgram(t, pkgs, mode)
+
+	pkgName := packageName(t, content)
+	pkgInfo := GetPkgInfo(prog, pkgs, pkgName)
+	if pkgInfo == nil {
+		t.Fatalf("fail to get package %s from loaded packages", pkgName)
+	}
+	return pkgInfo
+}
+
+// packageName is a test helper to extract the package name from a string
+// containing the content of a go file.
+func packageName(t testing.TB, content string) string {
+	f, err := parser.ParseFile(token.NewFileSet(), "", content, parser.PackageClauseOnly)
+	if err != nil {
+		t.Fatalf("parsing the file %q failed with error: %s", content, err)
+	}
+	return f.Name.Name
 }


### PR DESCRIPTION
It also removes the deprecated loader package and uses packages and txtar to load the package for testing. Now all packages are created under a go module.