### PR TITLE
go/analysis/passes/modernize: clarify TODO comment in methodGoVersion

### DIFF
--- a/go/analysis/passes/modernize/stditerators.go
+++ b/go/analysis/passes/modernize/stditerators.go
@@ -375,8 +375,8 @@ func stditerators(pass *analysis.Pass) (any, error) {
 // (pkgpath.recvtype).method appeared in the standard library.
 func methodGoVersion(pkgpath, recvtype, method string) (stdlib.Version, error) {
 	// TODO(adonovan): opt: this might be inefficient for large packages
-	// like go/types. If so, memoize using a map (and kill two birds with
-	// one stone by also memoizing the 'within' check above).
+	// like go/types. If so, memoize using a map (and accomplish two things
+	// at once by also memoizing the 'within' check above).
 	for _, sym := range stdlib.PackageSymbols[pkgpath] {
 		if sym.Kind == stdlib.Method {
 			_, recv, name := sym.SplitMethod()


### PR DESCRIPTION
Replaces the figurative "kill two birds with one stone" in the
methodGoVersion TODO comment with the more direct "accomplish two
things at once". The idiom is split across two physical lines; the
line break is kept at the same clause boundary so the diff is a
minimal +2/-2 inside a `//` comment. The original phrasing doesn't
translate cleanly across languages and is less direct than the
replacement. No logic, API, test, or generated-code changes.

Happy to follow up on go-review.googlesource.com if the bot opens a
CL — let me know if you'd prefer I open the CL directly instead.
I'll sign the Google CLA via the googlebot prompt as soon as it
appears on the PR. Thanks to reviewers, and to @adonovan for the
original TODO context.
