### PR TITLE
go/analysis/passes/modernize: skip slicesbackward fix when no s[i] accesses

### DIFF
--- a/go/analysis/passes/modernize/slicesbackward.go
+++ b/go/analysis/passes/modernize/slicesbackward.go
@@ -191,8 +191,13 @@ func slicesbackward(pass *analysis.Pass) (any, error) {
 			}
 
 			// Replace the loop header with a range over slices.Backward.
+			// If there are no s[i] accesses, don't offer a fix: the value
+			// variable v would be unused, causing a compile error.
+			if len(sliceIndexes) == 0 {
+				continue
+			}
 			var header string
-			if otherUses == 0 && len(sliceIndexes) > 0 {
+			if otherUses == 0 {
 				// All uses of i are s[i]; drop the index variable.
 				header = fmt.Sprintf("_, %s := range %sBackward(%s)",
 					elemName, prefix, sliceStr)

--- a/go/analysis/passes/modernize/testdata/src/slicesbackward/slicesbackward.go
+++ b/go/analysis/passes/modernize/testdata/src/slicesbackward/slicesbackward.go
@@ -24,7 +24,7 @@ func indexUsedElsewhere(s []int) {
 
 // Index used only for non-slice purpose (no s[i] at all).
 func indexNoSliceAccess(s []int) {
-	for i := len(s) - 1; i >= 0; i-- { // want "backward loop over slice can be modernized using slices.Backward"
+	for i := len(s) - 1; i >= 0; i-- {
 		println(i)
 	}
 }

--- a/go/analysis/passes/modernize/testdata/src/slicesbackward/slicesbackward.go.golden
+++ b/go/analysis/passes/modernize/testdata/src/slicesbackward/slicesbackward.go.golden
@@ -24,7 +24,7 @@ func indexUsedElsewhere(s []int) {
 
 // Index used only for non-slice purpose (no s[i] at all).
 func indexNoSliceAccess(s []int) {
-	for i, v := range slices.Backward(s) { // want "backward loop over slice can be modernized using slices.Backward"
+	for i := len(s) - 1; i >= 0; i-- {
 		println(i)
 	}
 }


### PR DESCRIPTION
Fixes golang/go#78629

The slicesbackward analyzer would incorrectly suggest replacing a backward loop with 'for i, v := range slices.Backward(s)' even when there are no s[i] element accesses in the loop body. In this case, the value variable v is never used, causing a 'declared and not used' compile error.

Skip offering the fix when len(sliceIndexes) == 0, since there would be no s[i] accesses to replace.