### PR TITLE
all: fix typos in comments and docs

### DIFF
--- a/go/analysis/internal/checker/fix_test.go
+++ b/go/analysis/internal/checker/fix_test.go
@@ -607,7 +607,7 @@ var relatedAnalyzer = &analysis.Analyzer{
 	},
 }
 
-// panics asserts that f() panics with with a value whose printed form matches the regexp want.
+// panics asserts that f() panics with a value whose printed form matches the regexp want.
 func panics(t *testing.T, want string, f func()) {
 	defer func() {
 		if x := recover(); x == nil {

--- a/go/analysis/passes/printf/testdata/src/a/a.go
+++ b/go/analysis/passes/printf/testdata/src/a/a.go
@@ -154,7 +154,7 @@ func PrintfTests() {
 	fmt.Println("%v", "hi")                     // want "fmt.Println call has possible Printf formatting directive %v"
 	fmt.Println("%T", "hi")                     // want "fmt.Println call has possible Printf formatting directive %T"
 	fmt.Println("%s"+" there", "hi")            // want "fmt.Println call has possible Printf formatting directive %s"
-	fmt.Println("http://foo.com?q%2Fabc")       // no diagnostic: %XX is excepted
+	fmt.Println("http://foo.com?q%2Fabc")       // no diagnostic: %XX is expected
 	fmt.Println("http://foo.com?q%2Fabc-%s")    // want"fmt.Println call has possible Printf formatting directive %s"
 	fmt.Println("0.0%")                         // correct (trailing % couldn't be a formatting directive)
 	fmt.Printf("%s", "hi", 3)                   // want "fmt.Printf call needs 1 arg but has 2 args"

--- a/go/types/objectpath/objectpath_test.go
+++ b/go/types/objectpath/objectpath_test.go
@@ -488,7 +488,7 @@ func TestIssue70418(t *testing.T) {
 	// objectpath would inspect the methods of I:
 	// - First we see I.A, which leads to Anon, to F, which is marked as seen.
 	// - Second we see I.F, embedded via alias Anon.
-	//   Since we've already seen F, we break ouf the the interface method loop.
+	//   Since we've already seen F, we break out of the interface method loop.
 	// - Third, we fail to visit I.Z.
 	// The solution is to skip only I.F, not the rest of the interface.
 

--- a/gopls/doc/features/transformation.md
+++ b/gopls/doc/features/transformation.md
@@ -801,7 +801,7 @@ form.
 
 When the selection is within an `if`/`else` statement that is not
 followed by `else if`, gopls offers a code action to invert the
-statement, negating the condition and swapping the `if` and and `else`
+statement, negating the condition and swapping the `if` and `else`
 blocks.
 
 ![Before "Invert if condition"](../assets/invert-if-before.png)

--- a/gopls/internal/analysis/yield/yield.go
+++ b/gopls/internal/analysis/yield/yield.go
@@ -461,7 +461,7 @@ func (s state) update(num int, mask, sense bool) state {
 
 // -- SSA CFG as graph.Graph --
 
-// fnGraph adapts an [ssa.Function] to to the [graph.Graph] interface
+// fnGraph adapts an [ssa.Function] to the [graph.Graph] interface
 // required by the flow analysis framework.
 // Nodes are labelled by their block indices and connected by the
 // successor relation.

--- a/gopls/internal/cache/os_windows.go
+++ b/gopls/internal/cache/os_windows.go
@@ -47,7 +47,7 @@ func windowsCheckPathValid(path string) error {
 	}
 	longstr := syscall.UTF16ToString(long)
 
-	// Check that the the path -> short -> long roundtrip was idempotent.
+	// Check that the path -> short -> long roundtrip was idempotent.
 	isRoot := func(p string) bool {
 		return p[len(p)-1] == filepath.Separator
 	}

--- a/gopls/internal/cmd/codeaction.go
+++ b/gopls/internal/cmd/codeaction.go
@@ -41,7 +41,7 @@ to be executed by the server, which may have an effect such as:
 - changing the state of the server; or
 - requesting that the client open a document.
 
-The -kind and and -title flags filter the list of actions.
+The -kind and -title flags filter the list of actions.
 
 The -kind flag specifies a comma-separated list of LSP CodeAction kinds.
 Only actions of these kinds will be requested from the server.

--- a/gopls/internal/cmd/usage/codeaction.hlp
+++ b/gopls/internal/cmd/usage/codeaction.hlp
@@ -12,7 +12,7 @@ to be executed by the server, which may have an effect such as:
 - changing the state of the server; or
 - requesting that the client open a document.
 
-The -kind and and -title flags filter the list of actions.
+The -kind and -title flags filter the list of actions.
 
 The -kind flag specifies a comma-separated list of LSP CodeAction kinds.
 Only actions of these kinds will be requested from the server.

--- a/gopls/internal/filewatcher/filewatcher_test.go
+++ b/gopls/internal/filewatcher/filewatcher_test.go
@@ -356,7 +356,7 @@ func TestBrokenSymlink(t *testing.T) {
 	}
 
 	{
-		// Prepare a dir with with broken symbolic link.
+		// Prepare a dir with broken symbolic link.
 		// foo                       <- 1st
 		// ├── from.go -> root/to.go <- 1st
 		// ├── a.go                  <- 1st

--- a/gopls/internal/test/integration/codelens/codelens_test.go
+++ b/gopls/internal/test/integration/codelens/codelens_test.go
@@ -385,7 +385,7 @@ func Foo() {
 }
 `
 	Run(t, workspace, func(t *testing.T, env *Env) {
-		// Open the file. We have a nonexistant symbol that will break cgo processing.
+		// Open the file. We have a nonexistent symbol that will break cgo processing.
 		env.OpenFile("cgo.go")
 		env.AfterChange(
 			Diagnostics(env.AtRegexp("cgo.go", ``), WithMessage("go list failed to return CompiledGoFiles")),


### PR DESCRIPTION
Fix several doubled words and misspellings found across 
comments, test files, and documentation

- go/types/objectpath: "ouf the the" → "out of the"
- gopls/internal/cache: "the the" → "the"
- gopls/internal/cmd/codeaction: "and and" → "and"
- gopls/internal/analysis/yield: "to to" → "to"
- gopls/doc/features/transformation: "and and" → "and"
- go/analysis/internal/checker: "with with" → "with"
- gopls/internal/filewatcher: "with with" → "with"
- go/analysis/passes/printf: "excepted" → "expected"
- gopls/internal/test/integration/codelens: "nonexistant" → "nonexistent"