### PR TITLE
go/analysis: expose GoMod etc. to Pass.Module

### DIFF
--- a/go/analysis/analysis.go
+++ b/go/analysis/analysis.go
@@ -11,6 +11,7 @@ import (
 	"go/token"
 	"go/types"
 	"reflect"
+	"time"
 )
 
 // An Analyzer describes an analysis function and its options.
@@ -250,7 +251,19 @@ type Fact interface {
 
 // A Module describes the module to which a package belongs.
 type Module struct {
-	Path      string // module path
-	Version   string // module version ("" if unknown, such as for workspace modules)
-	GoVersion string // go version used in module (e.g. "go1.22.0")
+	Path      string       // module path
+	Version   string       // module version ("" if unknown, such as for workspace modules)
+	Replace   *Module      // replaced by this module
+	Time      *time.Time   // time version was created
+	Main      bool         // is this the main module?
+	Indirect  bool         // is this module only an indirect dependency of main module?
+	Dir       string       // directory holding files for this module, if any
+	GoMod     string       // path to go.mod file used when loading this module, if any
+	GoVersion string       // go version used in module (e.g. "go1.22.0")
+	Error     *ModuleError // error loading module
+}
+
+// ModuleError holds errors loading a module.
+type ModuleError struct {
+	Err string // the error itself
 }

--- a/go/analysis/checker/checker.go
+++ b/go/analysis/checker/checker.go
@@ -311,9 +311,7 @@ func (act *Action) execOnce() {
 
 	module := &analysis.Module{} // possibly empty (non nil) in go/analysis drivers.
 	if mod := act.Package.Module; mod != nil {
-		module.Path = mod.Path
-		module.Version = mod.Version
-		module.GoVersion = mod.GoVersion
+		module = analysisModuleFromPackagesModule(mod)
 	}
 
 	// Run the analysis.
@@ -626,4 +624,30 @@ func forEach(roots []*Action, f func(*Action) error) error {
 		return nil
 	}
 	return visitAll(roots)
+}
+
+func analysisModuleFromPackagesModule(mod *packages.Module) *analysis.Module {
+	if mod == nil {
+		return nil
+	}
+
+	var modErr *analysis.ModuleError
+	if mod.Error != nil {
+		modErr = &analysis.ModuleError{
+			Err: mod.Error.Err,
+		}
+	}
+
+	return &analysis.Module{
+		Path:      mod.Path,
+		Version:   mod.Version,
+		Replace:   analysisModuleFromPackagesModule(mod.Replace),
+		Time:      mod.Time,
+		Main:      mod.Main,
+		Indirect:  mod.Indirect,
+		Dir:       mod.Dir,
+		GoMod:     mod.GoMod,
+		GoVersion: mod.GoVersion,
+		Error:     modErr,
+	}
 }

--- a/go/analysis/checker/checker_test.go
+++ b/go/analysis/checker/checker_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package checker_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/checker"
+	"golang.org/x/tools/go/packages"
+	"golang.org/x/tools/txtar"
+)
+
+// TestPassModule checks that an analyzer observes the correct Pass.Module
+// fields (GoMod, Dir, Path, Main, GoVersion) when run on a module.
+func TestPassModule(t *testing.T) {
+	const src = `
+-- go.mod --
+module example.com/hello
+go 1.13
+
+-- hello.go --
+package hello
+`
+	dir, err := os.MkdirTemp("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	fs, err := txtar.FS(txtar.Parse([]byte(src)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.CopyFS(dir, fs); err != nil {
+		t.Fatal(err)
+	}
+
+	// Capture the Module seen by the analyzer.
+	var got *analysis.Module
+	testAnalyzer := &analysis.Analyzer{
+		Name: "testmodule",
+		Doc:  "Captures Pass.Module for testing.",
+		Run: func(pass *analysis.Pass) (any, error) {
+			got = pass.Module
+			return nil, nil
+		},
+	}
+
+	cfg := &packages.Config{
+		Mode: packages.LoadAllSyntax | packages.NeedModule,
+		Dir:  dir,
+	}
+	pkgs, err := packages.Load(cfg, "example.com/hello")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := checker.Analyze([]*analysis.Analyzer{testAnalyzer}, pkgs, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	if got == nil {
+		t.Fatal("Pass.Module is nil")
+	}
+	if got.Path != "example.com/hello" {
+		t.Errorf("Pass.Module.Path = %q, want %q", got.Path, "example.com/hello")
+	}
+	if !got.Main {
+		t.Errorf("Pass.Module.Main = false, want true")
+	}
+	wantGoMod := filepath.Join(dir, "go.mod")
+	if got.GoMod != wantGoMod {
+		t.Errorf("Pass.Module.GoMod = %q, want %q", got.GoMod, wantGoMod)
+	}
+	if got.Dir != dir {
+		t.Errorf("Pass.Module.Dir = %q, want %q", got.Dir, dir)
+	}
+	if got.GoVersion != "1.13" {
+		t.Errorf("Pass.Module.GoVersion = %q, want %q", got.GoVersion, "1.13")
+	}
+}


### PR DESCRIPTION
go.mod (w/ go.sum in the same dir) is needed by
https://github.com/AkihiroSuda/gosocialcheck
to check the reputation of dependencies.

Updates golang/go#73878