### PR TITLE
go/packages: add GOROOT env to avoid TestTarget failure in OpenBSD

### DIFF
--- a/go/packages/packages_test.go
+++ b/go/packages/packages_test.go
@@ -3363,7 +3363,7 @@ func main() {
 
 	pkgs, err := packages.Load(&packages.Config{
 		Mode: packages.NeedName | packages.NeedTarget,
-		Env:  []string{"GOPATH=" + gopath, "GO111MODULE=off"},
+		Env:  append(os.Environ(), "GOPATH=" + gopath, "GO111MODULE=off"),
 	}, filepath.Join(gopath, "src", "..."))
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
When running tests in OpenBSD if 'go' is built with -trimpath,
the TestTarget will always fail. Because when invoked without
proper environments, 'go' itself fails to find the GOROOT path.

Fixes golang/go#70891