### PR TITLE
gopls/internal/template: fix panic in completion when cursor is between opening braces

### DIFF
--- a/gopls/internal/template/completion.go
+++ b/gopls/internal/template/completion.go
@@ -127,6 +127,9 @@ func (c *completer) complete() (*protocol.CompletionList, error) {
 	if err != nil {
 		return ans, err
 	}
+	if c.offset > start {
+		return ans, nil
+	}
 	sofar := c.p.buf[c.offset:start]
 	if len(sofar) == 0 || sofar[len(sofar)-1] == ' ' || sofar[len(sofar)-1] == '\t' {
 		return ans, nil

--- a/gopls/internal/template/completion_test.go
+++ b/gopls/internal/template/completion_test.go
@@ -73,6 +73,45 @@ func TestParsed(t *testing.T) {
 	}
 }
 
+// TestCompleteBoundsCheck tests that complete() does not panic
+// when c.offset > start (e.g. cursor between the two '{' characters).
+// This is a regression test for a DoS vulnerability where a crafted
+// cursor position within "{{" caused a slice bounds out of range panic.
+func TestCompleteBoundsCheck(t *testing.T) {
+	buf := []byte("hello {{ }}")
+	p := parseBuffer("", buf)
+	if p.parseErr != nil {
+		t.Logf("parseBuffer (expected): %v", p.parseErr)
+	}
+	// Simulate cursor at position 7 (between '{' and '{').
+	// This creates a situation where c.offset (= start + len("{{")) > cursorPos.
+	pos, err := p.mapper.OffsetPosition(7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Manually construct a completer that triggers the problematic case:
+	// set offset to 8 (simulating tk.start=6, offset = 6 + len("{{") = 8)
+	// with cursor position 7 (start < c.offset).
+	c := &completer{
+		p:      p,
+		pos:    pos,
+		offset: 8,
+		ctx:    protocol.CompletionContext{TriggerKind: protocol.Invoked},
+		syms:   make(map[string]symbol),
+	}
+	// This must not panic.
+	ans, err := c.complete()
+	if err != nil {
+		t.Fatalf("complete returned error: %v", err)
+	}
+	if ans == nil {
+		t.Fatal("complete returned nil")
+	}
+	if len(ans.Items) != 0 {
+		t.Errorf("expected no completions, got %d", len(ans.Items))
+	}
+}
+
 func testCompleter(t *testing.T, tx tparse) *completer {
 	// seen chars up to ^
 	offset := strings.Index(tx.marked, "^")


### PR DESCRIPTION
### Summary

Fix a Denial of Service (DoS) vulnerability in `gopls` where the language server crashes with `panic: slice bounds out of range [8:7]` when code completion is requested at a cursor position between the two `{` characters of a template action delimiter `{{`.

### Root Cause

In `completer.complete()`, the expression `c.p.buf[c.offset:start]` panics when `c.offset > start`. This occurs when:
- A `.tmpl` file contains a template action like `hello {{ }}`
- The cursor is placed between the first `{` and second `{` (e.g., at byte offset 7)
- `c.offset` is computed as `tk.Start + len("{{")` = 8
- `start` (cursor position) = 7
- Resulting slice `buf[8:7]` triggers `panic: runtime error: slice bounds out of range [8:7]`

Since there is no recovery mechanism, this crashes the entire `gopls` process, degrading the user's IDE workspace.

### Fix

Added a bounds check before the slice operation in `completer.complete()`:
```go
if c.offset > start {
    return ans, nil
}
```

This returns an empty completion list when the cursor is inside the delimiter characters, which is the correct behavior — there is no meaningful text to complete at that position.

### Testing

- Added `TestCompleteBoundsCheck` regression test that directly constructs the problematic state (offset=8, cursor=7) and verifies `complete()` returns gracefully without panicking
- All existing tests continue to pass (21 `TestParsed` subtests + `TestSymbols` + `TestWordAt` + `TestQuotes`)

### Reproduction

1. Open a workspace with `gopls` and configure `templateExtensions: ["tmpl"]`
2. Create `hi.tmpl` with content: `hello {{ }}`
3. Place cursor between the two `{` characters (byte offset 7)
4. Trigger code completion → `gopls` crashes

### Impact

Denial of Service. An attacker can craft a malicious Go project containing a `.tmpl` file that crashes `gopls` when the victim opens it and the cursor enters the trigger position.