### PR TITLE
gopls: add CompiledAsmFiles in cache.Package

### DIFF
--- a/gopls/internal/cache/check.go
+++ b/gopls/internal/cache/check.go
@@ -1468,8 +1468,8 @@ type typeCheckInputs struct {
 	// Used for type checking:
 	pkgPath                  PackagePath
 	name                     PackageName
-	goFiles, compiledGoFiles []file.Handle
-	sizes                    types.Sizes
+	goFiles, compiledGoFiles, asmFiles []file.Handle
+	sizes                              types.Sizes
 	depsByImpPath            map[ImportPath]PackageID
 	goVersion                string // packages.Module.GoVersion, e.g. "1.18"
 
@@ -1501,6 +1501,10 @@ func (s *Snapshot) typeCheckInputs(ctx context.Context, mp *metadata.Package) (*
 	if err != nil {
 		return nil, err
 	}
+	asmFiles, err := readFiles(ctx, s, mp.AsmFiles)
+	if err != nil {
+		return nil, err
+	}
 
 	goVersion := ""
 	if mp.Module != nil && mp.Module.GoVersion != "" {
@@ -1516,6 +1520,7 @@ func (s *Snapshot) typeCheckInputs(ctx context.Context, mp *metadata.Package) (*
 		name:            mp.Name,
 		goFiles:         goFiles,
 		compiledGoFiles: compiledGoFiles,
+		asmFiles:        asmFiles,
 		sizes:           mp.TypesSizes,
 		depsByImpPath:   mp.DepsByImpPath,
 		goVersion:       goVersion,
@@ -1566,6 +1571,10 @@ func localPackageKey(inputs *typeCheckInputs) file.Hash {
 	}
 	fmt.Fprintf(hasher, "goFiles: %d\n", len(inputs.goFiles))
 	for _, fh := range inputs.goFiles {
+		fmt.Fprintln(hasher, fh.Identity())
+	}
+	fmt.Fprintf(hasher, "asmFiles: %d\n", len(inputs.asmFiles))
+	for _, fh := range inputs.asmFiles {
 		fmt.Fprintln(hasher, fh.Identity())
 	}
 
@@ -1623,6 +1632,10 @@ func (b *typeCheckBatch) checkPackage(ctx context.Context, fset *token.FileSet, 
 		if pgf.ParseErr != nil {
 			pkg.parseErrors = append(pkg.parseErrors, pgf.ParseErr)
 		}
+	}
+	pkg.asmFiles, err = parseAsmFiles(ctx, inputs.asmFiles...)
+	if err != nil {
+		return nil, err
 	}
 
 	// Use the default type information for the unsafe package.

--- a/gopls/internal/cache/check.go
+++ b/gopls/internal/cache/check.go
@@ -1254,7 +1254,7 @@ func (b *packageHandleBuilder) evaluatePackageHandle(ctx context.Context, n *han
 		ph.localInputs = inputs
 
 	checkOpen:
-		for _, files := range [][]file.Handle{inputs.goFiles, inputs.compiledGoFiles} {
+		for _, files := range [][]file.Handle{inputs.goFiles, inputs.compiledGoFiles, inputs.asmFiles} {
 			for _, fh := range files {
 				if _, ok := fh.(*overlay); ok {
 					ph.isOpen = true

--- a/gopls/internal/cache/load.go
+++ b/gopls/internal/cache/load.go
@@ -453,6 +453,13 @@ func buildMetadata(updates map[PackageID]*metadata.Package, loadDir string, stan
 			*dst = append(*dst, protocol.URIFromPath(filename))
 		}
 	}
+	// Copy SFiles to AsmFiles.
+	for _, filename := range pkg.OtherFiles {
+		if !strings.HasSuffix(filename, ".s") {
+			continue
+		}
+		mp.AsmFiles = append(mp.AsmFiles, protocol.URIFromPath(filename))
+	}
 	copyURIs(&mp.CompiledGoFiles, pkg.CompiledGoFiles)
 	copyURIs(&mp.GoFiles, pkg.GoFiles)
 	copyURIs(&mp.IgnoredFiles, pkg.IgnoredFiles)

--- a/gopls/internal/cache/metadata/metadata.go
+++ b/gopls/internal/cache/metadata/metadata.go
@@ -58,7 +58,7 @@ type Package struct {
 	Errors        []packages.Error          // must be set for packages in import cycles
 	DepsByImpPath map[ImportPath]PackageID  // may contain dups; empty ID => missing
 	DepsByPkgPath map[PackagePath]PackageID // values are unique and non-empty
-	Module        *packages.Module
+	Module        *packages.Module          // may be missing for std and cmd; see Go issue #65816.
 	DepsErrors    []*packagesinternal.PackageError
 	LoadDir       string // directory from which go/packages was run
 	Standalone    bool   // package synthesized for a standalone file (e.g. ignore-tagged)

--- a/gopls/internal/cache/metadata/metadata.go
+++ b/gopls/internal/cache/metadata/metadata.go
@@ -51,12 +51,14 @@ type Package struct {
 	IgnoredFiles    []protocol.DocumentURI
 	OtherFiles      []protocol.DocumentURI
 
+	AsmFiles []protocol.DocumentURI // *.s subset of OtherFiles
+
 	ForTest       PackagePath // q in a "p [q.test]" package, else ""
 	TypesSizes    types.Sizes
 	Errors        []packages.Error          // must be set for packages in import cycles
 	DepsByImpPath map[ImportPath]PackageID  // may contain dups; empty ID => missing
 	DepsByPkgPath map[PackagePath]PackageID // values are unique and non-empty
-	Module        *packages.Module          // may be missing for std and cmd; see Go issue #65816.
+	Module        *packages.Module
 	DepsErrors    []*packagesinternal.PackageError
 	LoadDir       string // directory from which go/packages was run
 	Standalone    bool   // package synthesized for a standalone file (e.g. ignore-tagged)

--- a/gopls/internal/cache/package.go
+++ b/gopls/internal/cache/package.go
@@ -20,6 +20,7 @@ import (
 	"golang.org/x/tools/gopls/internal/cache/testfuncs"
 	"golang.org/x/tools/gopls/internal/cache/xrefs"
 	"golang.org/x/tools/gopls/internal/protocol"
+	"golang.org/x/tools/gopls/internal/util/asm"
 	"golang.org/x/tools/gopls/internal/util/safetoken"
 )
 
@@ -51,6 +52,7 @@ type syntaxPackage struct {
 	fset            *token.FileSet // for now, same as the snapshot's FileSet
 	goFiles         []*parsego.File
 	compiledGoFiles []*parsego.File
+	asmFiles        []*asm.File
 	diagnostics     []*Diagnostic
 	parseErrors     []scanner.ErrorList
 	typeErrors      []types.Error
@@ -71,7 +73,7 @@ type syntaxPackage struct {
 
 func (p *syntaxPackage) xrefs(enc *objectpath.Encoder) *xrefs.Index {
 	p.xrefsOnce.Do(func() {
-		p._xrefs = xrefs.NewIndex(enc, p.compiledGoFiles, p.types, p.typesInfo)
+		p._xrefs = xrefs.NewIndex(enc, p.compiledGoFiles, p.types, p.typesInfo, p.asmFiles)
 	})
 	return p._xrefs
 }
@@ -212,4 +214,21 @@ func (p *Package) ParseErrors() []scanner.ErrorList {
 // package, if any.
 func (p *Package) TypeErrors() []types.Error {
 	return p.pkg.typeErrors
+}
+
+func (p *Package) AsmFiles() []*asm.File {
+	return p.pkg.asmFiles
+}
+
+func (p *Package) AsmFile(uri protocol.DocumentURI) (*asm.File, error) {
+	return p.pkg.AsmFile(uri)
+}
+
+func (pkg *syntaxPackage) AsmFile(uri protocol.DocumentURI) (*asm.File, error) {
+	for _, af := range pkg.asmFiles {
+		if af.URI == uri {
+			return af, nil
+		}
+	}
+	return nil, fmt.Errorf("no parsed file for %s in %v", uri, pkg.id)
 }

--- a/gopls/internal/cache/package.go
+++ b/gopls/internal/cache/package.go
@@ -73,7 +73,7 @@ type syntaxPackage struct {
 
 func (p *syntaxPackage) xrefs(enc *objectpath.Encoder) *xrefs.Index {
 	p.xrefsOnce.Do(func() {
-		p._xrefs = xrefs.NewIndex(enc, p.compiledGoFiles, p.types, p.typesInfo, p.asmFiles)
+		p._xrefs = xrefs.NewIndex(enc, p.types, p.typesInfo, p.compiledGoFiles, p.asmFiles)
 	})
 	return p._xrefs
 }
@@ -226,7 +226,7 @@ func (p *Package) AsmFile(uri protocol.DocumentURI) (*asm.File, error) {
 
 func (pkg *syntaxPackage) AsmFile(uri protocol.DocumentURI) (*asm.File, error) {
 	for _, af := range pkg.asmFiles {
-		if af.URI == uri {
+		if af.Mapper.URI == uri {
 			return af, nil
 		}
 	}

--- a/gopls/internal/cache/parse.go
+++ b/gopls/internal/cache/parse.go
@@ -13,6 +13,7 @@ import (
 
 	"golang.org/x/tools/gopls/internal/cache/parsego"
 	"golang.org/x/tools/gopls/internal/file"
+	"golang.org/x/tools/gopls/internal/util/asm"
 )
 
 // ParseGo parses the file whose contents are provided by fh.
@@ -42,4 +43,22 @@ func parseGoImpl(ctx context.Context, fset *token.FileSet, fh file.Handle, mode 
 	}
 	pgf, _ := parsego.Parse(ctx, fset, fh.URI(), content, mode, purgeFuncBodies) // ignore 'fixes'
 	return pgf, nil
+}
+
+// parseAsmFiles parses the assembly files whose contents are provided by fhs.
+func parseAsmFiles(ctx context.Context, fhs ...file.Handle) ([]*asm.File, error) {
+	pafs := make([]*asm.File, len(fhs))
+	for i, fh := range fhs {
+		var err error
+		content, err := fh.Content()
+		if err != nil {
+			return nil, err
+		}
+		// Check for context cancellation before actually doing the parse.
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		pafs[i] = asm.Parse(fh.URI(), content)
+	}
+	return pafs, nil
 }

--- a/gopls/internal/cache/parse.go
+++ b/gopls/internal/cache/parse.go
@@ -49,14 +49,13 @@ func parseGoImpl(ctx context.Context, fset *token.FileSet, fh file.Handle, mode 
 func parseAsmFiles(ctx context.Context, fhs ...file.Handle) ([]*asm.File, error) {
 	pafs := make([]*asm.File, len(fhs))
 	for i, fh := range fhs {
-		var err error
+		// Check for context cancellation before reading file content.
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
 		content, err := fh.Content()
 		if err != nil {
 			return nil, err
-		}
-		// Check for context cancellation before actually doing the parse.
-		if ctx.Err() != nil {
-			return nil, ctx.Err()
 		}
 		pafs[i] = asm.Parse(fh.URI(), content)
 	}

--- a/gopls/internal/cache/xrefs/xrefs.go
+++ b/gopls/internal/cache/xrefs/xrefs.go
@@ -167,6 +167,10 @@ func NewIndex(enc *objectpath.Encoder, files []*parsego.File, pkg *types.Package
 			}
 			if rng, err := af.IdentRange(id); err == nil {
 				gobObj.Refs = append(gobObj.Refs, gobRef{
+					// FileIndex for asm files is offset by len(files)
+					// (i.e. the number of compiledGoFiles).
+					// Lookup reverses this by comparing against
+					// len(mp.CompiledGoFiles); the two counts must be equal.
 					FileIndex: len(files) + fileIndex,
 					Range:     rng,
 				})
@@ -225,9 +229,15 @@ func (idx *Index) Lookup(mp *metadata.Package, targets map[metadata.PackagePath]
 					for _, ref := range gobObj.Refs {
 						var uri protocol.DocumentURI
 						if asmIndex := ref.FileIndex - len(mp.CompiledGoFiles); asmIndex < 0 {
+							// CompiledGoFile reference.
+							// Invariant: len(files) passed to NewIndex
+							// equals len(mp.CompiledGoFiles).
 							uri = mp.CompiledGoFiles[ref.FileIndex]
-						} else {
+						} else if asmIndex < len(mp.AsmFiles) {
 							uri = mp.AsmFiles[asmIndex]
+						} else {
+							// Corrupt index: skip.
+							continue
 						}
 						locs = append(locs, protocol.Location{
 							URI:   uri,

--- a/gopls/internal/cache/xrefs/xrefs.go
+++ b/gopls/internal/cache/xrefs/xrefs.go
@@ -17,8 +17,10 @@ import (
 	"golang.org/x/tools/gopls/internal/cache/metadata"
 	"golang.org/x/tools/gopls/internal/cache/parsego"
 	"golang.org/x/tools/gopls/internal/protocol"
+	"golang.org/x/tools/gopls/internal/util/asm"
 	"golang.org/x/tools/gopls/internal/util/bug"
 	"golang.org/x/tools/gopls/internal/util/frob"
+	"golang.org/x/tools/gopls/internal/util/morestrings"
 )
 
 // NewIndex constructs an index of outbound cross-references for the
@@ -27,7 +29,7 @@ import (
 // Callers indexing many packages should share one objectpath Encoder
 // so that a heavily referenced package's object paths are encoded
 // once rather than once per referencing package.
-func NewIndex(enc *objectpath.Encoder, files []*parsego.File, pkg *types.Package, info *types.Info) *Index {
+func NewIndex(enc *objectpath.Encoder, files []*parsego.File, pkg *types.Package, info *types.Info, asmFiles []*asm.File) *Index {
 	// pkgObjects maps each referenced package Q to a mapping:
 	// from each referenced symbol in Q to the ordered list
 	// of references to that symbol from this package.
@@ -117,6 +119,61 @@ func NewIndex(enc *objectpath.Encoder, files []*parsego.File, pkg *types.Package
 		}
 	}
 
+	// For each asm file, record cross-package references.
+	// Within-package asm references are found by localReferences
+	// scanning syntax, not by the xrefs index.
+	for fileIndex, af := range asmFiles {
+		for _, id := range af.Idents {
+			if id.Kind != asm.Data && id.Kind != asm.Ref {
+				continue
+			}
+			pkgpath, name, ok := morestrings.CutLast(id.Name, ".")
+			if !ok {
+				continue
+			}
+			if pkgpath == "" || pkgpath == pkg.Path() {
+				// Within-package reference; skip (handled by localReferences).
+				continue
+			}
+			// Cross-package reference: find the dependency package.
+			//
+			// TODO(adonovan): assembly may legally reference
+			// non-dependencies (e.g. sync/atomic calls internal/runtime/atomic).
+			// Currently we only search direct imports; see goasm.Definition
+			// which searches the full metadata graph.
+			var depPkg *types.Package
+			for _, imp := range pkg.Imports() {
+				if imp.Path() == pkgpath {
+					depPkg = imp
+					break
+				}
+			}
+			if depPkg == nil {
+				continue
+			}
+			obj := depPkg.Scope().Lookup(name)
+			if obj == nil {
+				continue
+			}
+			objects := getObjects(depPkg)
+			gobObj, ok := objects[obj]
+			if !ok {
+				path, err := objectpathFor(obj)
+				if err != nil {
+					continue
+				}
+				gobObj = &gobObject{Path: path}
+				objects[obj] = gobObj
+			}
+			if rng, err := af.IdentRange(id); err == nil {
+				gobObj.Refs = append(gobObj.Refs, gobRef{
+					FileIndex: len(files) + fileIndex,
+					Range:     rng,
+				})
+			}
+		}
+	}
+
 	// Flatten the maps into slices, and sort for determinism.
 	var packages []*gobPackage
 	for p := range pkgObjects {
@@ -166,7 +223,12 @@ func (idx *Index) Lookup(mp *metadata.Package, targets map[metadata.PackagePath]
 			for _, gobObj := range gp.Objects {
 				if _, ok := objectSet[gobObj.Path]; ok {
 					for _, ref := range gobObj.Refs {
-						uri := mp.CompiledGoFiles[ref.FileIndex]
+						var uri protocol.DocumentURI
+						if asmIndex := ref.FileIndex - len(mp.CompiledGoFiles); asmIndex < 0 {
+							uri = mp.CompiledGoFiles[ref.FileIndex]
+						} else {
+							uri = mp.AsmFiles[asmIndex]
+						}
 						locs = append(locs, protocol.Location{
 							URI:   uri,
 							Range: ref.Range,
@@ -208,6 +270,6 @@ type gobObject struct {
 }
 
 type gobRef struct {
-	FileIndex int            // index of enclosing file within P's CompiledGoFiles
+	FileIndex int            // index of enclosing file within P's CompiledGoFiles + AsmFiles
 	Range     protocol.Range // source range of reference
 }

--- a/gopls/internal/cache/xrefs/xrefs.go
+++ b/gopls/internal/cache/xrefs/xrefs.go
@@ -29,7 +29,7 @@ import (
 // Callers indexing many packages should share one objectpath Encoder
 // so that a heavily referenced package's object paths are encoded
 // once rather than once per referencing package.
-func NewIndex(enc *objectpath.Encoder, files []*parsego.File, pkg *types.Package, info *types.Info, asmFiles []*asm.File) *Index {
+func NewIndex(enc *objectpath.Encoder, pkg *types.Package, info *types.Info, files []*parsego.File, asmFiles []*asm.File) *Index {
 	// pkgObjects maps each referenced package Q to a mapping:
 	// from each referenced symbol in Q to the ordered list
 	// of references to that symbol from this package.
@@ -122,8 +122,16 @@ func NewIndex(enc *objectpath.Encoder, files []*parsego.File, pkg *types.Package
 	// For each asm file, record cross-package references.
 	// Within-package asm references are found by localReferences
 	// scanning syntax, not by the xrefs index.
-	for fileIndex, af := range asmFiles {
-		for _, id := range af.Idents {
+
+	// Build a mapping from import path to package, so that each
+	// cross-package identifier can be resolved without a linear
+	// scan of pkg.Imports() for every identifier.
+	importsByPath := make(map[string]*types.Package, len(pkg.Imports()))
+	for _, imp := range pkg.Imports() {
+		importsByPath[imp.Path()] = imp
+	}
+	for fileIndex, file := range asmFiles {
+		for _, id := range file.Idents {
 			if id.Kind != asm.Data && id.Kind != asm.Ref {
 				continue
 			}
@@ -137,18 +145,12 @@ func NewIndex(enc *objectpath.Encoder, files []*parsego.File, pkg *types.Package
 			}
 			// Cross-package reference: find the dependency package.
 			//
-			// TODO(adonovan): assembly may legally reference
+			// TODO(Groot Guo): assembly may legally reference
 			// non-dependencies (e.g. sync/atomic calls internal/runtime/atomic).
 			// Currently we only search direct imports; see goasm.Definition
 			// which searches the full metadata graph.
-			var depPkg *types.Package
-			for _, imp := range pkg.Imports() {
-				if imp.Path() == pkgpath {
-					depPkg = imp
-					break
-				}
-			}
-			if depPkg == nil {
+			depPkg, ok := importsByPath[pkgpath]
+			if !ok {
 				continue
 			}
 			obj := depPkg.Scope().Lookup(name)
@@ -158,14 +160,14 @@ func NewIndex(enc *objectpath.Encoder, files []*parsego.File, pkg *types.Package
 			objects := getObjects(depPkg)
 			gobObj, ok := objects[obj]
 			if !ok {
-				path, err := objectpathFor(obj)
+				path, err := enc.For(obj)
 				if err != nil {
 					continue
 				}
 				gobObj = &gobObject{Path: path}
 				objects[obj] = gobObj
 			}
-			if rng, err := af.IdentRange(id); err == nil {
+			if rng, err := file.IdentRange(id); err == nil {
 				gobObj.Refs = append(gobObj.Refs, gobRef{
 					// FileIndex for asm files is offset by len(files)
 					// (i.e. the number of compiledGoFiles).
@@ -233,11 +235,8 @@ func (idx *Index) Lookup(mp *metadata.Package, targets map[metadata.PackagePath]
 							// Invariant: len(files) passed to NewIndex
 							// equals len(mp.CompiledGoFiles).
 							uri = mp.CompiledGoFiles[ref.FileIndex]
-						} else if asmIndex < len(mp.AsmFiles) {
-							uri = mp.AsmFiles[asmIndex]
 						} else {
-							// Corrupt index: skip.
-							continue
+							uri = mp.AsmFiles[asmIndex]
 						}
 						locs = append(locs, protocol.Location{
 							URI:   uri,

--- a/gopls/internal/goasm/definition.go
+++ b/gopls/internal/goasm/definition.go
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Package goasm provides language-server features for files in Go
-// assembly language (https://go.dev/doc/asm).
 package goasm
 
 import (
@@ -36,7 +34,7 @@ func Definition(ctx context.Context, snapshot *cache.Snapshot, fh file.Handle, r
 		return nil, err
 	}
 	mapper := protocol.NewMapper(fh.URI(), content)
-	offset, err := mapper.PositionOffset(rng.Start)
+	start, end, err := mapper.RangeOffsets(rng)
 	if err != nil {
 		return nil, err
 	}
@@ -48,10 +46,11 @@ func Definition(ctx context.Context, snapshot *cache.Snapshot, fh file.Handle, r
 	file := asm.Parse(fh.URI(), content)
 
 	// Figure out the selected symbol.
-	// For now, just find the identifier around the cursor.
+	// Use the selection range so that haphazard selections that
+	// happen to start in an identifier don't produce spurious matches.
 	var found *asm.Ident
 	for _, id := range file.Idents {
-		if id.Offset <= offset && offset <= id.End() {
+		if id.Offset <= start && end <= id.End() {
 			found = &id
 			break
 		}

--- a/gopls/internal/goasm/definition.go
+++ b/gopls/internal/goasm/definition.go
@@ -36,7 +36,7 @@ func Definition(ctx context.Context, snapshot *cache.Snapshot, fh file.Handle, r
 		return nil, err
 	}
 	mapper := protocol.NewMapper(fh.URI(), content)
-	start, end, err := mapper.RangeOffsets(rng)
+	offset, err := mapper.PositionOffset(rng.Start)
 	if err != nil {
 		return nil, err
 	}
@@ -45,13 +45,13 @@ func Definition(ctx context.Context, snapshot *cache.Snapshot, fh file.Handle, r
 	//
 	// TODO(adonovan): make this just another
 	// attribute of the type-checked cache.Package.
-	file := asm.Parse(content)
+	file := asm.Parse(fh.URI(), content)
 
 	// Figure out the selected symbol.
 	// For now, just find the identifier around the cursor.
 	var found *asm.Ident
 	for _, id := range file.Idents {
-		if id.Offset <= start && end <= id.End() {
+		if id.Offset <= offset && offset <= id.End() {
 			found = &id
 			break
 		}

--- a/gopls/internal/goasm/references.go
+++ b/gopls/internal/goasm/references.go
@@ -1,0 +1,211 @@
+// Copyright 2025 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package goasm provides language-server features for files in Go
+// assembly language (https://go.dev/doc/asm).
+package goasm
+
+import (
+	"context"
+	"fmt"
+	"go/ast"
+	"go/types"
+	"sort"
+
+	"golang.org/x/tools/go/types/objectpath"
+	"golang.org/x/tools/gopls/internal/cache"
+	"golang.org/x/tools/gopls/internal/cache/metadata"
+	"golang.org/x/tools/gopls/internal/file"
+	"golang.org/x/tools/gopls/internal/protocol"
+	"golang.org/x/tools/gopls/internal/util/asm"
+	"golang.org/x/tools/gopls/internal/util/morestrings"
+	"golang.org/x/tools/internal/event"
+)
+
+// References returns a list of locations (file and position) where the symbol under the cursor in an assembly file is referenced,
+// including both Go source files and assembly files within the same package.
+func References(ctx context.Context, snapshot *cache.Snapshot, fh file.Handle, position protocol.Position, includeDeclaration bool) ([]protocol.Location, error) {
+	ctx, done := event.Start(ctx, "goasm.References")
+	defer done()
+
+	mps, err := snapshot.MetadataForFile(ctx, fh.URI(), false)
+	if err != nil {
+		return nil, err
+	}
+	metadata.RemoveIntermediateTestVariants(&mps)
+	if len(mps) == 0 {
+		return nil, fmt.Errorf("no package metadata for file %s", fh.URI())
+	}
+	mp := mps[0]
+	pkgs, err := snapshot.TypeCheck(ctx, mp.ID)
+	if err != nil {
+		return nil, err
+	}
+	pkg := pkgs[0]
+	asmFile, err := pkg.AsmFile(fh.URI())
+	if err != nil {
+		return nil, err // "can't happen"
+	}
+
+	offset, err := asmFile.Mapper.PositionOffset(position)
+	if err != nil {
+		return nil, err
+	}
+
+	// Figure out the selected symbol.
+	// For now, just find the identifier around the cursor.
+	var found *asm.Ident
+	for _, id := range asmFile.Idents {
+		if id.Offset <= offset && offset <= id.End() {
+			found = &id
+			break
+		}
+	}
+	if found == nil {
+		return nil, fmt.Errorf("not an identifier")
+	}
+
+	var locations []protocol.Location
+
+	pkgpath, name, ok := morestrings.CutLast(found.Name, ".")
+	if !ok {
+		return nil, fmt.Errorf("not found")
+	}
+
+	// Determine the declaring package for this symbol.
+	var (
+		declPkg   = pkg
+		declMP    = mp
+		symbolObj types.Object
+	)
+	if pkgpath == "" || pkgpath == string(mp.PkgPath) {
+		// Same-package reference: look up in the current package.
+		symbolObj = pkg.Types().Scope().Lookup(name)
+	} else {
+		// Cross-package reference: find the declaring package.
+		// See goasm.Definition for the same approach.
+		var declaring *metadata.Package
+		for dep := range snapshot.MetadataGraph().ForwardReflexiveTransitiveClosure(mp.ID) {
+			if dep.PkgPath == metadata.PackagePath(pkgpath) {
+				declaring = dep
+				break
+			}
+		}
+		if declaring == nil {
+			return nil, fmt.Errorf("package %q is not a dependency", pkgpath)
+		}
+		pkgs, err = snapshot.TypeCheck(ctx, declaring.ID)
+		if err != nil {
+			return nil, err
+		}
+		declPkg = pkgs[0]
+		declMP = declaring
+		symbolObj = declPkg.Types().Scope().Lookup(name)
+	}
+	if symbolObj == nil {
+		return nil, fmt.Errorf("symbol %q not found in package %q", name, pkgpath)
+	}
+
+	// Scan Go files in the declaring package for references to the symbol.
+	for _, pgf := range declPkg.CompiledGoFiles() {
+		for curId := range pgf.Cursor().Preorder((*ast.Ident)(nil)) {
+			id := curId.Node().(*ast.Ident)
+			curObj := declPkg.TypesInfo().ObjectOf(id)
+			if curObj != symbolObj {
+				continue
+			}
+			if !includeDeclaration && declPkg.TypesInfo().Defs[id] != nil {
+				// For cross-package references from assembly,
+				// the Go declaration is the canonical declaration
+				// and should be excluded when not including declarations.
+				// For same-package references, the asm TEXT line
+				// is the declaration, so Go Defs are reference targets.
+				if pkgpath != "" && pkgpath != string(mp.PkgPath) {
+					continue
+				}
+			}
+			loc, err := pgf.NodeLocation(id)
+			if err != nil {
+				return nil, err
+			}
+			locations = append(locations, loc)
+		}
+	}
+
+	// Scan asm files in the current package for matching identifiers.
+	for _, asmFile := range pkg.AsmFiles() {
+		for _, id := range asmFile.Idents {
+			if id.Name == found.Name {
+				if id.Kind == asm.Label {
+					continue
+				}
+				if !includeDeclaration && (id.Kind == asm.Text || id.Kind == asm.Global) {
+					continue
+				}
+				if loc, err := asmFile.IdentLocation(id); err == nil {
+					locations = append(locations, loc)
+				}
+			}
+		}
+	}
+
+	// Global workspace search via xrefs index for exported symbols.
+	// Skip if the symbol cannot be objectpath-encoded (rare edge case);
+	// golang.References handles this the same way.
+	if symbolObj.Exported() {
+		if path, err := objectpath.For(symbolObj); err == nil {
+
+			// Compute the scope: all reverse dependencies of the
+			// declaring package, restricted to the workspace.
+			workspace, err := snapshot.WorkspaceMetadata(ctx)
+			if err != nil {
+				return nil, err
+			}
+			workspaceMap := make(map[metadata.PackageID]*metadata.Package, len(workspace))
+			for _, wmp := range workspace {
+				workspaceMap[wmp.ID] = wmp
+			}
+
+			rdeps, err := snapshot.ReverseDependencies(ctx, declMP.ID, false)
+			if err != nil {
+				return nil, err
+			}
+
+			var globalIDs []metadata.PackageID
+			for id := range rdeps {
+				if _, ok := workspaceMap[id]; ok {
+					globalIDs = append(globalIDs, id)
+				}
+			}
+
+			if len(globalIDs) > 0 {
+				targets := map[metadata.PackagePath]map[objectpath.Path]struct{}{
+					declMP.PkgPath: {path: {}},
+				}
+				indexes, err := snapshot.References(ctx, globalIDs...)
+				if err != nil {
+					return nil, err
+				}
+				for _, index := range indexes {
+					for _, loc := range index.Lookup(targets) {
+						locations = append(locations, loc)
+					}
+				}
+			}
+		}
+	}
+
+	// Deduplicate by location.
+	sort.Slice(locations, func(i, j int) bool {
+		return protocol.CompareLocation(locations[i], locations[j]) < 0
+	})
+	out := locations[:0]
+	for _, loc := range locations {
+		if len(out) == 0 || out[len(out)-1] != loc {
+			out = append(out, loc)
+		}
+	}
+
+	return out, nil
+}

--- a/gopls/internal/goasm/references.go
+++ b/gopls/internal/goasm/references.go
@@ -133,6 +133,26 @@ func References(ctx context.Context, snapshot *cache.Snapshot, fh file.Handle, p
 		}
 	}
 
+	// For cross-package references, also scan assembly files
+	// in the declaring package.
+	if pkgpath != "" && pkgpath != string(mp.PkgPath) {
+		for _, asmFile := range declPkg.AsmFiles() {
+			for _, id := range asmFile.Idents {
+				if id.Name == found.Name {
+					if id.Kind == asm.Label {
+						continue
+					}
+					if !includeDeclaration && (id.Kind == asm.Text || id.Kind == asm.Global) {
+						continue
+					}
+					if loc, err := asmFile.IdentLocation(id); err == nil {
+						locations = append(locations, loc)
+					}
+				}
+			}
+		}
+	}
+
 	// Scan asm files in the current package for matching identifiers.
 	for _, asmFile := range pkg.AsmFiles() {
 		for _, id := range asmFile.Idents {

--- a/gopls/internal/goasm/references.go
+++ b/gopls/internal/goasm/references.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"go/ast"
 	"go/types"
+	"slices"
 	"sort"
 
 	"golang.org/x/tools/go/types/objectpath"
@@ -220,12 +221,7 @@ func References(ctx context.Context, snapshot *cache.Snapshot, fh file.Handle, p
 	sort.Slice(locations, func(i, j int) bool {
 		return protocol.CompareLocation(locations[i], locations[j]) < 0
 	})
-	out := locations[:0]
-	for _, loc := range locations {
-		if len(out) == 0 || out[len(out)-1] != loc {
-			out = append(out, loc)
-		}
-	}
+	locations = slices.Compact(locations)
 
-	return out, nil
+	return locations, nil
 }

--- a/gopls/internal/golang/references.go
+++ b/gopls/internal/golang/references.go
@@ -643,7 +643,7 @@ func localReferences(pkg *cache.Package, targets map[types.Object]bool, correspo
 			}
 			if rng, err := af.IdentRange(id); err == nil {
 				report(protocol.Location{
-					URI:   af.URI,
+					URI:   af.Mapper.URI,
 					Range: rng,
 				}, false)
 			}

--- a/gopls/internal/golang/references.go
+++ b/gopls/internal/golang/references.go
@@ -33,7 +33,9 @@ import (
 	"golang.org/x/tools/gopls/internal/cache/parsego"
 	"golang.org/x/tools/gopls/internal/file"
 	"golang.org/x/tools/gopls/internal/protocol"
+	"golang.org/x/tools/gopls/internal/util/asm"
 	"golang.org/x/tools/gopls/internal/util/cursorutil"
+	"golang.org/x/tools/gopls/internal/util/morestrings"
 	"golang.org/x/tools/gopls/internal/util/safetoken"
 
 	"golang.org/x/tools/internal/event"
@@ -615,6 +617,35 @@ func localReferences(pkg *cache.Package, targets map[types.Object]bool, correspo
 			}
 			if obj, ok := pkg.TypesInfo().Uses[id]; ok && matches(obj) {
 				report(mustLocation(pgf, id), false)
+			}
+		}
+	}
+
+	// Scan assembly files for references to the target objects.
+	for _, af := range pkg.AsmFiles() {
+		for _, id := range af.Idents {
+			if id.Kind != asm.Data && id.Kind != asm.Ref {
+				continue
+			}
+			pkgpath, name, ok := morestrings.CutLast(id.Name, ".")
+			if !ok {
+				continue
+			}
+			if pkgpath != "" && pkgpath != pkg.Types().Path() {
+				continue
+			}
+			obj := pkg.Types().Scope().Lookup(name)
+			if obj == nil {
+				continue
+			}
+			if !matches(obj) {
+				continue
+			}
+			if rng, err := af.IdentRange(id); err == nil {
+				report(protocol.Location{
+					URI:   af.URI,
+					Range: rng,
+				}, false)
 			}
 		}
 	}

--- a/gopls/internal/server/references.go
+++ b/gopls/internal/server/references.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	"golang.org/x/tools/gopls/internal/file"
+	"golang.org/x/tools/gopls/internal/goasm"
 	"golang.org/x/tools/gopls/internal/golang"
 	"golang.org/x/tools/gopls/internal/label"
 	"golang.org/x/tools/gopls/internal/mod"
@@ -38,6 +39,8 @@ func (s *server) References(ctx context.Context, params *protocol.ReferenceParam
 		return golang.References(ctx, snapshot, fh, params.Range, params.Context.IncludeDeclaration)
 	case file.Mod:
 		return mod.References(ctx, snapshot, fh, params)
+	case file.Asm:
+		return goasm.References(ctx, snapshot, fh, params.Position, params.Context.IncludeDeclaration)
 	}
 	return nil, nil // empty result
 }

--- a/gopls/internal/test/marker/testdata/references/asm.txt
+++ b/gopls/internal/test/marker/testdata/references/asm.txt
@@ -1,0 +1,22 @@
+Test of asm references.
+
+-- example/label_example.s --
+TEXT ·JumpDemo(SB), $0-0
+label1: //@loc(defLabel, "label1")
+    JMP label1 //@loc(refLabel, "label1")
+
+-- example/in_package_ref.s --
+TEXT ·Foo(SB), $0-8 //@loc(defFooAsm, "·Foo")
+    RET
+
+TEXT ·Bar(SB), $0-8
+    CALL ·Foo(SB) //@loc(callFooAsm, "·Foo")
+    RET
+
+-- example/example_data.s --
+DATA ·myGlobal+0(SB)/8, $42
+GLOBL ·myGlobal(SB), NOPTR, 8
+
+TEXT ·UseGlobal(SB), $0-0
+    MOVQ ·myGlobal(SB), AX //@loc(refMyGlobal, "·myGlobal")
+    RET

--- a/gopls/internal/test/marker/testdata/references/asm_cross_pkg.txt
+++ b/gopls/internal/test/marker/testdata/references/asm_cross_pkg.txt
@@ -1,0 +1,24 @@
+Test cross-package references involving assembly files.
+
+-- go.mod --
+module example.com
+go 1.24
+
+-- lib/lib.go --
+package lib
+
+func Helper() int { return 42 } //@loc(defHelper, "Helper"), refs("Helper", defHelper, goCallHelper, asmCallHelper)
+
+-- caller/caller.go --
+package caller
+
+import "example.com/lib"
+
+func Use() {
+    lib.Helper() //@loc(goCallHelper, "Helper")
+}
+
+-- caller/impl.s --
+TEXT ·Wrapper(SB), $0-0
+    CALL example·com∕lib·Helper(SB) //@loc(asmCallHelper, "example·com∕lib·Helper"), refs("Helper", defHelper, goCallHelper, asmCallHelper)
+    RET

--- a/gopls/internal/test/marker/testdata/references/asm_go.txt
+++ b/gopls/internal/test/marker/testdata/references/asm_go.txt
@@ -1,0 +1,41 @@
+This test validates the References request functionality in Go assembly files.
+
+-- go.mod --
+module example.com
+go 1.24
+
+-- go_call_asm/example_func.go --
+package go_call_asm
+
+func Add(a, b int) int //@loc(defAddGo, "Add"), refs("Add", defAddGo, callAddGo)
+func UseAdd() int {
+    return Add(1, 2) //@loc(callAddGo, "Add")
+}
+var myGlobal int64 //@loc(defMyGlobalGo, "myGlobal"), refs("myGlobal", defMyGlobalGo, refMyGlobal, refMyGlobalGo)
+var _ = myGlobal   //@loc(refMyGlobalGo, "myGlobal")
+
+-- go_call_asm/example_asm.s --
+TEXT ·Add(SB), $0-24 //@loc(defAddGoAsm, "·Add"), refs("Add", defAddGoAsm, defAddGo, callAddGo)
+    MOVQ a+0(FP), AX
+    ADDQ b+8(FP), AX
+    RET
+
+DATA ·myGlobal+0(SB)/8, $42
+GLOBL ·myGlobal(SB), NOPTR, 8
+TEXT ·UseGlobal(SB), $0-0
+    MOVQ ·myGlobal(SB), AX //@loc(refMyGlobal, "·myGlobal")
+    RET
+
+-- asm_call_go/example_sub.go --
+package asm_call_go
+
+func Sub(a, b int) int { return a - b } //@loc(defSubGo, "Sub")
+
+-- asm_call_go/call_sub.s --
+TEXT ·CallSub(SB), $0-16
+    MOVQ $10, AX
+    MOVQ $3, BX
+    MOVQ AX, a+0(FP)
+    MOVQ BX, b+8(FP)
+    CALL ·Sub(SB) //@loc(callSubAsm, "·Sub")
+    RET

--- a/gopls/internal/util/asm/parse.go
+++ b/gopls/internal/util/asm/parse.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"strings"
 	"unicode"
+
+	"golang.org/x/tools/gopls/internal/protocol"
 )
 
 // Kind describes the nature of an identifier in an assembly file.
@@ -43,25 +45,39 @@ var kindString = [...]string{
 
 // A file represents a parsed file of Go assembly language.
 type File struct {
+	URI    protocol.DocumentURI
 	Idents []Ident
+
+	Mapper *protocol.Mapper
 
 	// TODO(adonovan): use token.File? This may be important in a
 	// future in which analyzers can report diagnostics in .s files.
 }
 
+// IdentRange returns the protocol.Range for the identifier in this file.
+func (f *File) IdentRange(ident Ident) (protocol.Range, error) {
+	return f.Mapper.OffsetRange(ident.Offset, ident.Offset+ident.OrigLen)
+}
+
+// IdentLocation returns a protocol Location for the identifier in this file.
+func (f *File) IdentLocation(ident Ident) (protocol.Location, error) {
+	return f.Mapper.OffsetLocation(ident.Offset, ident.Offset+ident.OrigLen)
+}
+
 // Ident represents an identifier in an assembly file.
 type Ident struct {
-	Name   string // symbol name (after correcting [·∕]); Name[0]='.' => current package
-	Offset int    // zero-based byte offset
-	Kind   Kind
+	Name    string // symbol name (after correcting [·∕]); Name[0]='.' => current package
+	Offset  int    // zero-based byte offset
+	OrigLen int    // original length of the symbol name (before cleanup)
+	Kind    Kind
 }
 
 // End returns the identifier's end offset.
-func (id Ident) End() int { return id.Offset + len(id.Name) }
+func (id Ident) End() int { return id.Offset + id.OrigLen }
 
 // Parse extracts identifiers from Go assembly files.
 // Since it is a best-effort parser, it never returns an error.
-func Parse(content []byte) *File {
+func Parse(uri protocol.DocumentURI, content []byte) *File {
 	var idents []Ident
 	offset := 0 // byte offset of start of current line
 
@@ -86,9 +102,10 @@ func Parse(content []byte) *File {
 			label := strings.TrimSpace(line[:colon])
 			if isIdent(label) {
 				idents = append(idents, Ident{
-					Name:   label,
-					Offset: offset + strings.Index(line, label),
-					Kind:   Label,
+					Name:    label,
+					Offset:  offset + strings.Index(line, label),
+					OrigLen: len(label),
+					Kind:    Label,
 				})
 				continue
 			}
@@ -122,9 +139,10 @@ func Parse(content []byte) *File {
 				if isIdent(sym) {
 					// (The Index call assumes sym is not itself "TEXT" etc.)
 					idents = append(idents, Ident{
-						Name:   cleanup(sym),
-						Kind:   kind,
-						Offset: offset + strings.Index(line, sym),
+						Name:    cleanup(sym),
+						Kind:    kind,
+						Offset:  offset + strings.Index(line, sym),
+						OrigLen: len(sym),
 					})
 				}
 				continue
@@ -182,9 +200,10 @@ func Parse(content []byte) *File {
 			sym = cutBefore(sym, "<")   // "sym<ABIInternal>" =>> "sym"
 			if isIdent(sym) {
 				idents = append(idents, Ident{
-					Name:   cleanup(sym),
-					Kind:   Ref,
-					Offset: offset + tokenPos,
+					Name:    cleanup(sym),
+					Kind:    Ref,
+					Offset:  offset + tokenPos,
+					OrigLen: len(sym),
 				})
 			}
 		}
@@ -192,7 +211,7 @@ func Parse(content []byte) *File {
 
 	_ = scan.Err() // ignore scan errors
 
-	return &File{Idents: idents}
+	return &File{Idents: idents, Mapper: protocol.NewMapper(uri, content), URI: uri}
 }
 
 // isIdent reports whether s is a valid Go assembly identifier.

--- a/gopls/internal/util/asm/parse.go
+++ b/gopls/internal/util/asm/parse.go
@@ -45,7 +45,6 @@ var kindString = [...]string{
 
 // A file represents a parsed file of Go assembly language.
 type File struct {
-	URI    protocol.DocumentURI
 	Idents []Ident
 
 	Mapper *protocol.Mapper
@@ -211,7 +210,7 @@ func Parse(uri protocol.DocumentURI, content []byte) *File {
 
 	_ = scan.Err() // ignore scan errors
 
-	return &File{Idents: idents, Mapper: protocol.NewMapper(uri, content), URI: uri}
+	return &File{Idents: idents, Mapper: protocol.NewMapper(uri, content)}
 }
 
 // isIdent reports whether s is a valid Go assembly identifier.

--- a/gopls/internal/util/asm/parse_test.go
+++ b/gopls/internal/util/asm/parse_test.go
@@ -39,7 +39,7 @@ TEXT ·g(SB),NOSPLIT,$0
 `[1:])
 	const filename = "asm.s"
 	m := protocol.NewMapper(protocol.URIFromPath(filename), src)
-	file := asm.Parse(src)
+	file := asm.Parse("", src)
 
 	want := `
 asm.s:5:6-11:	data "hello"

--- a/gopls/internal/util/asm/parse_test.go
+++ b/gopls/internal/util/asm/parse_test.go
@@ -39,7 +39,7 @@ TEXT ·g(SB),NOSPLIT,$0
 `[1:])
 	const filename = "asm.s"
 	m := protocol.NewMapper(protocol.URIFromPath(filename), src)
-	file := asm.Parse("", src)
+	file := asm.Parse(protocol.URIFromPath(filename), src)
 
 	want := `
 asm.s:5:6-11:	data "hello"


### PR DESCRIPTION
The CompiledAsmFiles field supports storing assembly files.

Update golang/go#71754