### PR TITLE
go/packages: add TypesInfo properly when NeedTypesInfo was set while NeedSyntax & NeedTypes were not

### DIFF
--- a/go/packages/golist.go
+++ b/go/packages/golist.go
@@ -145,7 +145,7 @@ func goListDriver(cfg *Config, patterns ...string) (_ *DriverResponse, err error
 	}
 
 	// Fill in response.Sizes asynchronously if necessary.
-	if cfg.Mode&NeedTypesSizes != 0 || cfg.Mode&NeedTypes != 0 {
+	if cfg.Mode&NeedTypesSizes != 0 || cfg.Mode&NeedTypes != 0 || cfg.Mode&NeedTypesInfo != 0 {
 		errCh := make(chan error)
 		go func() {
 			compiler, arch, err := getSizesForArgs(ctx, state.cfgInvocation(), cfg.gocmdRunner)
@@ -751,7 +751,7 @@ func jsonFlag(cfg *Config, goVersion int) string {
 		}
 	}
 	addFields("Name", "ImportPath", "Error") // These fields are always needed
-	if cfg.Mode&NeedFiles != 0 || cfg.Mode&NeedTypes != 0 {
+	if cfg.Mode&NeedFiles != 0 || cfg.Mode&(NeedTypes|NeedTypesInfo) != 0 {
 		addFields("Dir", "GoFiles", "IgnoredGoFiles", "IgnoredOtherFiles", "CFiles",
 			"CgoFiles", "CXXFiles", "MFiles", "HFiles", "FFiles", "SFiles",
 			"SwigFiles", "SwigCXXFiles", "SysoFiles")
@@ -759,7 +759,7 @@ func jsonFlag(cfg *Config, goVersion int) string {
 			addFields("TestGoFiles", "XTestGoFiles")
 		}
 	}
-	if cfg.Mode&NeedTypes != 0 {
+	if cfg.Mode&(NeedTypes|NeedTypesInfo) != 0 {
 		// CompiledGoFiles seems to be required for the test case TestCgoNoSyntax,
 		// even when -compiled isn't passed in.
 		// TODO(#52435): Should we make the test ask for -compiled, or automatically

--- a/go/packages/packages.go
+++ b/go/packages/packages.go
@@ -764,7 +764,7 @@ func newLoader(cfg *Config) *loader {
 	ld.requestedMode = ld.Mode
 	ld.Mode = impliedLoadMode(ld.Mode)
 
-	if ld.Mode&NeedTypes != 0 || ld.Mode&NeedSyntax != 0 {
+	if ld.Mode&NeedTypes != 0 || ld.Mode&NeedSyntax != 0 || ld.Mode&NeedTypesInfo != 0 {
 		if ld.Fset == nil {
 			ld.Fset = token.NewFileSet()
 		}
@@ -920,7 +920,7 @@ func (ld *loader) refine(response *DriverResponse) ([]*Package, error) {
 
 	// Load type data and syntax if needed, starting at
 	// the initial packages (roots of the import DAG).
-	if ld.Mode&NeedTypes != 0 || ld.Mode&NeedSyntax != 0 {
+	if ld.Mode&NeedTypes != 0 || ld.Mode&NeedSyntax != 0 || ld.Mode&NeedTypesInfo != 0 {
 		var wg sync.WaitGroup
 		for _, lpkg := range initial {
 			wg.Add(1)
@@ -1158,7 +1158,7 @@ func (ld *loader) loadPackage(lpkg *loaderPackage) {
 	}
 
 	lpkg.Syntax = files
-	if ld.Config.Mode&NeedTypes == 0 {
+	if ld.Config.Mode&NeedTypes == 0 && ld.Config.Mode&NeedTypesInfo == 0 {
 		return
 	}
 

--- a/go/packages/packages_test.go
+++ b/go/packages/packages_test.go
@@ -3176,3 +3176,36 @@ func TestIssue69606b(t *testing.T) {
 		t.Fatal("Expected to get an error because missing unsafe package but got a nil error")
 	}
 }
+
+// TestNeedTypesInfoOnly tests when NeedTypesInfo was set and NeedSyntax & NeedTypes were not,
+// Load should include the TypesInfo of packages properly
+func TestLoadTypesInfoWithoutSyntaxOrTypes(t *testing.T) {
+	testAllOrModulesParallel(t, testLoadTypesInfoWithoutSyntaxOrTypes)
+}
+
+func testLoadTypesInfoWithoutSyntaxOrTypes(t *testing.T, exporter packagestest.Exporter) {
+	exported := packagestest.Export(t, exporter, []packagestest.Module{{
+		Name: "golang.org/fake",
+		Files: map[string]interface{}{
+			"a/a.go": `package a; 
+
+func foo() int {
+	i := 0
+	s := "abc"
+	return i + len(s)
+}
+`,
+		}}})
+	defer exported.Cleanup()
+	exported.Config.Mode = packages.NeedTypesInfo
+
+	packs, err := packages.Load(exported.Config, "golang.org/fake/a")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// check if types info is present
+	if packs[0].TypesInfo == nil {
+		t.Errorf("expected types info to be present but got nil")
+	}
+}


### PR DESCRIPTION
The `NeedTypesInfo` option indicates that `packages.Load` would add `TypesInfo` field to result packages. But it turns out that when `NeedTypesInfo` was used separately from `NeedSyntax` or `NeedTypes`, the `TypesInfo` fields would simply be `nil`. This PR aims to fix this.

### How to reproduce the issue
Simply include `NeedTypesInfo` while no `NeedSyntax` or `NeedTypes` in `LoadMode` of `packages.Load` call's config paramter, then call `packages.Load`. The `TypesInfo` fields in the packages returned would be `nil` value, which does not meet the expect of `NeedTypesInfo` mode.

### How does this PR fix this
Under most circumstances `NeedTypesInfo` should work the same as `NeedTypes` in branch-conditions, since `Types` and `TypesInfo` are produced together when do the type checking (except for cases when ExportFiles were included). So I added or-conditions to some judgements related to `NeedTypes`, including:
- When initializing loader, `NeedTypesInfo` also requires creating a new FileSet, since it can only be created through type-checking, so an Fset is required for syntax-parsing.
- In golistdriver, not only `NeedTypes` requires type sizes, go files and go compiled files, `NeedTypesInfo` also needs these stuff.
- The condition to load packages recursively should also include `NeedTypesInfo`, otherwise the load recursively process would simply be skipped.
- Before type checking on single packages, it should also not return in advance when `NeedTypesInfo` was set.

I also added a unit-test to this case.

A more simple way to do this could be adding `NeedTypes` to LoadMode when `NeedTypesInfo` inside `impliedLoadMode`, because actually the `Types` would be produced anyway when producing `TypesInfo`. But I thought control Load process more carefully without modifying user's original LoadMode intent could be better. (And it matches the semantics of single LoadMode more since no `Types` would be returned!)

