### PR TITLE
gopls/internal/golang: fix folding range for function calls

### DIFF
--- a/gopls/internal/test/marker/testdata/foldingrange/a.txt
+++ b/gopls/internal/test/marker/testdata/foldingrange/a.txt
@@ -6,13 +6,17 @@ package folding //@foldingrange(raw)
 import (
 	"fmt"
 	_ "log"
+	"sort"
+	"time"
 )
 
 import _ "os"
 
 // bar is a function.
 // With a multiline doc comment.
-func bar() string {
+func bar() (
+	string,
+) {
 	/* This is a single line comment */
 	switch {
 	case true:
@@ -76,19 +80,74 @@ func bar() string {
 this string
 is not indented`
 }
+
+func _() {
+	slice := []int{1, 2, 3}
+	sort.Slice(slice, func(i, j int) bool {
+		a, b := slice[i], slice[j]
+		return a < b
+	})
+
+	sort.Slice(slice, func(i, j int) bool { return slice[i] < slice[j] })
+
+	sort.Slice(
+		slice,
+		func(i, j int) bool {
+			return slice[i] < slice[j]
+		},
+	)
+
+	fmt.Println(
+		1, 2, 3,
+		4,
+	)
+
+	fmt.Println(1, 2, 3,
+		4, 5, 6,
+		7, 8, 9,
+		10)
+
+	// Call with ellipsis.
+	_ = fmt.Errorf(
+		"test %d %d",
+		[]any{1, 2, 3}...,
+	)
+
+	// Check multiline string.
+	fmt.Println(
+		`multi
+		line
+		string
+		`,
+		1, 2, 3,
+	)
+
+	// Call without arguments.
+	_ = time.Now()
+}
+
+func _(
+	a int, b int,
+	c int,
+) {
+}
 -- @raw --
 package folding //@foldingrange(raw)
 
 import (<0 kind="imports">
 	"fmt"
 	_ "log"
+	"sort"
+	"time"
 </0>)
 
 import _ "os"
 
 // bar is a function.<1 kind="comment">
 // With a multiline doc comment.</1>
-func bar(<2 kind=""></2>) string {<3 kind="">
+func bar() (<2 kind="">
+	string,
+</2>) {<3 kind="">
 	/* This is a single line comment */
 	switch {<4 kind="">
 	case true:<5 kind="">
@@ -152,3 +211,54 @@ func bar(<2 kind=""></2>) string {<3 kind="">
 this string
 is not indented`</34>
 </3>}
+
+func _() {<35 kind="">
+	slice := []int{<36 kind="">1, 2, 3</36>}
+	sort.Slice(<37 kind="">slice, func(<38 kind="">i, j int</38>) bool {<39 kind="">
+		a, b := slice[i], slice[j]
+		return a < b
+	</39>}</37>)
+
+	sort.Slice(<40 kind="">slice, func(<41 kind="">i, j int</41>) bool {<42 kind=""> return slice[i] < slice[j] </42>}</40>)
+
+	sort.Slice(<43 kind="">
+		slice,
+		func(<44 kind="">i, j int</44>) bool {<45 kind="">
+			return slice[i] < slice[j]
+		</45>},
+	</43>)
+
+	fmt.Println(<46 kind="">
+		1, 2, 3,
+		4,
+	</46>)
+
+	fmt.Println(<47 kind="">1, 2, 3,
+		4, 5, 6,
+		7, 8, 9,
+		10</47>)
+
+	// Call with ellipsis.
+	_ = fmt.Errorf(<48 kind="">
+		"test %d %d",
+		[]any{<49 kind="">1, 2, 3</49>}...,
+	</48>)
+
+	// Check multiline string.
+	fmt.Println(<50 kind="">
+		<51 kind="">`multi
+		line
+		string
+		`</51>,
+		1, 2, 3,
+	</50>)
+
+	// Call without arguments.
+	_ = time.Now()
+</35>}
+
+func _(<52 kind="">
+	a int, b int,
+	c int,
+</52>) {<53 kind="">
+</53>}

--- a/gopls/internal/test/marker/testdata/foldingrange/a_lineonly.txt
+++ b/gopls/internal/test/marker/testdata/foldingrange/a_lineonly.txt
@@ -15,6 +15,8 @@ package folding //@foldingrange(raw)
 import (
 	"fmt"
 	_ "log"
+	"sort"
+	"time"
 )
 
 import _ "os"
@@ -85,12 +87,65 @@ func bar() string {
 this string
 is not indented`
 }
+
+func _() {
+	slice := []int{1, 2, 3}
+	sort.Slice(slice, func(i, j int) bool {
+		a, b := slice[i], slice[j]
+		return a < b
+	})
+
+	sort.Slice(slice, func(i, j int) bool { return slice[i] < slice[j] })
+
+	sort.Slice(
+		slice,
+		func(i, j int) bool {
+			return slice[i] < slice[j]
+		},
+	)
+
+	fmt.Println(
+		1, 2, 3,
+		4,
+	)
+
+	fmt.Println(1, 2, 3,
+		4, 5, 6,
+		7, 8, 9,
+		10)
+
+	// Call with ellipsis.
+	_ = fmt.Errorf(
+		"test %d %d",
+		[]any{1, 2, 3}...,
+	)
+
+	// Check multiline string.
+	fmt.Println(
+		`multi
+		line
+		string
+		`,
+		1, 2, 3,
+	)
+
+	// Call without arguments.
+	_ = time.Now()
+}
+
+func _(
+	a int, b int,
+	c int,
+) {
+}
 -- @raw --
 package folding //@foldingrange(raw)
 
 import (<0 kind="imports">
 	"fmt"
-	_ "log"</0>
+	_ "log"
+	"sort"
+	"time"</0>
 )
 
 import _ "os"
@@ -122,7 +177,7 @@ func bar() string {<2 kind="">
 	_ = []int{<11 kind="">
 		1,
 		2,
-		3</11>,
+		3,</11>
 	}
 	_ = [2]string{"d",
 		"e",
@@ -130,7 +185,7 @@ func bar() string {<2 kind="">
 	_ = map[string]int{<12 kind="">
 		"a": 1,
 		"b": 2,
-		"c": 3</12>,
+		"c": 3,</12>
 	}
 	type T struct {<13 kind="">
 		f string
@@ -140,7 +195,7 @@ func bar() string {<2 kind="">
 	_ = T{<14 kind="">
 		f: "j",
 		g: 4,
-		h: "i"</14>,
+		h: "i",</14>
 	}
 	x, y := make(chan bool), make(chan bool)
 	select {<15 kind="">
@@ -160,4 +215,55 @@ func bar() string {<2 kind="">
 	return <22 kind="">`
 this string
 is not indented`</2></22>
+}
+
+func _() {<23 kind="">
+	slice := []int{1, 2, 3}
+	sort.Slice(slice, func(i, j int) bool {<24 kind="">
+		a, b := slice[i], slice[j]
+		return a < b</24>
+	})
+
+	sort.Slice(slice, func(i, j int) bool { return slice[i] < slice[j] })
+
+	sort.Slice(<25 kind="">
+		slice,
+		func(i, j int) bool {<26 kind="">
+			return slice[i] < slice[j]</26>
+		},</25>
+	)
+
+	fmt.Println(<27 kind="">
+		1, 2, 3,
+		4,</27>
+	)
+
+	fmt.Println(1, 2, 3,
+		4, 5, 6,
+		7, 8, 9,
+		10)
+
+	// Call with ellipsis.
+	_ = fmt.Errorf(<28 kind="">
+		"test %d %d",
+		[]any{1, 2, 3}...,</28>
+	)
+
+	// Check multiline string.
+	fmt.Println(<29 kind="">
+		<30 kind="">`multi
+		line
+		string
+		`</30>,
+		1, 2, 3,</29>
+	)
+
+	// Call without arguments.
+	_ = time.Now()</23>
+}
+
+func _(<31 kind="">
+	a int, b int,
+	c int,</31>
+) {
 }

--- a/gopls/internal/test/marker/testdata/foldingrange/bad.txt
+++ b/gopls/internal/test/marker/testdata/foldingrange/bad.txt
@@ -31,11 +31,11 @@ import (<1 kind="imports">
 	_ "os" </1>)
 	
 // badBar is a function.
-func badBar(<2 kind=""></2>) string {<3 kind=""> x := true
-	if x {<4 kind=""> 
+func badBar() string {<2 kind=""> x := true
+	if x {<3 kind=""> 
 		// This is the only foldable thing in this file when lineFoldingOnly
-		fmt.Println(<5 kind="">"true"</5>)
-	</4>} else {<6 kind="">
-		fmt.Println(<7 kind="">"false"</7>) </6>}
+		fmt.Println(<4 kind="">"true"</4>)
+	</3>} else {<5 kind="">
+		fmt.Println(<6 kind="">"false"</6>) </5>}
 	return ""
-</3>}
+</2>}

--- a/gopls/internal/test/marker/testdata/foldingrange/parse_errors.txt
+++ b/gopls/internal/test/marker/testdata/foldingrange/parse_errors.txt
@@ -1,0 +1,26 @@
+This test verifies that textDocument/foldingRange does not panic
+and produces no folding ranges if a file contains errors.
+
+-- flags --
+-ignore_extra_diags
+
+-- a.go --
+package folding //@foldingrange(raw)
+
+// No comma.
+func _(
+	a string
+) {}
+
+// Extra brace.
+func _() {}}
+-- @raw --
+package folding //@foldingrange(raw)
+
+// No comma.
+func _(
+	a string
+) {}
+
+// Extra brace.
+func _() {}}


### PR DESCRIPTION
Make folding ranges for function calls consistent with folding
ranges for function bodies and composite literals:

- keep the closing parenthesis visible
- do not generate a folding range if either the first or last
  argument is on the same line as the opening or closing parenthesis

In order to achieve this, calculate folding ranges by analyzing
whitespace in the source instead of analyzing AST.

Fixes golang/go#70467