### PR TITLE
all: replace ioutil.ReadDir

### DIFF
--- a/go/buildutil/util.go
+++ b/go/buildutil/util.go
@@ -11,7 +11,7 @@ import (
 	"go/parser"
 	"go/token"
 	"io"
-	"io/ioutil"
+	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
@@ -180,7 +180,23 @@ func ReadDir(ctxt *build.Context, path string) ([]os.FileInfo, error) {
 	if ctxt.ReadDir != nil {
 		return ctxt.ReadDir(path)
 	}
-	return ioutil.ReadDir(path)
+	return GetFileInfos(path)
+}
+
+func GetFileInfos(path string) ([]os.FileInfo, error) {
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+	infos := make([]fs.FileInfo, 0, len(entries))
+	for _, entry := range entries {
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		infos = append(infos, info)
+	}
+	return infos, nil
 }
 
 // SplitPathList behaves like filepath.SplitList,

--- a/godoc/vfs/os.go
+++ b/godoc/vfs/os.go
@@ -7,12 +7,13 @@ package vfs
 import (
 	"fmt"
 	"go/build"
-	"io/ioutil"
 	"os"
 	pathpkg "path"
 	"path/filepath"
 	"runtime"
 	"slices"
+
+	"golang.org/x/tools/go/buildutil"
 )
 
 // We expose a new variable because otherwise we need to copy the findGOROOT logic again
@@ -100,5 +101,5 @@ func (root osFS) Stat(path string) (os.FileInfo, error) {
 }
 
 func (root osFS) ReadDir(path string) ([]os.FileInfo, error) {
-	return ioutil.ReadDir(root.resolve(path)) // is sorted
+	return buildutil.GetFileInfos(root.resolve(path)) // is sorted
 }

--- a/internal/imports/fix.go
+++ b/internal/imports/fix.go
@@ -15,7 +15,6 @@ import (
 	"go/token"
 	"go/types"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -30,6 +29,7 @@ import (
 	"maps"
 
 	"golang.org/x/tools/go/ast/astutil"
+	"golang.org/x/tools/go/buildutil"
 	"golang.org/x/tools/internal/event"
 	"golang.org/x/tools/internal/gocommand"
 	"golang.org/x/tools/internal/gopathwalk"
@@ -1081,7 +1081,7 @@ func (e *ProcessEnv) buildContext() (*build.Context, error) {
 	// HACK: setting any of the Context I/O hooks prevents Import from invoking
 	// 'go list', regardless of GO111MODULE. This is undocumented, but it's
 	// unlikely to change before GOPATH support is removed.
-	ctx.ReadDir = ioutil.ReadDir
+	ctx.ReadDir = buildutil.GetFileInfos
 
 	return &ctx, nil
 }


### PR DESCRIPTION
buildutil: replace depreacted io/ioutil,
create separate function for retrieving file info from the path, export the func