### PR TITLE
perf: optimize insert method in Sparse by inlining wordMask logic

### DIFF
--- a/container/intsets/sparse.go
+++ b/container/intsets/sparse.go
@@ -120,7 +120,8 @@ func wordMask(i uint) (w uint, mask word) {
 // insert sets the block b's ith bit and
 // returns true if it was not already set.
 func (b *block) insert(i uint) bool {
-	w, mask := wordMask(i)
+	w := i / bitsPerWord
+	mask := word(1 << (i % bitsPerWord))
 	if b.bits[w]&mask == 0 {
 		b.bits[w] |= mask
 		return true


### PR DESCRIPTION
Optimized the `insert` method in the `Sparse` type by inlining the logic of the 
`wordMask` function directly within the method. This change eliminates the 
overhead of an additional function call, resulting in a slight performance 
improvement during insert operations.

While the core logic remains unchanged, this optimization could provide minor 
gains in performance, particularly in tight loops or performance-sensitive 
scenarios where the `insert` method is frequently called.

The change has been localized to `container/intsets/sparse.go`.
