### PR TITLE
importgraph: correct typo in graph_test.go

### DIFF
--- a/refactor/importgraph/graph_test.go
+++ b/refactor/importgraph/graph_test.go
@@ -153,7 +153,7 @@ func TestBuild(t *testing.T) {
 	}
 	if !reverse.Search(this)[this] {
 		printNode("reverse", this)
-		t.Errorf("irrefexive: reverse.Search(importgraph)[importgraph] not found")
+		t.Errorf("irreflexive: reverse.Search(importgraph)[importgraph] not found")
 	}
 
 	// Test Search is transitive.  (There is no direct edge to these packages.)


### PR DESCRIPTION
This PR corrects a typo in the error message for the reverse.Search function.
The word "irrefexive" was incorrectly spelled and has been corrected to
"irreflexive."