### PR TITLE
config for vim-lsp

### DIFF
--- a/gopls/doc/vim.md
+++ b/gopls/doc/vim.md
@@ -56,7 +56,7 @@ Use [prabirshrestha/vim-lsp], with the following configuration:
 augroup LspGo
   au!
   autocmd User lsp_setup call lsp#register_server({
-      \ 'name': 'go-lang',
+      \ 'name': 'gopls',
       \ 'cmd': {server_info->['gopls']},
       \ 'whitelist': ['go'],
       \ })


### PR DESCRIPTION
Avoid duplicate results if name and and server info do not match

I'm unsure where's the origin for this, this is a workaround till we detect if this comes from `vim-lsp` or from `gopls`