### PR TITLE
go/analysis/unitchecker: add Config.Module

### DIFF
--- a/go/analysis/unitchecker/separate_test.go
+++ b/go/analysis/unitchecker/separate_test.go
@@ -20,6 +20,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/printf"
 	"golang.org/x/tools/go/analysis/unitchecker"
 	"golang.org/x/tools/go/gcexportdata"
@@ -170,6 +171,7 @@ func MyPrintf(format string, args ...any) {
 			}
 			cfg.ModulePath = pkg.Module.Path
 			cfg.ModuleVersion = pkg.Module.Version
+			cfg.Module = analysisModuleFromPackagesModule(pkg.Module)
 		}
 
 		// Write the JSON configuration message to a file.
@@ -293,6 +295,28 @@ func exportTypes(cfg *unitchecker.Config, fset *token.FileSet, pkg *types.Packag
 }
 
 // -- helpers --
+
+func analysisModuleFromPackagesModule(mod *packages.Module) *analysis.Module {
+	if mod == nil {
+		return nil
+	}
+	var modErr *analysis.ModuleError
+	if mod.Error != nil {
+		modErr = &analysis.ModuleError{Err: mod.Error.Err}
+	}
+	return &analysis.Module{
+		Path:      mod.Path,
+		Version:   mod.Version,
+		Replace:   analysisModuleFromPackagesModule(mod.Replace),
+		Time:      mod.Time,
+		Main:      mod.Main,
+		Indirect:  mod.Indirect,
+		Dir:       mod.Dir,
+		GoMod:     mod.GoMod,
+		GoVersion: mod.GoVersion,
+		Error:     modErr,
+	}
+}
 
 type importerFunc func(path string) (*types.Package, error)
 

--- a/go/analysis/unitchecker/unitchecker.go
+++ b/go/analysis/unitchecker/unitchecker.go
@@ -66,8 +66,9 @@ type Config struct {
 	GoFiles                   []string
 	NonGoFiles                []string
 	IgnoredFiles              []string
-	ModulePath                string            // module path
-	ModuleVersion             string            // module version
+	ModulePath                string            // Deprecated: redundant w.r.t. Module.Path in go1.27; remove after go1.28.
+	ModuleVersion             string            // Deprecated: redundant w.r.t. Module.Version in go1.27; remove after go1.28.
+	Module                    *analysis.Module  // module information, if any
 	ImportMap                 map[string]string // maps import path to package path
 	PackageFile               map[string]string // maps package path to file of type information
 	Standard                  map[string]bool   // package belongs to standard library
@@ -446,10 +447,14 @@ func run(fset *token.FileSet, cfg *Config, analyzers []*analysis.Analyzer) ([]re
 				factFilter[reflect.TypeOf(f)] = true
 			}
 
-			module := &analysis.Module{
-				Path:      cfg.ModulePath,
-				Version:   cfg.ModuleVersion,
-				GoVersion: cfg.GoVersion,
+			module := cfg.Module
+			// cmd/go vet prior to go1.27 did not populate cfg.Module. Do our best.
+			if module == nil && cfg.ModulePath != "" {
+				module = &analysis.Module{
+					Path:      cfg.ModulePath,
+					Version:   cfg.ModuleVersion,
+					GoVersion: cfg.GoVersion,
+				}
 			}
 
 			pass := &analysis.Pass{


### PR DESCRIPTION
Follow-up to https://go-review.googlesource.com/c/tools/+/676455/comments/34707247_5e471a91

> The next step is to make the corresponding change to unitchecker, used by go vet/fix.
> You'll need to add fields to x/tools/go/analysis/unitchecker.Config first,
> then to cmd/go/internal/work.vetConfig to populate the data.

Updates golang/go#73878