### PR TITLE
gopls/internal/cache: set Pass.Module

### DIFF
--- a/gopls/internal/cache/analysis.go
+++ b/gopls/internal/cache/analysis.go
@@ -32,6 +32,7 @@ import (
 
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/packages"
 	"golang.org/x/tools/gopls/internal/cache/metadata"
 	"golang.org/x/tools/gopls/internal/file"
 	"golang.org/x/tools/gopls/internal/filecache"
@@ -1012,6 +1013,7 @@ func (act *action) exec(ctx context.Context) (any, *actionSummary, error) {
 		TypesInfo:    apkg.pkg.TypesInfo(),
 		TypesSizes:   apkg.pkg.TypesSizes(),
 		TypeErrors:   apkg.typeErrors,
+		Module:       analysisModuleFromPackagesModule(apkg.pkg.metadata.Module),
 		ResultOf:     inputs,
 		Report: func(d analysis.Diagnostic) {
 			// Assert that SuggestedFixes are well formed.
@@ -1430,4 +1432,31 @@ func stableName(a *analysis.Analyzer) string {
 	// it is unique, but making them always differ helps avoid
 	// name/stablename confusion.
 	return fmt.Sprintf("%s(%s:%d)", a.Name, filepath.Base(file), line)
+}
+
+// analysisModuleFromPackagesModule converts a packages.Module to an analysis.Module.
+func analysisModuleFromPackagesModule(mod *packages.Module) *analysis.Module {
+	if mod == nil {
+		return nil
+	}
+
+	var modErr *analysis.ModuleError
+	if mod.Error != nil {
+		modErr = &analysis.ModuleError{
+			Err: mod.Error.Err,
+		}
+	}
+
+	return &analysis.Module{
+		Path:      mod.Path,
+		Version:   mod.Version,
+		Replace:   analysisModuleFromPackagesModule(mod.Replace),
+		Time:      mod.Time,
+		Main:      mod.Main,
+		Indirect:  mod.Indirect,
+		Dir:       mod.Dir,
+		GoMod:     mod.GoMod,
+		GoVersion: mod.GoVersion,
+		Error:     modErr,
+	}
 }


### PR DESCRIPTION
Follow-up to https://github.com/golang/go/issues/73878#issuecomment-4248724973

> I think the necessary gopls changes would go in
> gopls/internal/cache/analysis.go, where the Pass is constructed,
> and should copy fields from apkg.pkg.Metadata().Module to the Pass,
> similar to your other changes.  (I don't think any changes are needed to
> analysisNode.cacheKey.) Thanks.

Updates golang/go#73878