### PR TITLE
Updated neovim-imports to reflect breaking change in neovim 0.11

### DIFF
--- a/gopls/doc/vim.md
+++ b/gopls/doc/vim.md
@@ -174,11 +174,12 @@ Use the following configuration to have your imports organized on save using
 the logic of `goimports` and your code formatted.
 
 ```lua
-autocmd("BufWritePre", {
+vim.api.nvim_create_autocmd("BufWritePre", {
   pattern = "*.go",
   callback = function()
-    local params = vim.lsp.util.make_range_params()
-    params.context = {only = {"source.organizeImports"}}
+    local params = vim.lsp.util.make_range_params(0, "utf-8")
+    params.context = { only = { "source.organizeImports" } }
+
     -- buf_request_sync defaults to a 1000ms timeout. Depending on your
     -- machine and codebase, you may want longer. Add an additional
     -- argument after params if you find that you have to write the file
@@ -193,7 +194,7 @@ autocmd("BufWritePre", {
         end
       end
     end
-    vim.lsp.buf.format({async = false})
+    vim.lsp.buf.format({ async = false })
   end
 })
 ```


### PR DESCRIPTION
https://neovim.io/doc/user/news-0.11.html#_lsp

`make_range_params` now requires the `position_encoding` parameter. If you don't specify it in neovim 0.11, it throws an error. I haven't tested this on <0.11, but I'm pretty sure that the `position_encoding` parameter was always there, just optional so it should work on older versions.

