### PR TITLE
gopls/internal/analysis/modernize: fix slicedelete triggers on slice identifiers with side effects

### DIFF
--- a/gopls/internal/analysis/modernize/modernize.go
+++ b/gopls/internal/analysis/modernize/modernize.go
@@ -187,3 +187,23 @@ func enabledCategory(filter, category string) bool {
 	}
 	return exclude
 }
+
+// isIdempotentExpr returns true if we can determine that
+// the passed expression is idempotent.
+func isIdempotentExpr(expr ast.Expr) bool {
+	isDeterministic := true
+	ast.Inspect(expr, func(n ast.Node) bool {
+        switch n.(type) {
+		case nil, *ast.Ident, *ast.BasicLit, *ast.BinaryExpr, *ast.UnaryExpr,
+			*ast.ParenExpr, *ast.SelectorExpr, *ast.IndexExpr, *ast.SliceExpr,
+			*ast.TypeAssertExpr, *ast.StarExpr, *ast.CompositeLit,
+			*ast.ArrayType, *ast.StructType, *ast.MapType, *ast.InterfaceType:
+			return true
+		default:
+			isDeterministic = false
+			return false
+		}
+	})
+	return isDeterministic
+}
+

--- a/gopls/internal/analysis/modernize/modernize.go
+++ b/gopls/internal/analysis/modernize/modernize.go
@@ -199,17 +199,18 @@ func noEffects(expr ast.Expr) bool {
 			*ast.SelectorExpr, *ast.IndexExpr, *ast.SliceExpr, *ast.TypeAssertExpr,
 			*ast.StarExpr, *ast.CompositeLit, *ast.ArrayType, *ast.StructType,
 			*ast.MapType, *ast.InterfaceType, *ast.KeyValueExpr:
-			return true
+			// no effect
 		case *ast.UnaryExpr:
+			// channel send <-ch has effects
 			if v.Op == token.ARROW {
 				noEffects = false
-				return false
 			}
-			return true
 		default:
+			// all other expressions have effects
 			noEffects = false
-			return false
 		}
+
+		return noEffects
 	})
 	return noEffects
 }

--- a/gopls/internal/analysis/modernize/modernize.go
+++ b/gopls/internal/analysis/modernize/modernize.go
@@ -193,7 +193,7 @@ func enabledCategory(filter, category string) bool {
 func isIdempotentExpr(expr ast.Expr) bool {
 	isDeterministic := true
 	ast.Inspect(expr, func(n ast.Node) bool {
-        switch n.(type) {
+		switch n.(type) {
 		case nil, *ast.Ident, *ast.BasicLit, *ast.BinaryExpr, *ast.UnaryExpr,
 			*ast.ParenExpr, *ast.SelectorExpr, *ast.IndexExpr, *ast.SliceExpr,
 			*ast.TypeAssertExpr, *ast.StarExpr, *ast.CompositeLit,
@@ -206,4 +206,3 @@ func isIdempotentExpr(expr ast.Expr) bool {
 	})
 	return isDeterministic
 }
-

--- a/gopls/internal/analysis/modernize/modernize.go
+++ b/gopls/internal/analysis/modernize/modernize.go
@@ -188,24 +188,24 @@ func enabledCategory(filter, category string) bool {
 	return exclude
 }
 
-// noEffects reports whether the expression has no side effects, i.e., it 
+// noEffects reports whether the expression has no side effects, i.e., it
 // does not modify the memory state. This function is conservative: it may
 // return false even when the expression has no effect.
 func noEffects(expr ast.Expr) bool {
 	noEffects := true
 	ast.Inspect(expr, func(n ast.Node) bool {
-        switch v := n.(type) {
+		switch v := n.(type) {
 		case nil, *ast.Ident, *ast.BasicLit, *ast.BinaryExpr, *ast.ParenExpr,
-            *ast.SelectorExpr, *ast.IndexExpr, *ast.SliceExpr, *ast.TypeAssertExpr,
-            *ast.StarExpr, *ast.CompositeLit, *ast.ArrayType, *ast.StructType,
-            *ast.MapType, *ast.InterfaceType, *ast.KeyValueExpr:
+			*ast.SelectorExpr, *ast.IndexExpr, *ast.SliceExpr, *ast.TypeAssertExpr,
+			*ast.StarExpr, *ast.CompositeLit, *ast.ArrayType, *ast.StructType,
+			*ast.MapType, *ast.InterfaceType, *ast.KeyValueExpr:
 			return true
-        case *ast.UnaryExpr:
-            if v.Op == token.ARROW {
-                noEffects = false
-                return false
-            }
-            return true
+		case *ast.UnaryExpr:
+			if v.Op == token.ARROW {
+				noEffects = false
+				return false
+			}
+			return true
 		default:
 			noEffects = false
 			return false

--- a/gopls/internal/analysis/modernize/slices.go
+++ b/gopls/internal/analysis/modernize/slices.go
@@ -210,6 +210,9 @@ func appendclipped(pass *analysis.Pass) {
 //	x[:len(x):len(x)]		(nonempty)  res=x
 //	x[:k:k]	 	         	(nonempty)
 //	slices.Clip(x)			(nonempty)  res=x
+//
+// TODO(adonovan): Add a check that the expression x has no side effects in
+// case x[:len(x):len(x)] -> x. Now the program behavior may change.
 func clippedSlice(info *types.Info, e ast.Expr) (res ast.Expr, empty bool) {
 	switch e := e.(type) {
 	case *ast.SliceExpr:

--- a/gopls/internal/analysis/modernize/slicescontains.go
+++ b/gopls/internal/analysis/modernize/slicescontains.go
@@ -46,6 +46,9 @@ import (
 // It may change cardinality of effects of the "needle" expression.
 // (Mostly this appears to be a desirable optimization, avoiding
 // redundantly repeated evaluation.)
+//
+// TODO(adonovan): Add a check that needle/predicate expression from
+// if-statement has no effects. Now the program behavior may change.
 func slicescontains(pass *analysis.Pass) {
 	// Skip the analyzer in packages where its
 	// fixes would create an import cycle.

--- a/gopls/internal/analysis/modernize/slicesdelete.go
+++ b/gopls/internal/analysis/modernize/slicesdelete.go
@@ -94,7 +94,7 @@ func slicesdelete(pass *analysis.Pass) {
 					slice2, ok2 := call.Args[1].(*ast.SliceExpr)
 					if ok1 && slice1.Low == nil && !slice1.Slice3 &&
 						ok2 && slice2.High == nil && !slice2.Slice3 &&
-						equalSyntax(slice1.X, slice2.X) && isIdempotentExpr(slice1.X) &&
+						equalSyntax(slice1.X, slice2.X) && noEffects(slice1.X) &&
 						increasingSliceIndices(info, slice1.High, slice2.Low) {
 						// Have append(s[:a], s[b:]...) where we can verify a < b.
 						report(file, call, slice1, slice2)

--- a/gopls/internal/analysis/modernize/slicesdelete.go
+++ b/gopls/internal/analysis/modernize/slicesdelete.go
@@ -94,7 +94,7 @@ func slicesdelete(pass *analysis.Pass) {
 					slice2, ok2 := call.Args[1].(*ast.SliceExpr)
 					if ok1 && slice1.Low == nil && !slice1.Slice3 &&
 						ok2 && slice2.High == nil && !slice2.Slice3 &&
-						equalSyntax(slice1.X, slice2.X) && noEffects(slice1.X) &&
+						equalSyntax(slice1.X, slice2.X) && noEffects(info, slice1.X) &&
 						increasingSliceIndices(info, slice1.High, slice2.Low) {
 						// Have append(s[:a], s[b:]...) where we can verify a < b.
 						report(file, call, slice1, slice2)

--- a/gopls/internal/analysis/modernize/slicesdelete.go
+++ b/gopls/internal/analysis/modernize/slicesdelete.go
@@ -94,7 +94,7 @@ func slicesdelete(pass *analysis.Pass) {
 					slice2, ok2 := call.Args[1].(*ast.SliceExpr)
 					if ok1 && slice1.Low == nil && !slice1.Slice3 &&
 						ok2 && slice2.High == nil && !slice2.Slice3 &&
-						equalSliceX(slice1, slice2) &&
+						equalSyntax(slice1.X, slice2.X) && isIdempotentExpr(slice1.X) &&
 						increasingSliceIndices(info, slice1.High, slice2.Low) {
 						// Have append(s[:a], s[b:]...) where we can verify a < b.
 						report(file, call, slice1, slice2)
@@ -103,11 +103,6 @@ func slicesdelete(pass *analysis.Pass) {
 			}
 		}
 	}
-}
-
-// equalSliceX checks that we're dealing with the same slice
-func equalSliceX(slice1, slice2 *ast.SliceExpr) bool {
-	return equalSyntax(slice1.X, slice2.X) && isIdempotentExpr(slice1.X)
 }
 
 // Given two slice indices a and b, returns true if we can verify that a < b.

--- a/gopls/internal/analysis/modernize/slicesdelete.go
+++ b/gopls/internal/analysis/modernize/slicesdelete.go
@@ -94,7 +94,7 @@ func slicesdelete(pass *analysis.Pass) {
 					slice2, ok2 := call.Args[1].(*ast.SliceExpr)
 					if ok1 && slice1.Low == nil && !slice1.Slice3 &&
 						ok2 && slice2.High == nil && !slice2.Slice3 &&
-						equalSyntax(slice1.X, slice2.X) &&
+						equalSliceX(slice1, slice2) &&
 						increasingSliceIndices(info, slice1.High, slice2.Low) {
 						// Have append(s[:a], s[b:]...) where we can verify a < b.
 						report(file, call, slice1, slice2)
@@ -103,6 +103,11 @@ func slicesdelete(pass *analysis.Pass) {
 			}
 		}
 	}
+}
+
+// equalSliceX checks that we're dealing with the same slice
+func equalSliceX(slice1, slice2 *ast.SliceExpr) bool {
+    return equalSyntax(slice1.X, slice2.X) && isIdempotentExpr(slice1.X)
 }
 
 // Given two slice indices a and b, returns true if we can verify that a < b.

--- a/gopls/internal/analysis/modernize/slicesdelete.go
+++ b/gopls/internal/analysis/modernize/slicesdelete.go
@@ -107,7 +107,7 @@ func slicesdelete(pass *analysis.Pass) {
 
 // equalSliceX checks that we're dealing with the same slice
 func equalSliceX(slice1, slice2 *ast.SliceExpr) bool {
-    return equalSyntax(slice1.X, slice2.X) && isIdempotentExpr(slice1.X)
+	return equalSyntax(slice1.X, slice2.X) && isIdempotentExpr(slice1.X)
 }
 
 // Given two slice indices a and b, returns true if we can verify that a < b.

--- a/gopls/internal/analysis/modernize/testdata/src/slicesdelete/slicesdelete.go
+++ b/gopls/internal/analysis/modernize/testdata/src/slicesdelete/slicesdelete.go
@@ -2,6 +2,8 @@ package slicesdelete
 
 var g struct{ f []int }
 
+func h() []int { return []int{} }
+
 func slicesdelete(test, other []byte, i int) {
 	const k = 1
 	_ = append(test[:i], test[i+1:]...) // want "Replace append with slices.Delete"
@@ -25,6 +27,8 @@ func slicesdelete(test, other []byte, i int) {
 	_ = append(test[:1], test[3:]...) // want "Replace append with slices.Delete"
 
 	_ = append(g.f[:i], g.f[i+k:]...) // want "Replace append with slices.Delete"
+
+	_ = append(h()[:i], h()[i+1:]...) // potentially non idempotent expression
 
 	_ = append(test[:3], test[i+1:]...) // cannot verify a < b
 

--- a/gopls/internal/analysis/modernize/testdata/src/slicesdelete/slicesdelete.go
+++ b/gopls/internal/analysis/modernize/testdata/src/slicesdelete/slicesdelete.go
@@ -4,6 +4,8 @@ var g struct{ f []int }
 
 func h() []int { return []int{} }
 
+var ch chan []int
+
 func slicesdelete(test, other []byte, i int) {
 	const k = 1
 	_ = append(test[:i], test[i+1:]...) // want "Replace append with slices.Delete"
@@ -28,7 +30,9 @@ func slicesdelete(test, other []byte, i int) {
 
 	_ = append(g.f[:i], g.f[i+k:]...) // want "Replace append with slices.Delete"
 
-	_ = append(h()[:i], h()[i+1:]...) // potentially non idempotent expression
+	_ = append(h()[:i], h()[i+1:]...) // potentially has side effects
+
+	_ = append((<-ch)[:i], (<-ch)[i+1:]...) // has side effects
 
 	_ = append(test[:3], test[i+1:]...) // cannot verify a < b
 

--- a/gopls/internal/analysis/modernize/testdata/src/slicesdelete/slicesdelete.go.golden
+++ b/gopls/internal/analysis/modernize/testdata/src/slicesdelete/slicesdelete.go.golden
@@ -9,38 +9,38 @@ func h() []int { return []int{} }
 var ch chan []int
 
 func slicesdelete(test, other []byte, i int) {
-    const k = 1
-    _ = slices.Delete(test, i, i+1) // want "Replace append with slices.Delete"
+	const k = 1
+	_ = slices.Delete(test, i, i+1) // want "Replace append with slices.Delete"
 
-    _ = slices.Delete(test, i+1, i+2) // want "Replace append with slices.Delete"
+	_ = slices.Delete(test, i+1, i+2) // want "Replace append with slices.Delete"
 
-    _ = append(test[:i+1], test[i+1:]...) // not deleting any slice elements
+	_ = append(test[:i+1], test[i+1:]...) // not deleting any slice elements
 
-    _ = append(test[:i], test[i-1:]...) // not deleting any slice elements
+	_ = append(test[:i], test[i-1:]...) // not deleting any slice elements
 
-    _ = slices.Delete(test, i-1, i) // want "Replace append with slices.Delete"
+	_ = slices.Delete(test, i-1, i) // want "Replace append with slices.Delete"
 
-    _ = slices.Delete(test, i-2, i+1) // want "Replace append with slices.Delete"
+	_ = slices.Delete(test, i-2, i+1) // want "Replace append with slices.Delete"
 
-    _ = append(test[:i-2], other[i+1:]...) // different slices "test" and "other"
+	_ = append(test[:i-2], other[i+1:]...) // different slices "test" and "other"
 
-    _ = append(test[:i-2], other[i+1+k:]...) // cannot verify a < b
+	_ = append(test[:i-2], other[i+1+k:]...) // cannot verify a < b
 
-    _ = append(test[:i-2], test[11:]...) // cannot verify a < b
+	_ = append(test[:i-2], test[11:]...) // cannot verify a < b
 
-    _ = slices.Delete(test, 1, 3) // want "Replace append with slices.Delete"
+	_ = slices.Delete(test, 1, 3) // want "Replace append with slices.Delete"
 
-    _ = slices.Delete(g.f, i, i+k) // want "Replace append with slices.Delete"
+	_ = slices.Delete(g.f, i, i+k) // want "Replace append with slices.Delete"
 
 	_ = append(h()[:i], h()[i+1:]...) // potentially has side effects
 
 	_ = append((<-ch)[:i], (<-ch)[i+1:]...) // has side effects
 
-    _ = append(test[:3], test[i+1:]...) // cannot verify a < b
+	_ = append(test[:3], test[i+1:]...) // cannot verify a < b
 
-    _ = slices.Delete(test, i-4, i-1) // want "Replace append with slices.Delete"
+	_ = slices.Delete(test, i-4, i-1) // want "Replace append with slices.Delete"
 
-    _ = slices.Delete(test, 1+2, 3+4) // want "Replace append with slices.Delete"
+	_ = slices.Delete(test, 1+2, 3+4) // want "Replace append with slices.Delete"
 
-    _ = append(test[:1+2], test[i-1:]...) // cannot verify a < b
+	_ = append(test[:1+2], test[i-1:]...) // cannot verify a < b
 }

--- a/gopls/internal/analysis/modernize/testdata/src/slicesdelete/slicesdelete.go.golden
+++ b/gopls/internal/analysis/modernize/testdata/src/slicesdelete/slicesdelete.go.golden
@@ -4,6 +4,8 @@ import "slices"
 
 var g struct{ f []int }
 
+func h() []int { return []int{} }
+
 func slicesdelete(test, other []byte, i int) {
     const k = 1
     _ = slices.Delete(test, i, i+1) // want "Replace append with slices.Delete"
@@ -27,6 +29,8 @@ func slicesdelete(test, other []byte, i int) {
     _ = slices.Delete(test, 1, 3) // want "Replace append with slices.Delete"
 
     _ = slices.Delete(g.f, i, i+k) // want "Replace append with slices.Delete"
+
+    _ = append(h()[:i], h()[i+1:]...) // potentially non idempotent expression
 
     _ = append(test[:3], test[i+1:]...) // cannot verify a < b
 

--- a/gopls/internal/analysis/modernize/testdata/src/slicesdelete/slicesdelete.go.golden
+++ b/gopls/internal/analysis/modernize/testdata/src/slicesdelete/slicesdelete.go.golden
@@ -6,6 +6,8 @@ var g struct{ f []int }
 
 func h() []int { return []int{} }
 
+var ch chan []int
+
 func slicesdelete(test, other []byte, i int) {
     const k = 1
     _ = slices.Delete(test, i, i+1) // want "Replace append with slices.Delete"
@@ -30,7 +32,9 @@ func slicesdelete(test, other []byte, i int) {
 
     _ = slices.Delete(g.f, i, i+k) // want "Replace append with slices.Delete"
 
-    _ = append(h()[:i], h()[i+1:]...) // potentially non idempotent expression
+	_ = append(h()[:i], h()[i+1:]...) // potentially has side effects
+
+	_ = append((<-ch)[:i], (<-ch)[i+1:]...) // has side effects
 
     _ = append(test[:3], test[i+1:]...) // cannot verify a < b
 


### PR DESCRIPTION
Add a check that the expression defining the slice has no side effects to trigger slicedelete. This is a necessary condition to ensure that the change does not change the program behavior.

Fixes golang/go#72955