### PR TITLE
gopls/internal: stubcalledfunction: improve logic of selecting insert position

### DIFF
--- a/gopls/internal/golang/stub.go
+++ b/gopls/internal/golang/stub.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"go/ast"
 	"go/format"
 	"go/parser"
 	"go/token"
@@ -26,7 +25,6 @@ import (
 	"golang.org/x/tools/gopls/internal/util/safetoken"
 	"golang.org/x/tools/internal/diff"
 	"golang.org/x/tools/internal/tokeninternal"
-	"golang.org/x/tools/internal/typesinternal"
 )
 
 // stubMissingInterfaceMethodsFixer returns a suggested fix to declare the missing
@@ -50,24 +48,7 @@ func stubMissingCalledFunctionFixer(ctx context.Context, snapshot *cache.Snapsho
 	if si == nil {
 		return nil, nil, fmt.Errorf("invalid type request")
 	}
-	var sym types.Object
-	sym = si.Receiver.Obj()
-	// If the enclosing function declaration is a method declaration,
-	// and matches the receiver type of the diagnostic,
-	// insert after the enclosing method.
-	if len(si.Path) > 1 {
-		decl, ok := si.Path[len(si.Path)-2].(*ast.FuncDecl)
-		if ok && decl.Recv != nil {
-			for _, mr := range decl.Recv.List {
-				mrt := si.Info.TypeOf(mr.Type)
-				if mrt != nil && types.Unalias(typesinternal.Unpointer(mrt)) == sym.Type() {
-					sym = si.Info.ObjectOf(decl.Name)
-					break
-				}
-			}
-		}
-	}
-	return insertDeclsAfter(ctx, snapshot, pkg.Metadata(), si.Fset, sym, si.Emit)
+	return insertDeclsAfter(ctx, snapshot, pkg.Metadata(), si.Fset, si.After, si.Emit)
 }
 
 // An emitter writes new top-level declarations into an existing

--- a/gopls/internal/golang/stubmethods/stubcalledfunc.go
+++ b/gopls/internal/golang/stubmethods/stubcalledfunc.go
@@ -27,8 +27,8 @@ type CallStubInfo struct {
 	Receiver   typesinternal.NamedOrAlias // the method's receiver type
 	MethodName string
 	pointer    bool
-	info       *types.Info
-	path       []ast.Node // path enclosing the CallExpr
+	Info       *types.Info
+	Path       []ast.Node // path enclosing the CallExpr
 }
 
 // GetCallStubInfo extracts necessary information to generate a method definition from
@@ -63,8 +63,8 @@ func GetCallStubInfo(fset *token.FileSet, info *types.Info, path []ast.Node, pos
 				Receiver:   recvType,
 				MethodName: s.Sel.Name,
 				pointer:    pointer,
-				path:       path[i:],
-				info:       info,
+				Path:       path[i:],
+				Info:       info,
 			}
 		}
 	}
@@ -74,7 +74,7 @@ func GetCallStubInfo(fset *token.FileSet, info *types.Info, path []ast.Node, pos
 // Emit writes to out the missing method based on type info of si.Receiver and CallExpr.
 func (si *CallStubInfo) Emit(out *bytes.Buffer, qual types.Qualifier) error {
 	params := si.collectParams()
-	rets := typesFromContext(si.info, si.path, si.path[0].Pos())
+	rets := typesFromContext(si.Info, si.Path, si.Path[0].Pos())
 	recv := si.Receiver.Obj()
 	// Pointer receiver?
 	var star string
@@ -159,9 +159,9 @@ func (si *CallStubInfo) collectParams() []param {
 		params = append(params, p)
 	}
 
-	args := si.path[0].(*ast.CallExpr).Args
+	args := si.Path[0].(*ast.CallExpr).Args
 	for _, arg := range args {
-		t := si.info.TypeOf(arg)
+		t := si.Info.TypeOf(arg)
 		switch t := t.(type) {
 		// This is the case where another function call returning multiple
 		// results is used as an argument.

--- a/gopls/internal/test/marker/testdata/quickfix/stubmethods/fromcall_basic.txt
+++ b/gopls/internal/test/marker/testdata/quickfix/stubmethods/fromcall_basic.txt
@@ -52,3 +52,17 @@ func fun() {
 +func (t TypeDeclInOtherFile) other(i int) {
 +	panic("unimplemented")
 +}
+-- should_insert_after.go --
+package fromcallbasic
+
+type HasMethod struct{}
+
+func (h *HasMethod) m() {
+	h.should_insert_after() //@quickfix("should_insert_after", re"has no field or method", insert)
+}
+-- @insert/should_insert_after.go --
+@@ -8 +8,4 @@
++
++func (h *HasMethod) should_insert_after() {
++	panic("unimplemented")
++}

--- a/gopls/internal/test/marker/testdata/quickfix/stubmethods/fromcall_returns.txt
+++ b/gopls/internal/test/marker/testdata/quickfix/stubmethods/fromcall_returns.txt
@@ -1,8 +1,5 @@
 This test checks the return type of the generated missing method based on CallExpr.
 
--- basic_stub.go --
-package fromcallreturns
-
 -- param.go --
 package fromcallreturns
 


### PR DESCRIPTION
This CL adds the logic to insert generated method stubs 
immediately after the enclosing method declaration when 
the receiver types match. I often find myself move the 
generated code to the position after current method immediately, 
and this added logic is more consistent with undeclared.go's 
generate missing function quickfix.

Related CL 617619
Updates golang/go#69692