### PR TITLE
txtar: handle crlf line endings

### DIFF
--- a/txtar/archive.go
+++ b/txtar/archive.go
@@ -120,6 +120,9 @@ func isMarker(data []byte) (name string, after []byte) {
 	}
 	if i := bytes.IndexByte(data, '\n'); i >= 0 {
 		data, after = data[:i], data[i+1:]
+		if data[i-1] == '\r' { // handle \r\n line ending
+			data = data[:i-1]
+		}
 	}
 	if !(bytes.HasSuffix(data, markerEnd) && len(data) >= len(marker)+len(markerEnd)) {
 		return "", nil

--- a/txtar/archive_test.go
+++ b/txtar/archive_test.go
@@ -44,6 +44,14 @@ some content
 				},
 			},
 		},
+		{
+			name: "crlf",
+			text: "comment\r\n-- file --\r\ndata\r\n",
+			parsed: &Archive{
+				Comment: []byte("comment\r\n"),
+				Files:   []File{{"file", []byte("data\r\n")}},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Function isMarker detects a file marker line by checking if the data before
the first '\n' has a marker prefix and suffix.
In the case of CRLF line endings, the data before the first '\n' ends with
'\r', so the suffix check fails.

Here, '\r' is trimmed before checking the suffix.

Fixes golang/go#59264.