### PR TITLE
gopls: prevent crash in ExtractToNewFile when bounds are invalid

### DIFF
--- a/gopls/internal/golang/extracttofile.go
+++ b/gopls/internal/golang/extracttofile.go
@@ -111,16 +111,16 @@ func ExtractToNewFile(ctx context.Context, snapshot *cache.Snapshot, fh file.Han
 	end += token.Pos(spaces)
 	pgf.CheckPos(end) // #70553
 	if !(start <= end) {
-		bug.Reportf("start: not before end")
+		return nil, bug.Errorf("start: not before end")
 	}
 	// Inv: end is valid wrt pgf.Tok; env >= start.
 	fileStart := pgf.File.FileStart
 	pgf.CheckPos(fileStart) // #70553
-	if !(0 <= start-fileStart) {
-		bug.Reportf("start: out of bounds")
+	if !(0 <= int(start-fileStart)) {
+		return nil, bug.Errorf("start: out of bounds")
 	}
 	if !(int(end-fileStart) <= len(pgf.Src)) {
-		bug.Reportf("end: out of bounds")
+		return nil, bug.Errorf("end: out of bounds")
 	}
 	// Inv: 0 <= start-fileStart <= end-fileStart <= len(Src).
 	src := pgf.Src[start-fileStart : end-fileStart]


### PR DESCRIPTION
## Fix for golang/go#70553

### Problem
In `ExtractToNewFile`, the bounds checks at lines 118-124 called `bug.Reportf` but then continued execution. When `safetoken.Offset` returned an error that was ignored by `CheckPos`, the subsequent slice `pgf.Src[start-fileStart:end-fileStart]` would panic with "slice bounds out of range".

### Fix
Replace `bug.Reportf` with `return nil, bug.Errorf` so the function exits safely with an error instead of crashing.

Also fix the comparison `0 <= start-fileStart` which requires casting the `token.Pos` difference to `int`.

### Testing
Go syntax check passes. The fix ensures bounds checks guard the slice operation.

### Issue Reference
Fixes golang/go#70553