### PR TITLE
x/tools/gopls: fix rename command line fail

### DIFF
--- a/gopls/internal/cmd/cmd.go
+++ b/gopls/internal/cmd/cmd.go
@@ -807,9 +807,11 @@ func (c *cmdClient) openFiles(uri protocol.DocumentURI) ([]*cmdFile, error) {
 		if err != nil {
 			return nil, err
 		}
-		files := make([]*cmdFile, len(entries))
-		for i, e := range entries {
-			files[i] = c.getFile(protocol.DocumentURI(filepath.Join(string(uri), e.Name())))
+		files := make([]*cmdFile, 0)
+		for _, e := range entries {
+			if !e.IsDir() {
+				files = append(files, c.getFile(protocol.DocumentURI(filepath.Join(string(uri), e.Name()))))
+			}
 		}
 
 		return files, nil

--- a/gopls/internal/server/rename.go
+++ b/gopls/internal/server/rename.go
@@ -52,10 +52,9 @@ func (s *server) Rename(ctx context.Context, params *protocol.RenameParams) (*pr
 		// Update the last component of the file's enclosing directory.
 		oldDir := filepath.Dir(fh.URI().Path())
 		newDir := filepath.Join(filepath.Dir(oldDir), params.NewName)
-		fileName := filepath.Base(fh.URI().Path())
 		change := protocol.DocumentChangeRename(
-			protocol.URIFromPath(fmt.Sprintf("%s/%s", oldDir, fileName)),
-			protocol.URIFromPath(fmt.Sprintf("%s/%s", newDir, fileName)))
+			protocol.URIFromPath(oldDir),
+			protocol.URIFromPath(newDir))
 		changes = append(changes, change)
 	}
 

--- a/gopls/internal/server/rename.go
+++ b/gopls/internal/server/rename.go
@@ -52,9 +52,10 @@ func (s *server) Rename(ctx context.Context, params *protocol.RenameParams) (*pr
 		// Update the last component of the file's enclosing directory.
 		oldDir := filepath.Dir(fh.URI().Path())
 		newDir := filepath.Join(filepath.Dir(oldDir), params.NewName)
+		fileName := filepath.Base(fh.URI().Path())
 		change := protocol.DocumentChangeRename(
-			protocol.URIFromPath(oldDir),
-			protocol.URIFromPath(newDir))
+			protocol.URIFromPath(fmt.Sprintf("%s/%s", oldDir, fileName)),
+			protocol.URIFromPath(fmt.Sprintf("%s/%s", newDir, fileName)))
 		changes = append(changes, change)
 	}
 


### PR DESCRIPTION
Fixes golang/go#69582

if the path is not a  file, there is a error will occur. because rename need file content , and then change it.
https://github.com/golang/tools/blob/master/gopls/internal/cmd/cmd.go#L777

this is the result of fixed.
```
/Users/yincong/Library/Caches/JetBrains/GoLand2024.1/tmp/GoLand/___go_build_golang_org_x_tools_gopls rename -diff ./internal/a/a.go:#9 b
--- /Users/yincong/go/src/github.com/yincongcyincong/tools/gopls/internal/a/a.go.orig
+++ /Users/yincong/go/src/github.com/yincongcyincong/tools/gopls/internal/a/a.go
@@ -1 +1 @@
-package a
+package b
--- /Users/yincong/go/src/github.com/yincongcyincong/tools/gopls/internal/b/a.go.orig
+++ /Users/yincong/go/src/github.com/yincongcyincong/tools/gopls/internal/b/a.go
@@ -0,0 +1 @@
+package a
--- /Users/yincong/go/src/github.com/yincongcyincong/tools/gopls/internal/a/a.go.orig
+++ /Users/yincong/go/src/github.com/yincongcyincong/tools/gopls/internal/a/a.go
@@ -1 +0,0 @@
-package a

```