### PR TITLE
gopls/internal/analysis: add appendlen analyzer

### DIFF
--- a/gopls/internal/analysis/appendlen/appendlen.go
+++ b/gopls/internal/analysis/appendlen/appendlen.go
@@ -1,0 +1,270 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package appendlen
+
+import (
+	_ "embed"
+	"fmt"
+	"go/ast"
+	"go/token"
+	"go/types"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/internal/analysis/analyzerutil"
+	astutilinternal "golang.org/x/tools/internal/astutil"
+)
+
+//go:embed doc.go
+var doc string
+
+var Analyzer = &analysis.Analyzer{
+	Name: "appendlen",
+	Doc:  analyzerutil.MustExtractDoc(doc, "appendlen"),
+	Run:  run,
+	URL:  "https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/appendlen",
+}
+
+func run(pass *analysis.Pass) (any, error) {
+	for _, file := range pass.Files {
+		for _, decl := range file.Decls {
+			switch decl := decl.(type) {
+			case *ast.FuncDecl:
+				if decl.Body != nil {
+					scanStmtList(pass, decl.Body.List)
+				}
+			}
+		}
+	}
+	return nil, nil
+}
+
+func scanStmtList(pass *analysis.Pass, stmts []ast.Stmt) {
+	for i, stmt := range stmts {
+		if i+1 < len(stmts) {
+			cand := candidateFromStmt(pass, stmt)
+			if cand != nil {
+				if body, ok := immediateLoopBody(stmts[i+1], cand.rangeExpr); ok &&
+					hasAppendToVar(pass, body, cand.obj) {
+					pass.Report(analysis.Diagnostic{
+						Pos:     cand.makeCall.Pos(),
+						End:     cand.makeCall.End(),
+						Message: fmt.Sprintf("slice created with len(%s) is appended to while iterating over the same value", types.ExprString(cand.rangeExpr)),
+						SuggestedFixes: []analysis.SuggestedFix{{
+							Message: "Use zero length with preallocated capacity",
+							TextEdits: []analysis.TextEdit{{
+								Pos:     cand.lenCall.Pos(),
+								End:     cand.lenCall.Pos(),
+								NewText: []byte("0, "),
+							}},
+						}},
+					})
+				}
+			}
+		}
+		scanNestedStmt(pass, stmt)
+	}
+}
+
+func immediateLoopBody(stmt ast.Stmt, expr ast.Expr) (*ast.BlockStmt, bool) {
+	switch stmt := stmt.(type) {
+	case *ast.RangeStmt:
+		if astutilinternal.EqualSyntax(expr, stmt.X) {
+			return stmt.Body, true
+		}
+	case *ast.ForStmt:
+		if iteratesUsingIndexLoop(stmt, expr) {
+			return stmt.Body, true
+		}
+	}
+	return nil, false
+}
+
+func iteratesUsingIndexLoop(stmt *ast.ForStmt, expr ast.Expr) bool {
+	if stmt.Init == nil || stmt.Cond == nil || stmt.Post == nil {
+		return false
+	}
+	init, ok := stmt.Init.(*ast.AssignStmt)
+	if !ok || len(init.Lhs) != 1 || len(init.Rhs) != 1 {
+		return false
+	}
+	idx, ok := init.Lhs[0].(*ast.Ident)
+	if !ok {
+		return false
+	}
+	zero, ok := init.Rhs[0].(*ast.BasicLit)
+	if !ok || zero.Kind != token.INT || zero.Value != "0" {
+		return false
+	}
+	cond, ok := stmt.Cond.(*ast.BinaryExpr)
+	if !ok || cond.Op != token.LSS {
+		return false
+	}
+	condIdx, ok := cond.X.(*ast.Ident)
+	if !ok || condIdx.Name != idx.Name || condIdx.Obj != idx.Obj {
+		return false
+	}
+	lenCall, ok := cond.Y.(*ast.CallExpr)
+	if !ok || len(lenCall.Args) != 1 || !isBuiltin(lenCall.Fun, "len") {
+		return false
+	}
+	if !astutilinternal.EqualSyntax(expr, lenCall.Args[0]) {
+		return false
+	}
+	post, ok := stmt.Post.(*ast.IncDecStmt)
+	if !ok || post.Tok != token.INC {
+		return false
+	}
+	postIdx, ok := post.X.(*ast.Ident)
+	return ok && postIdx.Name == idx.Name && postIdx.Obj == idx.Obj
+}
+
+func scanNestedStmt(pass *analysis.Pass, stmt ast.Stmt) {
+	switch stmt := stmt.(type) {
+	case *ast.BlockStmt:
+		scanStmtList(pass, stmt.List)
+	case *ast.ForStmt:
+		scanStmtList(pass, stmt.Body.List)
+	case *ast.RangeStmt:
+		scanStmtList(pass, stmt.Body.List)
+	case *ast.IfStmt:
+		scanStmtList(pass, stmt.Body.List)
+		if stmt.Else != nil {
+			switch elseStmt := stmt.Else.(type) {
+			case *ast.BlockStmt:
+				scanStmtList(pass, elseStmt.List)
+			case *ast.IfStmt:
+				scanNestedStmt(pass, elseStmt)
+			}
+		}
+	case *ast.SwitchStmt:
+		for _, stmt := range stmt.Body.List {
+			clause := stmt.(*ast.CaseClause)
+			scanStmtList(pass, clause.Body)
+		}
+	case *ast.TypeSwitchStmt:
+		for _, stmt := range stmt.Body.List {
+			clause := stmt.(*ast.CaseClause)
+			scanStmtList(pass, clause.Body)
+		}
+	case *ast.SelectStmt:
+		for _, stmt := range stmt.Body.List {
+			clause := stmt.(*ast.CommClause)
+			scanStmtList(pass, clause.Body)
+		}
+	case *ast.LabeledStmt:
+		scanNestedStmt(pass, stmt.Stmt)
+	}
+}
+
+type candidate struct {
+	obj       types.Object
+	makeCall  *ast.CallExpr
+	lenCall   *ast.CallExpr
+	rangeExpr ast.Expr
+}
+
+func candidateFromStmt(pass *analysis.Pass, stmt ast.Stmt) *candidate {
+	switch stmt := stmt.(type) {
+	case *ast.AssignStmt:
+		if len(stmt.Lhs) != 1 || len(stmt.Rhs) != 1 {
+			return nil
+		}
+		ident, ok := stmt.Lhs[0].(*ast.Ident)
+		if !ok {
+			return nil
+		}
+		obj := pass.TypesInfo.ObjectOf(ident)
+		if obj == nil {
+			return nil
+		}
+		makeCall, lenCall, rangeExpr := matchMakeSliceWithLen(pass, stmt.Rhs[0])
+		if makeCall == nil {
+			return nil
+		}
+		return &candidate{obj: obj, makeCall: makeCall, lenCall: lenCall, rangeExpr: rangeExpr}
+
+	case *ast.DeclStmt:
+		gen, ok := stmt.Decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.VAR || len(gen.Specs) != 1 {
+			return nil
+		}
+		spec, ok := gen.Specs[0].(*ast.ValueSpec)
+		if !ok || len(spec.Names) != 1 || len(spec.Values) != 1 {
+			return nil
+		}
+		obj := pass.TypesInfo.ObjectOf(spec.Names[0])
+		if obj == nil {
+			return nil
+		}
+		makeCall, lenCall, rangeExpr := matchMakeSliceWithLen(pass, spec.Values[0])
+		if makeCall == nil {
+			return nil
+		}
+		return &candidate{obj: obj, makeCall: makeCall, lenCall: lenCall, rangeExpr: rangeExpr}
+	}
+	return nil
+}
+
+func matchMakeSliceWithLen(pass *analysis.Pass, expr ast.Expr) (*ast.CallExpr, *ast.CallExpr, ast.Expr) {
+	makeCall, ok := expr.(*ast.CallExpr)
+	if !ok || len(makeCall.Args) != 2 || makeCall.Ellipsis.IsValid() {
+		return nil, nil, nil
+	}
+	if !isBuiltin(makeCall.Fun, "make") {
+		return nil, nil, nil
+	}
+	typ := pass.TypesInfo.TypeOf(makeCall)
+	if typ == nil {
+		return nil, nil, nil
+	}
+	if _, ok := typ.Underlying().(*types.Slice); !ok {
+		return nil, nil, nil
+	}
+	lenCall, ok := makeCall.Args[1].(*ast.CallExpr)
+	if !ok || len(lenCall.Args) != 1 || lenCall.Ellipsis.IsValid() {
+		return nil, nil, nil
+	}
+	if !isBuiltin(lenCall.Fun, "len") {
+		return nil, nil, nil
+	}
+	return makeCall, lenCall, lenCall.Args[0]
+}
+
+func hasAppendToVar(pass *analysis.Pass, body *ast.BlockStmt, obj types.Object) bool {
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		switch n := n.(type) {
+		case *ast.FuncLit:
+			return false
+		case *ast.AssignStmt:
+			if len(n.Lhs) != 1 || len(n.Rhs) != 1 {
+				return true
+			}
+			lhs, ok := n.Lhs[0].(*ast.Ident)
+			if !ok || pass.TypesInfo.ObjectOf(lhs) != obj {
+				return true
+			}
+			call, ok := n.Rhs[0].(*ast.CallExpr)
+			if !ok || len(call.Args) == 0 || !isBuiltin(call.Fun, "append") {
+				return true
+			}
+			first, ok := call.Args[0].(*ast.Ident)
+			if ok && pass.TypesInfo.ObjectOf(first) == obj {
+				found = true
+				return false
+			}
+		}
+		return true
+	})
+	return found
+}
+
+func isBuiltin(expr ast.Expr, name string) bool {
+	ident, ok := expr.(*ast.Ident)
+	return ok && ident.Name == name && ident.Obj == nil
+}

--- a/gopls/internal/analysis/appendlen/appendlen.go
+++ b/gopls/internal/analysis/appendlen/appendlen.go
@@ -12,8 +12,12 @@ import (
 	"go/types"
 
 	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/ast/edge"
+	"golang.org/x/tools/go/ast/inspector"
 	"golang.org/x/tools/internal/analysis/analyzerutil"
+	typeindexanalyzer "golang.org/x/tools/internal/analysis/typeindex"
 	astutilinternal "golang.org/x/tools/internal/astutil"
+	"golang.org/x/tools/internal/typesinternal/typeindex"
 )
 
 //go:embed doc.go
@@ -22,70 +26,203 @@ var doc string
 var Analyzer = &analysis.Analyzer{
 	Name: "appendlen",
 	Doc:  analyzerutil.MustExtractDoc(doc, "appendlen"),
-	Run:  run,
-	URL:  "https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/appendlen",
+	Requires: []*analysis.Analyzer{
+		typeindexanalyzer.Analyzer,
+	},
+	Run: run,
+	URL: "https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/appendlen",
 }
 
 func run(pass *analysis.Pass) (any, error) {
-	for _, file := range pass.Files {
-		for _, decl := range file.Decls {
-			switch decl := decl.(type) {
-			case *ast.FuncDecl:
-				if decl.Body != nil {
-					scanStmtList(pass, decl.Body.List)
-				}
-			}
-		}
+	var (
+		index         = pass.ResultOf[typeindexanalyzer.Analyzer].(*typeindex.Index)
+		makeBuiltin   = types.Universe.Lookup("make")
+		appendBuiltin = types.Universe.Lookup("append")
+	)
+	if makeBuiltin == nil || appendBuiltin == nil {
+		return nil, nil
 	}
+
+	var appendCalls []inspector.Cursor
+	for curAppend := range index.Calls(appendBuiltin) {
+		appendCalls = append(appendCalls, curAppend)
+	}
+
+	for curMake := range index.Calls(makeBuiltin) {
+		cand, ok := candidateFromMakeCall(pass, curMake)
+		if !ok {
+			continue
+		}
+		curLoop, ok := nextLoop(cand.curStmt)
+		if !ok {
+			continue
+		}
+		body, ok := matchingLoopBody(curLoop, cand.rangeExpr)
+		if !ok {
+			continue
+		}
+		if !hasIndexedAppendToVar(pass, body, cand.obj, appendCalls) {
+			continue
+		}
+
+		pass.Report(analysis.Diagnostic{
+			Pos:     cand.makeCall.Pos(),
+			End:     cand.makeCall.End(),
+			Message: fmt.Sprintf("slice created with len(%s) is appended to while iterating over the same value", types.ExprString(cand.rangeExpr)),
+			SuggestedFixes: []analysis.SuggestedFix{{
+				Message: "Use zero length with preallocated capacity",
+				TextEdits: []analysis.TextEdit{{
+					Pos:     cand.lenCall.Pos(),
+					End:     cand.lenCall.Pos(),
+					NewText: []byte("0, "),
+				}},
+			}},
+		})
+	}
+
 	return nil, nil
 }
 
-func scanStmtList(pass *analysis.Pass, stmts []ast.Stmt) {
-	for i, stmt := range stmts {
-		if i+1 < len(stmts) {
-			cand := candidateFromStmt(pass, stmt)
-			if cand != nil {
-				if body, ok := immediateLoopBody(stmts[i+1], cand.rangeExpr); ok &&
-					hasAppendToVar(pass, body, cand.obj) {
-					pass.Report(analysis.Diagnostic{
-						Pos:     cand.makeCall.Pos(),
-						End:     cand.makeCall.End(),
-						Message: fmt.Sprintf("slice created with len(%s) is appended to while iterating over the same value", types.ExprString(cand.rangeExpr)),
-						SuggestedFixes: []analysis.SuggestedFix{{
-							Message: "Use zero length with preallocated capacity",
-							TextEdits: []analysis.TextEdit{{
-								Pos:     cand.lenCall.Pos(),
-								End:     cand.lenCall.Pos(),
-								NewText: []byte("0, "),
-							}},
-						}},
-					})
-				}
-			}
-		}
-		scanNestedStmt(pass, stmt)
-	}
+type candidate struct {
+	obj       types.Object
+	makeCall  *ast.CallExpr
+	lenCall   *ast.CallExpr
+	rangeExpr ast.Expr
+	curStmt   inspector.Cursor
 }
 
-func immediateLoopBody(stmt ast.Stmt, expr ast.Expr) (*ast.BlockStmt, bool) {
-	switch stmt := stmt.(type) {
-	case *ast.RangeStmt:
-		if astutilinternal.EqualSyntax(expr, stmt.X) {
-			return stmt.Body, true
-		}
-	case *ast.ForStmt:
-		if iteratesUsingIndexLoop(stmt, expr) {
-			return stmt.Body, true
-		}
+func candidateFromMakeCall(pass *analysis.Pass, curMake inspector.Cursor) (*candidate, bool) {
+	makeCall := curMake.Node().(*ast.CallExpr)
+	lenCall, rangeExpr, ok := matchMakeSliceWithLen(pass, makeCall)
+	if !ok {
+		return nil, false
 	}
+
+	switch curMake.ParentEdgeKind() {
+	case edge.AssignStmt_Rhs:
+		curAssign := curMake.Parent()
+		assign := curAssign.Node().(*ast.AssignStmt)
+		if len(assign.Lhs) != 1 || len(assign.Rhs) != 1 {
+			return nil, false
+		}
+		ident, ok := assign.Lhs[0].(*ast.Ident)
+		if !ok {
+			return nil, false
+		}
+		obj := pass.TypesInfo.ObjectOf(ident)
+		if obj == nil {
+			return nil, false
+		}
+		curStmt, ok := enclosingSequentialStmt(curAssign)
+		if !ok {
+			return nil, false
+		}
+		return &candidate{
+			obj:       obj,
+			makeCall:  makeCall,
+			lenCall:   lenCall,
+			rangeExpr: rangeExpr,
+			curStmt:   curStmt,
+		}, true
+
+	case edge.ValueSpec_Values:
+		curSpec := curMake.Parent()
+		spec := curSpec.Node().(*ast.ValueSpec)
+		if len(spec.Names) != 1 || len(spec.Values) != 1 {
+			return nil, false
+		}
+		obj := pass.TypesInfo.ObjectOf(spec.Names[0])
+		if obj == nil {
+			return nil, false
+		}
+		curStmt, ok := enclosingSequentialStmt(curSpec)
+		if !ok {
+			return nil, false
+		}
+		return &candidate{
+			obj:       obj,
+			makeCall:  makeCall,
+			lenCall:   lenCall,
+			rangeExpr: rangeExpr,
+			curStmt:   curStmt,
+		}, true
+	}
+
 	return nil, false
 }
 
-func iteratesUsingIndexLoop(stmt *ast.ForStmt, expr ast.Expr) bool {
-	if stmt.Init == nil || stmt.Cond == nil || stmt.Post == nil {
+func matchMakeSliceWithLen(pass *analysis.Pass, makeCall *ast.CallExpr) (*ast.CallExpr, ast.Expr, bool) {
+	if len(makeCall.Args) != 2 || makeCall.Ellipsis.IsValid() {
+		return nil, nil, false
+	}
+	typ := pass.TypesInfo.TypeOf(makeCall)
+	if typ == nil {
+		return nil, nil, false
+	}
+	if _, ok := typ.Underlying().(*types.Slice); !ok {
+		return nil, nil, false
+	}
+	lenCall, ok := makeCall.Args[1].(*ast.CallExpr)
+	if !ok || len(lenCall.Args) != 1 || lenCall.Ellipsis.IsValid() {
+		return nil, nil, false
+	}
+	if !isBuiltin(lenCall.Fun, "len") {
+		return nil, nil, false
+	}
+	return lenCall, lenCall.Args[0], true
+}
+
+func enclosingSequentialStmt(cur inspector.Cursor) (inspector.Cursor, bool) {
+	for cur.Node() != nil {
+		if _, ok := cur.Node().(ast.Stmt); ok && isSequentialStmt(cur) {
+			return cur, true
+		}
+		cur = cur.Parent()
+	}
+	return inspector.Cursor{}, false
+}
+
+func isSequentialStmt(cur inspector.Cursor) bool {
+	switch cur.ParentEdgeKind() {
+	case edge.BlockStmt_List, edge.CaseClause_Body, edge.CommClause_Body:
+		return true
+	default:
 		return false
 	}
-	init, ok := stmt.Init.(*ast.AssignStmt)
+}
+
+func nextLoop(curStmt inspector.Cursor) (inspector.Cursor, bool) {
+	curNext, ok := curStmt.NextSibling()
+	if !ok {
+		return inspector.Cursor{}, false
+	}
+	switch curNext.Node().(type) {
+	case *ast.RangeStmt, *ast.ForStmt:
+		return curNext, true
+	default:
+		return inspector.Cursor{}, false
+	}
+}
+
+func matchingLoopBody(curLoop inspector.Cursor, expr ast.Expr) (inspector.Cursor, bool) {
+	switch loop := curLoop.Node().(type) {
+	case *ast.RangeStmt:
+		if astutilinternal.EqualSyntax(expr, loop.X) {
+			return curLoop.Child(loop.Body), true
+		}
+	case *ast.ForStmt:
+		if iteratesUsingIndexLoop(loop, expr) {
+			return curLoop.Child(loop.Body), true
+		}
+	}
+	return inspector.Cursor{}, false
+}
+
+func iteratesUsingIndexLoop(loop *ast.ForStmt, expr ast.Expr) bool {
+	if loop.Init == nil || loop.Cond == nil || loop.Post == nil {
+		return false
+	}
+	init, ok := loop.Init.(*ast.AssignStmt)
 	if !ok || len(init.Lhs) != 1 || len(init.Rhs) != 1 {
 		return false
 	}
@@ -97,7 +234,7 @@ func iteratesUsingIndexLoop(stmt *ast.ForStmt, expr ast.Expr) bool {
 	if !ok || zero.Kind != token.INT || zero.Value != "0" {
 		return false
 	}
-	cond, ok := stmt.Cond.(*ast.BinaryExpr)
+	cond, ok := loop.Cond.(*ast.BinaryExpr)
 	if !ok || cond.Op != token.LSS {
 		return false
 	}
@@ -112,7 +249,7 @@ func iteratesUsingIndexLoop(stmt *ast.ForStmt, expr ast.Expr) bool {
 	if !astutilinternal.EqualSyntax(expr, lenCall.Args[0]) {
 		return false
 	}
-	post, ok := stmt.Post.(*ast.IncDecStmt)
+	post, ok := loop.Post.(*ast.IncDecStmt)
 	if !ok || post.Tok != token.INC {
 		return false
 	}
@@ -120,148 +257,37 @@ func iteratesUsingIndexLoop(stmt *ast.ForStmt, expr ast.Expr) bool {
 	return ok && postIdx.Name == idx.Name && postIdx.Obj == idx.Obj
 }
 
-func scanNestedStmt(pass *analysis.Pass, stmt ast.Stmt) {
-	switch stmt := stmt.(type) {
-	case *ast.BlockStmt:
-		scanStmtList(pass, stmt.List)
-	case *ast.ForStmt:
-		scanStmtList(pass, stmt.Body.List)
-	case *ast.RangeStmt:
-		scanStmtList(pass, stmt.Body.List)
-	case *ast.IfStmt:
-		scanStmtList(pass, stmt.Body.List)
-		if stmt.Else != nil {
-			switch elseStmt := stmt.Else.(type) {
-			case *ast.BlockStmt:
-				scanStmtList(pass, elseStmt.List)
-			case *ast.IfStmt:
-				scanNestedStmt(pass, elseStmt)
-			}
+func hasIndexedAppendToVar(pass *analysis.Pass, curBody inspector.Cursor, obj types.Object, appendCalls []inspector.Cursor) bool {
+	for _, curAppend := range appendCalls {
+		if !curBody.Contains(curAppend) {
+			continue
 		}
-	case *ast.SwitchStmt:
-		for _, stmt := range stmt.Body.List {
-			clause := stmt.(*ast.CaseClause)
-			scanStmtList(pass, clause.Body)
+		if appendAssignedToObj(pass, curAppend, obj) {
+			return true
 		}
-	case *ast.TypeSwitchStmt:
-		for _, stmt := range stmt.Body.List {
-			clause := stmt.(*ast.CaseClause)
-			scanStmtList(pass, clause.Body)
-		}
-	case *ast.SelectStmt:
-		for _, stmt := range stmt.Body.List {
-			clause := stmt.(*ast.CommClause)
-			scanStmtList(pass, clause.Body)
-		}
-	case *ast.LabeledStmt:
-		scanNestedStmt(pass, stmt.Stmt)
 	}
+	return false
 }
 
-type candidate struct {
-	obj       types.Object
-	makeCall  *ast.CallExpr
-	lenCall   *ast.CallExpr
-	rangeExpr ast.Expr
-}
-
-func candidateFromStmt(pass *analysis.Pass, stmt ast.Stmt) *candidate {
-	switch stmt := stmt.(type) {
-	case *ast.AssignStmt:
-		if len(stmt.Lhs) != 1 || len(stmt.Rhs) != 1 {
-			return nil
-		}
-		ident, ok := stmt.Lhs[0].(*ast.Ident)
-		if !ok {
-			return nil
-		}
-		obj := pass.TypesInfo.ObjectOf(ident)
-		if obj == nil {
-			return nil
-		}
-		makeCall, lenCall, rangeExpr := matchMakeSliceWithLen(pass, stmt.Rhs[0])
-		if makeCall == nil {
-			return nil
-		}
-		return &candidate{obj: obj, makeCall: makeCall, lenCall: lenCall, rangeExpr: rangeExpr}
-
-	case *ast.DeclStmt:
-		gen, ok := stmt.Decl.(*ast.GenDecl)
-		if !ok || gen.Tok != token.VAR || len(gen.Specs) != 1 {
-			return nil
-		}
-		spec, ok := gen.Specs[0].(*ast.ValueSpec)
-		if !ok || len(spec.Names) != 1 || len(spec.Values) != 1 {
-			return nil
-		}
-		obj := pass.TypesInfo.ObjectOf(spec.Names[0])
-		if obj == nil {
-			return nil
-		}
-		makeCall, lenCall, rangeExpr := matchMakeSliceWithLen(pass, spec.Values[0])
-		if makeCall == nil {
-			return nil
-		}
-		return &candidate{obj: obj, makeCall: makeCall, lenCall: lenCall, rangeExpr: rangeExpr}
+func appendAssignedToObj(pass *analysis.Pass, curAppend inspector.Cursor, obj types.Object) bool {
+	call := curAppend.Node().(*ast.CallExpr)
+	if len(call.Args) == 0 {
+		return false
 	}
-	return nil
-}
-
-func matchMakeSliceWithLen(pass *analysis.Pass, expr ast.Expr) (*ast.CallExpr, *ast.CallExpr, ast.Expr) {
-	makeCall, ok := expr.(*ast.CallExpr)
-	if !ok || len(makeCall.Args) != 2 || makeCall.Ellipsis.IsValid() {
-		return nil, nil, nil
+	first, ok := call.Args[0].(*ast.Ident)
+	if !ok || pass.TypesInfo.ObjectOf(first) != obj {
+		return false
 	}
-	if !isBuiltin(makeCall.Fun, "make") {
-		return nil, nil, nil
+	if curAppend.ParentEdgeKind() != edge.AssignStmt_Rhs {
+		return false
 	}
-	typ := pass.TypesInfo.TypeOf(makeCall)
-	if typ == nil {
-		return nil, nil, nil
+	curAssign := curAppend.Parent()
+	assign := curAssign.Node().(*ast.AssignStmt)
+	if len(assign.Lhs) != 1 || len(assign.Rhs) != 1 {
+		return false
 	}
-	if _, ok := typ.Underlying().(*types.Slice); !ok {
-		return nil, nil, nil
-	}
-	lenCall, ok := makeCall.Args[1].(*ast.CallExpr)
-	if !ok || len(lenCall.Args) != 1 || lenCall.Ellipsis.IsValid() {
-		return nil, nil, nil
-	}
-	if !isBuiltin(lenCall.Fun, "len") {
-		return nil, nil, nil
-	}
-	return makeCall, lenCall, lenCall.Args[0]
-}
-
-func hasAppendToVar(pass *analysis.Pass, body *ast.BlockStmt, obj types.Object) bool {
-	found := false
-	ast.Inspect(body, func(n ast.Node) bool {
-		if found {
-			return false
-		}
-		switch n := n.(type) {
-		case *ast.FuncLit:
-			return false
-		case *ast.AssignStmt:
-			if len(n.Lhs) != 1 || len(n.Rhs) != 1 {
-				return true
-			}
-			lhs, ok := n.Lhs[0].(*ast.Ident)
-			if !ok || pass.TypesInfo.ObjectOf(lhs) != obj {
-				return true
-			}
-			call, ok := n.Rhs[0].(*ast.CallExpr)
-			if !ok || len(call.Args) == 0 || !isBuiltin(call.Fun, "append") {
-				return true
-			}
-			first, ok := call.Args[0].(*ast.Ident)
-			if ok && pass.TypesInfo.ObjectOf(first) == obj {
-				found = true
-				return false
-			}
-		}
-		return true
-	})
-	return found
+	lhs, ok := assign.Lhs[0].(*ast.Ident)
+	return ok && pass.TypesInfo.ObjectOf(lhs) == obj
 }
 
 func isBuiltin(expr ast.Expr, name string) bool {

--- a/gopls/internal/analysis/appendlen/appendlen_test.go
+++ b/gopls/internal/analysis/appendlen/appendlen_test.go
@@ -1,0 +1,16 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package appendlen_test
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+	"golang.org/x/tools/gopls/internal/analysis/appendlen"
+)
+
+func Test(t *testing.T) {
+	analysistest.RunWithSuggestedFixes(t, analysistest.TestData(), appendlen.Analyzer, "a")
+}

--- a/gopls/internal/analysis/appendlen/doc.go
+++ b/gopls/internal/analysis/appendlen/doc.go
@@ -1,0 +1,27 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package appendlen defines an Analyzer that detects a likely mistaken use of
+// make([]T, len(x)) immediately before appending to the slice while iterating over x.
+//
+// # Analyzer appendlen
+//
+// appendlen: detect slices initialized with len(x) and then appended to in a loop over x
+//
+// A common mistake is to write:
+//
+//	output := make([]T, len(input))
+//	for _, v := range input {
+//		output = append(output, f(v))
+//	}
+//
+// This usually leaves the first len(input) elements of output as zero values,
+// and appends the intended results after them. In these cases, the initialization
+// should usually be:
+//
+//	output := make([]T, 0, len(input))
+//
+// This analyzer deliberately matches only narrow, high-confidence patterns
+// where the make call is immediately followed by a loop over the same value.
+package appendlen

--- a/gopls/internal/analysis/appendlen/testdata/src/a/a.go
+++ b/gopls/internal/analysis/appendlen/testdata/src/a/a.go
@@ -1,0 +1,111 @@
+package a
+
+type myInts []int
+
+func basic(input []int) []int {
+	out := make([]int, len(input)) // want "slice created with len\\(input\\) is appended to while iterating over the same value"
+	for _, in := range input {
+		out = append(out, in)
+	}
+	return out
+}
+
+func assign(input []string) []string {
+	var out []string
+	out = make([]string, len(input)) // want "slice created with len\\(input\\) is appended to while iterating over the same value"
+	for _, in := range input {
+		out = append(out, in)
+	}
+	return out
+}
+
+func declared(input [][]byte) [][]byte {
+	var out = make([][]byte, len(input)) // want "slice created with len\\(input\\) is appended to while iterating over the same value"
+	for _, in := range input {
+		if len(in) > 0 {
+			out = append(out, in)
+		}
+	}
+	return out
+}
+
+func namedSlice(input []int) myInts {
+	out := make(myInts, len(input)) // want "slice created with len\\(input\\) is appended to while iterating over the same value"
+	for _, in := range input {
+		out = append(out, in)
+	}
+	return out
+}
+
+func alreadyGood(input []int) []int {
+	out := make([]int, 0, len(input))
+	for _, in := range input {
+		out = append(out, in)
+	}
+	return out
+}
+
+func differentRange(input, other []int) []int {
+	out := make([]int, len(input))
+	for _, in := range other {
+		out = append(out, in)
+	}
+	return out
+}
+
+func classicFor(input []int) []int {
+	out := make([]int, len(input)) // want "slice created with len\\(input\\) is appended to while iterating over the same value"
+	for i := 0; i < len(input); i++ {
+		out = append(out, input[i])
+	}
+	return out
+}
+
+func classicForDifferent(input, other []int) []int {
+	out := make([]int, len(input))
+	for i := 0; i < len(other); i++ {
+		out = append(out, other[i])
+	}
+	return out
+}
+
+func classicForNonZeroStart(input []int) []int {
+	out := make([]int, len(input))
+	for i := 1; i < len(input); i++ {
+		out = append(out, input[i])
+	}
+	return out
+}
+
+func classicForLE(input []int) []int {
+	out := make([]int, len(input))
+	for i := 0; i <= len(input)-1; i++ {
+		out = append(out, input[i])
+	}
+	return out
+}
+
+func classicForPredeclaredIndex(input []int) []int {
+	out := make([]int, len(input))
+	var i int
+	for i = 0; i < len(input); i++ {
+		out = append(out, input[i])
+	}
+	return out
+}
+
+func notImmediate(input []int) []int {
+	out := make([]int, len(input))
+	_ = cap(out)
+	for _, in := range input {
+		out = append(out, in)
+	}
+	return out
+}
+
+func unusedAppend(input []int) {
+	out := make([]int, len(input))
+	for _, in := range input {
+		_ = append(out, in)
+	}
+}

--- a/gopls/internal/analysis/appendlen/testdata/src/a/a.go.golden
+++ b/gopls/internal/analysis/appendlen/testdata/src/a/a.go.golden
@@ -1,0 +1,111 @@
+package a
+
+type myInts []int
+
+func basic(input []int) []int {
+	out := make([]int, 0, len(input)) // want "slice created with len\\(input\\) is appended to while iterating over the same value"
+	for _, in := range input {
+		out = append(out, in)
+	}
+	return out
+}
+
+func assign(input []string) []string {
+	var out []string
+	out = make([]string, 0, len(input)) // want "slice created with len\\(input\\) is appended to while iterating over the same value"
+	for _, in := range input {
+		out = append(out, in)
+	}
+	return out
+}
+
+func declared(input [][]byte) [][]byte {
+	var out = make([][]byte, 0, len(input)) // want "slice created with len\\(input\\) is appended to while iterating over the same value"
+	for _, in := range input {
+		if len(in) > 0 {
+			out = append(out, in)
+		}
+	}
+	return out
+}
+
+func namedSlice(input []int) myInts {
+	out := make(myInts, 0, len(input)) // want "slice created with len\\(input\\) is appended to while iterating over the same value"
+	for _, in := range input {
+		out = append(out, in)
+	}
+	return out
+}
+
+func alreadyGood(input []int) []int {
+	out := make([]int, 0, len(input))
+	for _, in := range input {
+		out = append(out, in)
+	}
+	return out
+}
+
+func differentRange(input, other []int) []int {
+	out := make([]int, len(input))
+	for _, in := range other {
+		out = append(out, in)
+	}
+	return out
+}
+
+func classicFor(input []int) []int {
+	out := make([]int, 0, len(input)) // want "slice created with len\\(input\\) is appended to while iterating over the same value"
+	for i := 0; i < len(input); i++ {
+		out = append(out, input[i])
+	}
+	return out
+}
+
+func classicForDifferent(input, other []int) []int {
+	out := make([]int, len(input))
+	for i := 0; i < len(other); i++ {
+		out = append(out, other[i])
+	}
+	return out
+}
+
+func classicForNonZeroStart(input []int) []int {
+	out := make([]int, len(input))
+	for i := 1; i < len(input); i++ {
+		out = append(out, input[i])
+	}
+	return out
+}
+
+func classicForLE(input []int) []int {
+	out := make([]int, len(input))
+	for i := 0; i <= len(input)-1; i++ {
+		out = append(out, input[i])
+	}
+	return out
+}
+
+func classicForPredeclaredIndex(input []int) []int {
+	out := make([]int, len(input))
+	var i int
+	for i = 0; i < len(input); i++ {
+		out = append(out, input[i])
+	}
+	return out
+}
+
+func notImmediate(input []int) []int {
+	out := make([]int, len(input))
+	_ = cap(out)
+	for _, in := range input {
+		out = append(out, in)
+	}
+	return out
+}
+
+func unusedAppend(input []int) {
+	out := make([]int, len(input))
+	for _, in := range input {
+		_ = append(out, in)
+	}
+}

--- a/gopls/internal/settings/analysis.go
+++ b/gopls/internal/settings/analysis.go
@@ -53,6 +53,7 @@ import (
 	"golang.org/x/tools/go/analysis/passes/unusedresult"
 	"golang.org/x/tools/go/analysis/passes/unusedwrite"
 	"golang.org/x/tools/go/analysis/passes/waitgroup"
+	"golang.org/x/tools/gopls/internal/analysis/appendlen"
 	"golang.org/x/tools/gopls/internal/analysis/deprecated"
 	"golang.org/x/tools/gopls/internal/analysis/embeddirective"
 	"golang.org/x/tools/gopls/internal/analysis/fillreturns"
@@ -213,9 +214,10 @@ var DefaultAnalyzers = []*Analyzer{
 	{analyzer: yield.Analyzer},   // uses go/ssa
 	{analyzer: sortslice.Analyzer},
 	{analyzer: embeddirective.Analyzer},
-	{analyzer: waitgroup.Analyzer},     // to appear in cmd/vet@go1.25
-	{analyzer: hostport.Analyzer},      // to appear in cmd/vet@go1.25
-	{analyzer: recursiveiter.Analyzer}, // under evaluation
+	{analyzer: appendlen.Analyzer, nonDefault: true}, // under evaluation; see #73830
+	{analyzer: waitgroup.Analyzer},                   // to appear in cmd/vet@go1.25
+	{analyzer: hostport.Analyzer},                    // to appear in cmd/vet@go1.25
+	{analyzer: recursiveiter.Analyzer},               // under evaluation
 	{analyzer: writestring.Analyzer},
 
 	// disabled due to high false positives


### PR DESCRIPTION
This adds a narrow appendlen analyzer to gopls/internal/analysis.

It detects a common slice-construction mistake: creating a slice with
make([]T, len(x)) and then immediately appending to it while iterating
over x.

The analyzer currently supports two high-confidence loop shapes:
for _, v := range x { out = append(out, ...) }
for i := 0; i < len(x); i++ { out = append(out, ...) }

It suggests rewriting the initialization to:
make([]T, 0, len(x))

The rule is intentionally narrow and is registered as non-default while
under evaluation.

Fixes golang/go#73830
