### PR TITLE
Refactor: simplify switch case in printNode for better clarity

### DIFF
--- a/refactor/importgraph/graph_test.go
+++ b/refactor/importgraph/graph_test.go
@@ -100,7 +100,6 @@ func TestBuild(t *testing.T) {
 		case "reverse":
 			g = reverse
 		default:
-			t.Helper()
 			t.Fatalf("bad direction: %q", direction)
 		}
 


### PR DESCRIPTION
This PR improves the readability of the printNode function by simplifying the switch statement that handles the direction parameter. The unnecessary t.Helper() call was removed, and the logic was made more concise.

This change doesn't affect the functionality of the code but makes it easier to understand and maintain.