### PR TITLE
modernize: fix slicesbackward crash when loop has no s[i] accesses

### DIFF
--- a/go/analysis/passes/modernize/slicesbackward.go
+++ b/go/analysis/passes/modernize/slicesbackward.go
@@ -192,7 +192,7 @@ func slicesbackward(pass *analysis.Pass) (any, error) {
 
 			// Replace the loop header with a range over slices.Backward.
 			var header string
-			if otherUses == 0 && len(sliceIndexes) > 0 {
+			if otherUses == 0 {
 				// All uses of i are s[i]; drop the index variable.
 				header = fmt.Sprintf("_, %s := range %sBackward(%s)",
 					elemName, prefix, sliceStr)


### PR DESCRIPTION
## Fix Description

Fixes golang/go#78629 - the slicesbackward analyzer panics when a backward loop iterates over a slice but never indexes into it.

### Root Cause
The condition requires both otherUses=0 AND len(sliceIndexes)>0, but when both are zero the code tries to format a header with an undefined elemName.

### Fix
Change condition from `otherUses == 0 && len(sliceIndexes) > 0` to `otherUses == 0` so elemName is always defined.

Closes golang/go#78629