### PR TITLE
gopls/internal/analysis/modernize: fix a typo in deprecation warning path

### DIFF
--- a/gopls/internal/analysis/modernize/cmd/modernize/main.go
+++ b/gopls/internal/analysis/modernize/cmd/modernize/main.go
@@ -8,7 +8,7 @@
 // See [golang.org/x/tools/go/analysis/passes/modernize] for details.
 //
 // Deprecated: use 'go run
-// golang.org/x/tools/go/passes/modernize/cmd/modernize' instead. In
+// golang.org/x/tools/go/analysis/passes/modernize/cmd/modernize' instead. In
 // due course the modernizer suite will be accessed through "go fix";
 // see https://go.dev/issue/71859.
 package main


### PR DESCRIPTION
The deprecated warning in gopls/internal/analysis/modernize/cmd/modernize/main.go directs users to `go run` a path that is missing the "analysis" directory, leading to a confusing error.

Not addressed — no version is specified in the `go run` example command, so the user has to know to add `@latest` or specify a version.

```
$ go run golang.org/x/tools/go/analysis/passes/modernize/cmd/modernize
no required module provides package golang.org/x/tools/go/analysis/passes/modernize/cmd/modernize: go.mod file not found in current directory or any parent directory; see 'go help modules'
```
```
$ go run golang.org/x/tools/go/passes/modernize/cmd/modernize@latest
go: golang.org/x/tools/go/passes/modernize/cmd/modernize@latest: module golang.org/x/tools@latest found (v0.38.0), but does not contain package golang.org/x/tools/go/passes/modernize/cmd/modernize
```
```
$ go run golang.org/x/tools/go/analysis/passes/modernize/cmd/modernize@latest
modernize is a tool for static analysis of Go programs.

Usage: modernize [-flag] [package]

Run 'modernize help' for more detail,
 or 'modernize help name' for details and flags of a specific analyzer.
exit status 1
```