### PR TITLE
go/analysis/singlechecker: respect custom FlagSet

### DIFF
--- a/go/analysis/internal/checker/checker.go
+++ b/go/analysis/internal/checker/checker.go
@@ -65,18 +65,23 @@ var (
 
 // RegisterFlags registers command-line flags used by the analysis driver.
 func RegisterFlags() {
+	RegisterFlagsWithFlagSet(flag.CommandLine)
+}
+
+// RegisterFlagsWithFlagSet registers command-line flags used by the analysis driver.
+func RegisterFlagsWithFlagSet(fs *flag.FlagSet) {
 	// When adding flags here, remember to update
 	// the list of suppressed flags in analysisflags.
 
-	flag.StringVar(&Debug, "debug", Debug, `debug flags, any subset of "fpstv"`)
+	fs.StringVar(&Debug, "debug", Debug, `debug flags, any subset of "fpstv"`)
 
-	flag.StringVar(&CPUProfile, "cpuprofile", "", "write CPU profile to this file")
-	flag.StringVar(&MemProfile, "memprofile", "", "write memory profile to this file")
-	flag.StringVar(&Trace, "trace", "", "write trace log to this file")
-	flag.BoolVar(&IncludeTests, "test", IncludeTests, "indicates whether test files should be analyzed, too")
+	fs.StringVar(&CPUProfile, "cpuprofile", "", "write CPU profile to this file")
+	fs.StringVar(&MemProfile, "memprofile", "", "write memory profile to this file")
+	fs.StringVar(&Trace, "trace", "", "write trace log to this file")
+	fs.BoolVar(&IncludeTests, "test", IncludeTests, "indicates whether test files should be analyzed, too")
 
-	flag.BoolVar(&Fix, "fix", false, "apply all suggested fixes")
-	flag.BoolVar(&Diff, "diff", false, "with -fix, don't update the files, but print a unified diff")
+	fs.BoolVar(&Fix, "fix", false, "apply all suggested fixes")
+	fs.BoolVar(&Diff, "diff", false, "with -fix, don't update the files, but print a unified diff")
 }
 
 // Run loads the packages specified by args using go/packages,

--- a/go/analysis/singlechecker/singlechecker.go
+++ b/go/analysis/singlechecker/singlechecker.go
@@ -46,9 +46,14 @@ func Main(a *analysis.Analyzer) {
 		log.Fatal(err)
 	}
 
-	checker.RegisterFlags()
+	flagSet := flag.CommandLine
+	if a.Flags.Parsed() {
+		flagSet = &a.Flags
+	}
 
-	flag.Usage = func() {
+	checker.RegisterFlagsWithFlagSet(flagSet)
+
+	flagSet.Usage = func() {
 		paras := strings.Split(a.Doc, "\n\n")
 		fmt.Fprintf(os.Stderr, "%s: %s\n\n", a.Name, paras[0])
 		fmt.Fprintf(os.Stderr, "Usage: %s [-flag] [package]\n\n", a.Name)
@@ -61,9 +66,9 @@ func Main(a *analysis.Analyzer) {
 
 	analyzers = analysisflags.Parse(analyzers, false)
 
-	args := flag.Args()
+	args := flagSet.Args()
 	if len(args) == 0 {
-		flag.Usage()
+		flagSet.Usage()
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
When a custom flag.FlagSet is provided, the args should be fetched from that custom FlagSet, not from the global os.Args.

This fix is useful for calling singlechecker from a CLI subcommand like `gosocialcheck run ./...`.

Fixes golang/go#73875