### PR TITLE
gopls: add doc link for quick fix implement method

### DIFF
--- a/gopls/doc/features/diagnostics.md
+++ b/gopls/doc/features/diagnostics.md
@@ -182,7 +182,7 @@ Gopls will offer a quick fix to declare this method:
 
 ```go
 
-// Error implements error.Error.
+// Error implements [error.Error].
 func (NegativeErr) Error() string {
 	panic("unimplemented")
 }

--- a/gopls/internal/cmd/integration_test.go
+++ b/gopls/internal/cmd/integration_test.go
@@ -1055,7 +1055,7 @@ var _ io.Reader = C{}
 
 type C struct{}
 
-// Read implements io.Reader.
+// Read implements [io.Reader].
 func (c C) Read(p []byte) (n int, err error) {
 	panic("unimplemented")
 }

--- a/gopls/internal/golang/stubmethods/stubmethods.go
+++ b/gopls/internal/golang/stubmethods/stubmethods.go
@@ -188,7 +188,7 @@ func (si *IfaceStubInfo) Emit(out *bytes.Buffer, qual types.Qualifier) error {
 			mrn = ""
 		}
 
-		fmt.Fprintf(out, `// %s implements %s.
+		fmt.Fprintf(out, `// %s implements [%s].
 %sfunc (%s%s%s%s) %s%s {
 	panic("unimplemented")
 }

--- a/gopls/internal/test/marker/testdata/quickfix/issue65024.txt
+++ b/gopls/internal/test/marker/testdata/quickfix/issue65024.txt
@@ -28,7 +28,7 @@ var _ a.I = &B{} //@ quickfix("&B{}", re"does not implement", out)
 
 -- @out/a/v2/b/b.go --
 @@ -7 +7,5 @@
-+// F implements a.I.
++// F implements [a.I].
 +func (b *B) F() a.T {
 +	panic("unimplemented")
 +}
@@ -69,7 +69,7 @@ type I = a.I
 +import a "example.com/a-a/v2"
 +
 @@ -7 +9,5 @@
-+// F implements a.I.
++// F implements [a.I].
 +func (b *B) F() a.T {
 +	panic("unimplemented")
 +}

--- a/gopls/internal/test/marker/testdata/quickfix/stub.txt
+++ b/gopls/internal/test/marker/testdata/quickfix/stub.txt
@@ -33,7 +33,7 @@ type readerFrom struct{}
 -- @readerFrom/add_selector.go --
 @@ -13 +13,5 @@
 +
-+// ReadFrom implements io.ReaderFrom.
++// ReadFrom implements [io.ReaderFrom].
 +func (*readerFrom) ReadFrom(r io.Reader) (n int64, err error) {
 +	panic("unimplemented")
 +}
@@ -52,7 +52,7 @@ type byteWriter struct{}
 -- @assign/assign.go --
 @@ -12 +12,5 @@
 +
-+// WriteByte implements io.ByteWriter.
++// WriteByte implements [io.ByteWriter].
 +func (b *byteWriter) WriteByte(c byte) error {
 +	panic("unimplemented")
 +}
@@ -72,7 +72,7 @@ type multiByteWriter struct{}
 -- @assign_multivars/assign_multivars.go --
 @@ -13 +13,5 @@
 +
-+// WriteByte implements io.ByteWriter.
++// WriteByte implements [io.ByteWriter].
 +func (m *multiByteWriter) WriteByte(c byte) error {
 +	panic("unimplemented")
 +}
@@ -93,7 +93,7 @@ type callExpr struct{}
 -- @call_expr/call_expr.go --
 @@ -14 +14,5 @@
 +
-+// Error implements error.
++// Error implements [error].
 +func (c *callExpr) Error() string {
 +	panic("unimplemented")
 +}
@@ -115,22 +115,22 @@ type embeddedInterface interface {
 }
 -- @embedded/embedded.go --
 @@ -12 +12,20 @@
-+// Len implements embeddedInterface.
++// Len implements [embeddedInterface].
 +func (e *embeddedConcrete) Len() int {
 +	panic("unimplemented")
 +}
 +
-+// Less implements embeddedInterface.
++// Less implements [embeddedInterface].
 +func (e *embeddedConcrete) Less(i int, j int) bool {
 +	panic("unimplemented")
 +}
 +
-+// Read implements embeddedInterface.
++// Read implements [embeddedInterface].
 +func (e *embeddedConcrete) Read(p []byte) (n int, err error) {
 +	panic("unimplemented")
 +}
 +
-+// Swap implements embeddedInterface.
++// Swap implements [embeddedInterface].
 +func (e *embeddedConcrete) Swap(i int, j int) {
 +	panic("unimplemented")
 +}
@@ -147,7 +147,7 @@ type customErr struct{}
 -- @err/err.go --
 @@ -9 +9,5 @@
 +
-+// Error implements error.
++// Error implements [error].
 +func (c *customErr) Error() string {
 +	panic("unimplemented")
 +}
@@ -166,7 +166,7 @@ type closer struct{}
 -- @function_return/function_return.go --
 @@ -12 +12,5 @@
 +
-+// Close implements io.Closer.
++// Close implements [io.Closer].
 +func (c closer) Close() error {
 +	panic("unimplemented")
 +}
@@ -185,7 +185,7 @@ type closer2 struct{}
 -- @successive/successive_function_return.go --
 @@ -12 +12,5 @@
 +
-+// Close implements io.Closer.
++// Close implements [io.Closer].
 +func (c closer2) Close() error {
 +	panic("unimplemented")
 +}
@@ -205,7 +205,7 @@ type genReader[T, Y any] struct {
 -- @generic_receiver/generic_receiver.go --
 @@ -13 +13,5 @@
 +
-+// ReadFrom implements io.ReaderFrom.
++// ReadFrom implements [io.ReaderFrom].
 +func (g *genReader[T, Y]) ReadFrom(r io.Reader) (n int64, err error) {
 +	panic("unimplemented")
 +}
@@ -231,7 +231,7 @@ type ignoredResetter struct{}
 -- @ignored_imports/ignored_imports.go --
 @@ -19 +19,5 @@
 +
-+// Reset implements zlib.Resetter.
++// Reset implements [zlib.Resetter].
 +func (i *ignoredResetter) Reset(r Reader, dict []byte) error {
 +	panic("unimplemented")
 +}
@@ -245,7 +245,7 @@ type C int
 var _ I = C(0) //@quickfix("C", re"does not implement", issue2606)
 -- @issue2606/issue2606.go --
 @@ -7 +7,5 @@
-+// Error implements I.
++// Error implements [I].
 +func (c C) Error() string {
 +	panic("unimplemented")
 +}
@@ -265,7 +265,7 @@ type multiVar struct{}
 -- @multi_var/multi_var.go --
 @@ -12 +12,5 @@
 +
-+// Read implements io.Reader.
++// Read implements [io.Reader].
 +func (m *multiVar) Read(p []byte) (n int, err error) {
 +	panic("unimplemented")
 +}
@@ -282,7 +282,7 @@ type pointerImpl struct{}
 -- @pointer/pointer.go --
 @@ -10 +10,5 @@
 +
-+// ReadFrom implements io.ReaderFrom.
++// ReadFrom implements [io.ReaderFrom].
 +func (p *pointerImpl) ReadFrom(r io.Reader) (n int64, err error) {
 +	panic("unimplemented")
 +}
@@ -301,7 +301,7 @@ type myIO struct{}
 -- @renamed_import/renamed_import.go --
 @@ -12 +12,5 @@
 +
-+// Reset implements zlib.Resetter.
++// Reset implements [zlib.Resetter].
 +func (m *myIO) Reset(r myio.Reader, dict []byte) error {
 +	panic("unimplemented")
 +}
@@ -325,7 +325,7 @@ type otherInterfaceImpl struct{}
 +	"context"
 @@ -14 +16,5 @@
 +
-+// Get implements other.Interface.
++// Get implements [other.Interface].
 +func (o *otherInterfaceImpl) Get(context.Context) *bytes.Buffer {
 +	panic("unimplemented")
 +}
@@ -342,7 +342,7 @@ type writer struct{}
 -- @stdlib/stdlib.go --
 @@ -10 +10,5 @@
 +
-+// Write implements io.Writer.
++// Write implements [io.Writer].
 +func (w writer) Write(p []byte) (n int, err error) {
 +	panic("unimplemented")
 +}

--- a/gopls/internal/test/marker/testdata/quickfix/stubmethods/basic.txt
+++ b/gopls/internal/test/marker/testdata/quickfix/stubmethods/basic.txt
@@ -23,7 +23,7 @@ type C int
 var _ error = C(0) //@quickfix(re"C.0.", re"missing method Error", stub)
 -- @stub/a/a.go --
 @@ -5 +5,5 @@
-+// Error implements error.
++// Error implements [error].
 +func (c C) Error() string {
 +	panic("unimplemented")
 +}

--- a/gopls/internal/test/marker/testdata/quickfix/stubmethods/basic_resolve.txt
+++ b/gopls/internal/test/marker/testdata/quickfix/stubmethods/basic_resolve.txt
@@ -13,7 +13,7 @@ type C int
 var _ error = C(0) //@quickfix(re"C.0.", re"missing method Error", stub)
 -- @stub/a/a.go --
 @@ -5 +5,5 @@
-+// Error implements error.
++// Error implements [error].
 +func (c C) Error() string {
 +	panic("unimplemented")
 +}

--- a/gopls/internal/test/marker/testdata/quickfix/stubmethods/issue61693.txt
+++ b/gopls/internal/test/marker/testdata/quickfix/stubmethods/issue61693.txt
@@ -19,7 +19,7 @@ func _() {
 }
 -- @stub/main.go --
 @@ -5 +5,5 @@
-+// Error implements error.
++// Error implements [error].
 +func (c C) Error() string {
 +	panic("unimplemented")
 +}

--- a/gopls/internal/test/marker/testdata/quickfix/stubmethods/issue61830.txt
+++ b/gopls/internal/test/marker/testdata/quickfix/stubmethods/issue61830.txt
@@ -17,7 +17,7 @@ type A struct{}
 var _ I = &A{} //@quickfix(re"&A..", re"missing method M", stub)
 -- @stub/p.go --
 @@ -13 +13,5 @@
-+// M implements I.
++// M implements [I].
 +func (a *A) M(io.Reader, B) {
 +	panic("unimplemented")
 +}

--- a/gopls/internal/test/marker/testdata/quickfix/stubmethods/issue64078.txt
+++ b/gopls/internal/test/marker/testdata/quickfix/stubmethods/issue64078.txt
@@ -19,17 +19,17 @@ type I interface {
 var _ I = &A{} //@quickfix(re"&A..", re"missing method M", stub)
 -- @stub/p.go --
 @@ -5 +5,15 @@
-+// M2 implements I.
++// M2 implements [I].
 +func (*A) M2(aa string) {
 +	panic("unimplemented")
 +}
 +
-+// M3 implements I.
++// M3 implements [I].
 +func (aa *A) M3(bb string) {
 +	panic("unimplemented")
 +}
 +
-+// M4 implements I.
++// M4 implements [I].
 +func (*A) M4() (aa string) {
 +	panic("unimplemented")
 +}

--- a/gopls/internal/test/marker/testdata/quickfix/stubmethods/issue64114.txt
+++ b/gopls/internal/test/marker/testdata/quickfix/stubmethods/issue64114.txt
@@ -9,7 +9,7 @@ var _ WriteTest = (*WriteStruct)(nil) //@quickfix("(", re"does not implement", i
 
 type WriterTwoStruct struct{}
 
-// Write implements io.ReadWriter.
+// Write implements [io.ReadWriter].
 func (t *WriterTwoStruct) RRRR(str string) error {
 	panic("unimplemented")
 }
@@ -25,13 +25,13 @@ type WriteStruct struct {
 -- @issue64114/issue64114.go --
 @@ -22 +22,11 @@
 +
-+// RRRR implements WriteTest.
++// RRRR implements [WriteTest].
 +// Subtle: this method shadows the method (WriterTwoStruct).RRRR of WriteStruct.WriterTwoStruct.
 +func (w *WriteStruct) RRRR() {
 +	panic("unimplemented")
 +}
 +
-+// WWWW implements WriteTest.
++// WWWW implements [WriteTest].
 +func (w *WriteStruct) WWWW() {
 +	panic("unimplemented")
 +}


### PR DESCRIPTION
Fixes golang/go#75487.

Adds '[]' around interface name on quick fix implement method. 