### PR TITLE
Check types assignability for TypeParams.

### DIFF
--- a/internal/apidiff/apidiff_test.go
+++ b/internal/apidiff/apidiff_test.go
@@ -65,7 +65,7 @@ func splitIntoPackages(t *testing.T, dir string) (incompatibles, compatibles []s
 	if err := os.MkdirAll(filepath.Join(dir, "src", "apidiff"), 0700); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "src", "apidiff", "go.mod"), []byte("module apidiff\n"), 0666); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "src", "apidiff", "go.mod"), []byte("module apidiff\n\ngo 1.22"), 0666); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/apidiff/correspondence.go
+++ b/internal/apidiff/correspondence.go
@@ -35,6 +35,9 @@ func (d *differ) corr(old, new types.Type, p *ifacePair) bool {
 	new = types.Unalias(new)
 	switch old := old.(type) {
 	case *types.Basic:
+		if isTypeParam(new) {
+			return types.AssignableTo(old, new.Underlying())
+		}
 		return types.Identical(old, new)
 
 	case *types.Array:
@@ -222,4 +225,9 @@ type ifacePair struct {
 
 func (p *ifacePair) identical(q *ifacePair) bool {
 	return p.x == q.x && p.y == q.y || p.x == q.y && p.y == q.x
+}
+
+func isTypeParam(t types.Type) bool {
+	_, ok := types.Unalias(t).(*types.TypeParam)
+	return ok
 }

--- a/internal/apidiff/testdata/tests.go
+++ b/internal/apidiff/testdata/tests.go
@@ -528,6 +528,12 @@ func F9(int) {}
 // OK, even though new S1 is incompatible with old S1 (see below)
 func F10(S1) {}
 
+// old
+func F11(string) {}
+
+// new
+func F11[C ~string](C) {} //OK: ~string includes string type
+
 //////////////// Structs
 
 // old


### PR DESCRIPTION
Currently, apidiff is tested against go version 1.16, i.e. pre-generics.
This patch [bumps](https://github.com/golang/tools/compare/master...mneverov:tools:fix-correspondence-type-constraints?expand=1#diff-02ad859b30292eda8e751a6551953b6bb7908ce8c6a6d953f0d0b782caa36751R68) go version and introduces a check if a new type is broader than the old one (old is assignable to the new).

Related to [k8s#127546](https://github.com/kubernetes/kubernetes/pull/127546), 