### PR TITLE
x/tools/gopls/internal/analysis/modernize/stringscutprefix add space

### DIFF
--- a/gopls/internal/analysis/modernize/stringscutprefix.go
+++ b/gopls/internal/analysis/modernize/stringscutprefix.go
@@ -115,7 +115,7 @@ func stringscutprefix(pass *analysis.Pass) {
 									{
 										Pos:     call.Fun.Pos(),
 										End:     call.Fun.Pos(),
-										NewText: fmt.Appendf(nil, "%s, %s :=", after, okVarName),
+										NewText: fmt.Appendf(nil, "%s, %s := ", after, okVarName),
 									},
 									{
 										Pos:     call.Fun.Pos(),


### PR DESCRIPTION
Added a space so the fix does match the pattern shown in the description / comments.

Without this change the fix of the code would be edited to this:
`after, ok :=strings.CutPrefix...`

After the change it should looks like this:
`after, ok := strings.CutPrefix...`

Will add the space anyway, but it would be nice to have the space out of the box.