### PR TITLE
gopls: fix extracted function shouldReturn boolean return value position

### DIFF
--- a/gopls/internal/golang/extract.go
+++ b/gopls/internal/golang/extract.go
@@ -1903,9 +1903,11 @@ func adjustReturnStatements(returnTypes []*ast.Field, seenVars map[types.Object]
 	// extracted function. We set the bool to 'true' because, if these return statements
 	// execute, the extracted function terminates early, and the enclosing function must
 	// return as well.
+	var shouldReturnCond []ast.Expr
 	if !isErrHandlingReturnsCase {
-		zeroVals = append(zeroVals, ast.NewIdent("true"))
+		shouldReturnCond = append(shouldReturnCond, ast.NewIdent("true"))
 	}
+
 	ast.Inspect(extractedBlock, func(n ast.Node) bool {
 		if n == nil {
 			return false
@@ -1915,7 +1917,7 @@ func adjustReturnStatements(returnTypes []*ast.Field, seenVars map[types.Object]
 			return false
 		}
 		if n, ok := n.(*ast.ReturnStmt); ok {
-			n.Results = slices.Concat(zeroVals, n.Results)
+			n.Results = slices.Concat(zeroVals, n.Results, shouldReturnCond)
 			return false
 		}
 		return true

--- a/gopls/internal/test/marker/testdata/codeaction/extract_control.txt
+++ b/gopls/internal/test/marker/testdata/codeaction/extract_control.txt
@@ -221,14 +221,14 @@ func FuncTwoReturns(x int) int {
 +
 +func newFunction(x int) (int, bool, int) {
 +	if x < 10 { //@ loc(twoReturns, re`(?s)if.x.*return.1....`)
-+		return true, 0, 0
++		return 0, true, 0
 +	}
 +	test := x - 4
 +	if test > 2 {
 +		return 0, false, 1
 +	}
 +	if test == 10 {
-+		return true, 1, 0
++		return 1, true, 0
 +	}
 +	return 0, false, 0
 +}

--- a/gopls/internal/test/marker/testdata/codeaction/functionextraction.txt
+++ b/gopls/internal/test/marker/testdata/codeaction/functionextraction.txt
@@ -129,10 +129,10 @@ func _() (int, string, error) {
 func newFunction(y string, x int) (string, int, string, error, bool) {
 	z := "bye" //@codeaction("z", "refactor.extract.function", end=rcEnd, result=rc)
 	if y == z {
-		return "", true, x, y, fmt.Errorf("same")
+		return "", x, y, fmt.Errorf("same"), true
 	} else if false {
 		z = "hi"
-		return "", true, x, z, nil
+		return "", x, z, nil, true
 	}
 	return z, 0, "", nil, false
 }
@@ -274,7 +274,7 @@ func _() string {
 func newFunction(x int) (string, bool) {
 	if x == 0 { //@codeaction("if", "refactor.extract.function", end=riEnd, result=ri)
 		x = 3
-		return true, "a"
+		return "a", true
 	}
 	return "", false
 }

--- a/gopls/internal/test/marker/testdata/codeaction/functionextraction_issue66289.txt
+++ b/gopls/internal/test/marker/testdata/codeaction/functionextraction_issue66289.txt
@@ -88,10 +88,10 @@ func G() (x, y int) {
 func newFunction() (int, int, int, bool) {
 	v := rand.Int() //@codeaction("v", "refactor.extract.function", end=endG, result=G)
 	if v < 0 {
-		return 0, true, 1, 2
+		return 0, 1, 2, true
 	}
 	if v > 0 {
-		return 0, true, 3, 4
+		return 0, 3, 4, true
 	}
 	return v, 0, 0, false
 }


### PR DESCRIPTION
In the extracted function, the shouldReturn boolean return value should be 
put after the existing return values.

Fixes golang/go#75527