### PR TITLE
gopls: add CompiledAsmFiles in cache.Package

### DIFF
--- a/go/packages/golist.go
+++ b/go/packages/golist.go
@@ -504,19 +504,20 @@ func (state *golistState) createDriverResponse(words ...string) (*DriverResponse
 		seen[p.ImportPath] = p
 
 		pkg := &Package{
-			Name:            p.Name,
-			ID:              p.ImportPath,
-			Dir:             p.Dir,
-			Target:          p.Target,
-			GoFiles:         absJoin(p.Dir, p.GoFiles, p.CgoFiles),
-			CompiledGoFiles: absJoin(p.Dir, p.CompiledGoFiles),
-			OtherFiles:      absJoin(p.Dir, otherFiles(p)...),
-			EmbedFiles:      absJoin(p.Dir, p.EmbedFiles),
-			EmbedPatterns:   absJoin(p.Dir, p.EmbedPatterns),
-			IgnoredFiles:    absJoin(p.Dir, p.IgnoredGoFiles, p.IgnoredOtherFiles),
-			ForTest:         p.ForTest,
-			depsErrors:      p.DepsErrors,
-			Module:          p.Module,
+			Name:             p.Name,
+			ID:               p.ImportPath,
+			Dir:              p.Dir,
+			Target:           p.Target,
+			GoFiles:          absJoin(p.Dir, p.GoFiles, p.CgoFiles),
+			CompiledGoFiles:  absJoin(p.Dir, p.CompiledGoFiles),
+			CompiledAsmFiles: absJoin(p.Dir, p.SFiles),
+			OtherFiles:       absJoin(p.Dir, otherFiles(p)...),
+			EmbedFiles:       absJoin(p.Dir, p.EmbedFiles),
+			EmbedPatterns:    absJoin(p.Dir, p.EmbedPatterns),
+			IgnoredFiles:     absJoin(p.Dir, p.IgnoredGoFiles, p.IgnoredOtherFiles),
+			ForTest:          p.ForTest,
+			depsErrors:       p.DepsErrors,
+			Module:           p.Module,
 		}
 
 		if (state.cfg.Mode&typecheckCgo) != 0 && len(p.CgoFiles) != 0 {

--- a/go/packages/packages.go
+++ b/go/packages/packages.go
@@ -463,6 +463,10 @@ type Package struct {
 	// This may differ from GoFiles if files are processed before compilation.
 	CompiledGoFiles []string
 
+	// CompiledAsmFiles list the absolute file paths of the package's source
+	// assembly files that are suitable for type checking.
+	CompiledAsmFiles []string
+
 	// OtherFiles lists the absolute file paths of the package's non-Go source files,
 	// including assembly, C, C++, Fortran, Objective-C, SWIG, and so on.
 	OtherFiles []string
@@ -612,18 +616,19 @@ func (err Error) Error() string {
 // TODO(adonovan): identify this struct with Package, effectively
 // publishing the JSON protocol.
 type flatPackage struct {
-	ID              string
-	Name            string            `json:",omitempty"`
-	PkgPath         string            `json:",omitempty"`
-	Errors          []Error           `json:",omitempty"`
-	GoFiles         []string          `json:",omitempty"`
-	CompiledGoFiles []string          `json:",omitempty"`
-	OtherFiles      []string          `json:",omitempty"`
-	EmbedFiles      []string          `json:",omitempty"`
-	EmbedPatterns   []string          `json:",omitempty"`
-	IgnoredFiles    []string          `json:",omitempty"`
-	ExportFile      string            `json:",omitempty"`
-	Imports         map[string]string `json:",omitempty"`
+	ID               string
+	Name             string            `json:",omitempty"`
+	PkgPath          string            `json:",omitempty"`
+	Errors           []Error           `json:",omitempty"`
+	GoFiles          []string          `json:",omitempty"`
+	CompiledGoFiles  []string          `json:",omitempty"`
+	CompiledAsmFiles []string          `json:",omitempty"`
+	OtherFiles       []string          `json:",omitempty"`
+	EmbedFiles       []string          `json:",omitempty"`
+	EmbedPatterns    []string          `json:",omitempty"`
+	IgnoredFiles     []string          `json:",omitempty"`
+	ExportFile       string            `json:",omitempty"`
+	Imports          map[string]string `json:",omitempty"`
 }
 
 // MarshalJSON returns the Package in its JSON form.
@@ -637,17 +642,18 @@ type flatPackage struct {
 // not intended for use by clients of the API and we may change the format.
 func (p *Package) MarshalJSON() ([]byte, error) {
 	flat := &flatPackage{
-		ID:              p.ID,
-		Name:            p.Name,
-		PkgPath:         p.PkgPath,
-		Errors:          p.Errors,
-		GoFiles:         p.GoFiles,
-		CompiledGoFiles: p.CompiledGoFiles,
-		OtherFiles:      p.OtherFiles,
-		EmbedFiles:      p.EmbedFiles,
-		EmbedPatterns:   p.EmbedPatterns,
-		IgnoredFiles:    p.IgnoredFiles,
-		ExportFile:      p.ExportFile,
+		ID:               p.ID,
+		Name:             p.Name,
+		PkgPath:          p.PkgPath,
+		Errors:           p.Errors,
+		GoFiles:          p.GoFiles,
+		CompiledGoFiles:  p.CompiledGoFiles,
+		CompiledAsmFiles: p.CompiledAsmFiles,
+		OtherFiles:       p.OtherFiles,
+		EmbedFiles:       p.EmbedFiles,
+		EmbedPatterns:    p.EmbedPatterns,
+		IgnoredFiles:     p.IgnoredFiles,
+		ExportFile:       p.ExportFile,
 	}
 	if len(p.Imports) > 0 {
 		flat.Imports = make(map[string]string, len(p.Imports))
@@ -666,17 +672,18 @@ func (p *Package) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	*p = Package{
-		ID:              flat.ID,
-		Name:            flat.Name,
-		PkgPath:         flat.PkgPath,
-		Errors:          flat.Errors,
-		GoFiles:         flat.GoFiles,
-		CompiledGoFiles: flat.CompiledGoFiles,
-		OtherFiles:      flat.OtherFiles,
-		EmbedFiles:      flat.EmbedFiles,
-		EmbedPatterns:   flat.EmbedPatterns,
-		IgnoredFiles:    flat.IgnoredFiles,
-		ExportFile:      flat.ExportFile,
+		ID:               flat.ID,
+		Name:             flat.Name,
+		PkgPath:          flat.PkgPath,
+		Errors:           flat.Errors,
+		GoFiles:          flat.GoFiles,
+		CompiledGoFiles:  flat.CompiledGoFiles,
+		CompiledAsmFiles: flat.CompiledAsmFiles,
+		OtherFiles:       flat.OtherFiles,
+		EmbedFiles:       flat.EmbedFiles,
+		EmbedPatterns:    flat.EmbedPatterns,
+		IgnoredFiles:     flat.IgnoredFiles,
+		ExportFile:       flat.ExportFile,
 	}
 	if len(flat.Imports) > 0 {
 		p.Imports = make(map[string]*Package, len(flat.Imports))

--- a/gopls/internal/cache/load.go
+++ b/gopls/internal/cache/load.go
@@ -454,6 +454,7 @@ func buildMetadata(updates map[PackageID]*metadata.Package, loadDir string, stan
 			*dst = append(*dst, protocol.URIFromPath(filename))
 		}
 	}
+	copyURIs(&mp.CompiledAsmFiles, pkg.CompiledAsmFiles)
 	copyURIs(&mp.CompiledGoFiles, pkg.CompiledGoFiles)
 	copyURIs(&mp.GoFiles, pkg.GoFiles)
 	copyURIs(&mp.IgnoredFiles, pkg.IgnoredFiles)

--- a/gopls/internal/cache/metadata/metadata.go
+++ b/gopls/internal/cache/metadata/metadata.go
@@ -46,10 +46,11 @@ type Package struct {
 	Name    PackageName
 
 	// These fields are as defined by go/packages.Package
-	GoFiles         []protocol.DocumentURI
-	CompiledGoFiles []protocol.DocumentURI
-	IgnoredFiles    []protocol.DocumentURI
-	OtherFiles      []protocol.DocumentURI
+	GoFiles          []protocol.DocumentURI
+	CompiledGoFiles  []protocol.DocumentURI
+	CompiledAsmFiles []protocol.DocumentURI
+	IgnoredFiles     []protocol.DocumentURI
+	OtherFiles       []protocol.DocumentURI
 
 	ForTest       PackagePath // q in a "p [q.test]" package, else ""
 	TypesSizes    types.Sizes

--- a/gopls/internal/cache/package.go
+++ b/gopls/internal/cache/package.go
@@ -46,16 +46,17 @@ type syntaxPackage struct {
 	id PackageID
 
 	// -- outputs --
-	fset            *token.FileSet // for now, same as the snapshot's FileSet
-	goFiles         []*parsego.File
-	compiledGoFiles []*parsego.File
-	diagnostics     []*Diagnostic
-	parseErrors     []scanner.ErrorList
-	typeErrors      []types.Error
-	types           *types.Package
-	typesInfo       *types.Info
-	typesSizes      types.Sizes
-	importMap       map[PackagePath]*types.Package
+	fset             *token.FileSet // for now, same as the snapshot's FileSet
+	goFiles          []*parsego.File
+	compiledGoFiles  []*parsego.File
+	compiledAsmFiles []*parsego.File
+	diagnostics      []*Diagnostic
+	parseErrors      []scanner.ErrorList
+	typeErrors       []types.Error
+	types            *types.Package
+	typesInfo        *types.Info
+	typesSizes       types.Sizes
+	importMap        map[PackagePath]*types.Package
 
 	xrefsOnce sync.Once
 	_xrefs    []byte // only used by the xrefs method


### PR DESCRIPTION
The CompiledAsmFiles field supports storing assembly files.

Fixes golang/go#71754