### PR TITLE
go/cfg: remove empty goto (without label) from test case

### DIFF
--- a/go/cfg/cfg_test.go
+++ b/go/cfg/cfg_test.go
@@ -127,12 +127,6 @@ func f10(ch chan int) {
 	}
 	live()
 }
-
-func f11() {
-	goto; // mustn't crash
-	dead()
-}
-
 `
 
 func TestDeadCode(t *testing.T) {


### PR DESCRIPTION
See CL 638395