### PR TITLE
go.mod: remove Go patch version specifier

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module golang.org/x/tools
 
-go 1.22.0 // => default GODEBUG has gotypesalias=0
+go 1.22 // => default GODEBUG has gotypesalias=0
 
 require (
 	github.com/google/go-cmp v0.6.0


### PR DESCRIPTION
Would we be able to get a non-patch version in here so downstream use isn't forced into a `toolchain` directive because of this package? Pretty please?