### PR TITLE
txtar: use slices.Clone instead of copy

### DIFF
--- a/txtar/fs.go
+++ b/txtar/fs.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"io/fs"
 	"path"
+	"slices"
 	"time"
 )
 
@@ -152,9 +153,7 @@ func (fsys *filesystem) ReadFile(name string) ([]byte, error) {
 		return nil, err
 	}
 	if file, ok := file.(*openFile); ok {
-		// TODO: use slices.Clone once x/tools has 1.21 available.
-		cp := make([]byte, file.size)
-		copy(cp, file.data)
+		cp := slices.Clone(file.data)
 		return cp, err
 	}
 	return nil, &fs.PathError{Op: "read", Path: name, Err: fs.ErrInvalid}

--- a/txtar/fs.go
+++ b/txtar/fs.go
@@ -153,8 +153,7 @@ func (fsys *filesystem) ReadFile(name string) ([]byte, error) {
 		return nil, err
 	}
 	if file, ok := file.(*openFile); ok {
-		cp := slices.Clone(file.data)
-		return cp, err
+		return slices.Clone(file.data), nil
 	}
 	return nil, &fs.PathError{Op: "read", Path: name, Err: fs.ErrInvalid}
 }


### PR DESCRIPTION
Use slices.Clone instead of copy now that x/tools uses Go >= 1.22.
Resolves an outstanding TODO.