### PR TITLE
gopls: reduce memory during large re-type-check passes

### DIFF
--- a/gopls/doc/settings.md
+++ b/gopls/doc/settings.md
@@ -673,6 +673,26 @@ as measured by du(1) may be significantly higher.
 
 Default: `0`.
 
+<a id='memoryLimit'></a>
+### `memoryLimit int64`
+
+**This setting is experimental and may be deleted.**
+
+memoryLimit sets a soft memory limit (in bytes) for the gopls process, via
+runtime/debug.SetMemoryLimit. If zero (the default), no limit is set.
+
+On large workspaces, a single edit that invalidates many packages (for
+example a syntax error in a widely-imported package) can make the heap
+briefly grow well above the steady-state working set before the garbage
+collector catches up, spiking memory and, on memory-constrained machines,
+causing swap. A soft limit makes the GC work harder to stay near the limit,
+trading some CPU for a lower memory peak.
+
+The limit is soft and may be exceeded; set it comfortably above the
+steady-state working set, as too low a value causes excessive GC.
+
+Default: `0`.
+
 <a id='verboseOutput'></a>
 ### `verboseOutput bool`
 

--- a/gopls/internal/cache/check.go
+++ b/gopls/internal/cache/check.go
@@ -53,8 +53,8 @@ type unit = struct{}
 // It shares state such as parsed files and imports, to optimize type-checking
 // for packages with overlapping dependency graphs.
 type typeCheckBatch struct {
-	// handleMu guards _handles, which must only be accessed via addHandles or
-	// getHandle.
+	// handleMu guards _handles and _syntaxIDs, which must only be accessed via
+	// their dedicated methods (addHandles/getHandle, addSyntaxIDs/isSyntaxID).
 	//
 	// An alternative would be to simply verify that package handles are present
 	// on the Snapshot, and access them directly, rather than copying maps for
@@ -63,6 +63,11 @@ type typeCheckBatch struct {
 	// persistent.Map used to store handles on the snapshot.
 	handleMu sync.Mutex
 	_handles map[PackageID]*packageHandle
+
+	// _syntaxIDs is the set of packages being fully type-checked in this batch.
+	// getImportPackage uses it to reuse a package's full result when importing it,
+	// rather than type-checking it a second time. See getImportPackage.
+	_syntaxIDs map[PackageID]bool
 
 	parseCache       *parseCache
 	fset             *token.FileSet                          // describes all parsed or imported files
@@ -91,6 +96,22 @@ func (b *typeCheckBatch) getHandle(id PackageID) *packageHandle {
 	b.handleMu.Lock()
 	defer b.handleMu.Unlock()
 	return b._handles[id]
+}
+
+// addSyntaxIDs records ids as packages being fully type-checked in this batch.
+func (b *typeCheckBatch) addSyntaxIDs(ids []PackageID) {
+	b.handleMu.Lock()
+	defer b.handleMu.Unlock()
+	for _, id := range ids {
+		b._syntaxIDs[id] = true
+	}
+}
+
+// isSyntaxID reports whether id is being fully type-checked in this batch.
+func (b *typeCheckBatch) isSyntaxID(id PackageID) bool {
+	b.handleMu.Lock()
+	defer b.handleMu.Unlock()
+	return b._syntaxIDs[id]
 }
 
 // TypeCheck parses and type-checks the specified packages,
@@ -258,6 +279,7 @@ func (s *Snapshot) acquireTypeChecking() (*typeCheckBatch, func()) {
 func newTypeCheckBatch(parseCache *parseCache, gopackagesdriver bool) *typeCheckBatch {
 	return &typeCheckBatch{
 		_handles:         make(map[PackageID]*packageHandle),
+		_syntaxIDs:       make(map[PackageID]bool),
 		parseCache:       parseCache,
 		fset:             fileSetWithBase(reservedForParsing),
 		cpulimit:         make(chan unit, runtime.GOMAXPROCS(0)),
@@ -281,6 +303,7 @@ func newTypeCheckBatch(parseCache *parseCache, gopackagesdriver bool) *typeCheck
 // package handle logic.
 func (b *typeCheckBatch) query(ctx context.Context, syntaxIDs []PackageID, pre preTypeCheck, post postTypeCheck, handles map[PackageID]*packageHandle) error {
 	b.addHandles(handles)
+	b.addSyntaxIDs(syntaxIDs)
 
 	// Start a single goroutine for each requested package.
 	//
@@ -324,7 +347,25 @@ func (b *typeCheckBatch) getImportPackage(ctx context.Context, id PackageID) (pk
 
 		data, err := filecache.Get(exportDataKind, ph.key, filecache.Bytes)
 		if err == filecache.ErrNotFound {
-			// No cached export data: type-check as fast as possible.
+			// No cached export data. If this package is also being fully
+			// type-checked in this batch, reuse that result instead of
+			// type-checking it a second time just to import it. This avoids
+			// redundant work when an edit invalidates a large reverse-dependency
+			// closure, where many closure packages import one another.
+			//
+			// Only reuse when the package is checked into the batch's shared
+			// FileSet (ph.state < validImports); otherwise getPackage uses a
+			// cloned FileSet whose positions aren't commensurable with importers
+			// using b.fset, so fall back to checkPackageForImport (which uses
+			// b.fset).
+			if ph.state < validImports && b.isSyntaxID(id) {
+				pkg, err := b.getPackage(ctx, ph)
+				if err != nil {
+					return nil, err
+				}
+				return pkg.Types(), nil
+			}
+			// type-check as fast as possible.
 			return b.checkPackageForImport(ctx, ph)
 		}
 		if err != nil {

--- a/gopls/internal/cache/check.go
+++ b/gopls/internal/cache/check.go
@@ -26,6 +26,7 @@ import (
 	"golang.org/x/mod/module"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/tools/go/ast/astutil"
+	"golang.org/x/tools/go/types/objectpath"
 	"golang.org/x/tools/gopls/internal/bloom"
 	"golang.org/x/tools/gopls/internal/cache/metadata"
 	"golang.org/x/tools/gopls/internal/cache/parsego"
@@ -75,6 +76,20 @@ type typeCheckBatch struct {
 	syntaxPackages   *futureCache[PackageID, *Package]       // transient cache of in-progress syntax futures
 	importPackages   *futureCache[PackageID, *types.Package] // persistent cache of imports
 	gopackagesdriver bool                                    // for bug reporting: were packages loaded with a driver?
+
+	// objpathEnc is one objectpath.Encoder shared across all per-package xref
+	// indexing in this batch (via objectpathFor), so a heavily-referenced
+	// package's object paths are encoded once rather than once per importer. The
+	// Encoder is not concurrency-safe, hence objpathMu.
+	objpathMu  sync.Mutex
+	objpathEnc objectpath.Encoder
+}
+
+// objectpathFor encodes obj's object path using the batch's shared Encoder.
+func (b *typeCheckBatch) objectpathFor(obj types.Object) (objectpath.Path, error) {
+	b.objpathMu.Lock()
+	defer b.objpathMu.Unlock()
+	return b.objpathEnc.For(obj)
 }
 
 // addHandles is called by each goroutine joining the type check batch, to
@@ -461,7 +476,7 @@ func (b *typeCheckBatch) getPackage(ctx context.Context, ph *packageHandle) (*Pa
 		}
 
 		// Update caches.
-		go storePackageResults(ctx, ph, p) // ...and write all packages to disk
+		go storePackageResults(ctx, ph, p, b.objectpathFor) // ...and write all packages to disk
 		return p, nil
 	})
 }
@@ -469,9 +484,9 @@ func (b *typeCheckBatch) getPackage(ctx context.Context, ph *packageHandle) (*Pa
 // storePackageResults serializes and writes information derived from p to the
 // file cache.
 // The context is used only for logging; cancellation does not affect the operation.
-func storePackageResults(ctx context.Context, ph *packageHandle, p *Package) {
+func storePackageResults(ctx context.Context, ph *packageHandle, p *Package, objectpathFor func(types.Object) (objectpath.Path, error)) {
 	toCache := map[string][]byte{
-		xrefsKind:       p.pkg.xrefs().Encode(),
+		xrefsKind:       p.pkg.xrefs(objectpathFor).Encode(),
 		methodSetsKind:  p.pkg.methodsets().Encode(),
 		testsKind:       p.pkg.tests().Encode(),
 		diagnosticsKind: encodeDiagnostics(p.pkg.diagnostics),

--- a/gopls/internal/cache/package.go
+++ b/gopls/internal/cache/package.go
@@ -13,6 +13,7 @@ import (
 	"slices"
 	"sync"
 
+	"golang.org/x/tools/go/types/objectpath"
 	"golang.org/x/tools/gopls/internal/cache/metadata"
 	"golang.org/x/tools/gopls/internal/cache/methodsets"
 	"golang.org/x/tools/gopls/internal/cache/parsego"
@@ -68,9 +69,12 @@ type syntaxPackage struct {
 	_tests    *testfuncs.Index // only used by the tests method
 }
 
-func (p *syntaxPackage) xrefs() *xrefs.Index {
+// xrefs returns the cross-reference index, computing it once on first call.
+// objectpathFor is passed to [xrefs.NewIndex]; callers indexing a batch of
+// packages should pass a shared encoder. It is ignored after the first call.
+func (p *syntaxPackage) xrefs(objectpathFor func(types.Object) (objectpath.Path, error)) *xrefs.Index {
 	p.xrefsOnce.Do(func() {
-		p._xrefs = xrefs.NewIndex(p.compiledGoFiles, p.types, p.typesInfo)
+		p._xrefs = xrefs.NewIndex(p.compiledGoFiles, p.types, p.typesInfo, objectpathFor)
 	})
 	return p._xrefs
 }

--- a/gopls/internal/cache/snapshot.go
+++ b/gopls/internal/cache/snapshot.go
@@ -14,6 +14,7 @@ import (
 	"go/build/constraint"
 	"go/parser"
 	"go/token"
+	"go/types"
 	"os"
 	"path"
 	"path/filepath"
@@ -581,8 +582,20 @@ func (s *Snapshot) References(ctx context.Context, ids ...PackageID) ([]xrefInde
 		}
 		return true
 	}
+	// Share one objectpath.Encoder across the indexed packages (post may run
+	// concurrently, hence the mutex) so a heavily-referenced package's object
+	// paths are encoded once.
+	var (
+		objpathMu  sync.Mutex
+		objpathEnc objectpath.Encoder
+	)
+	objectpathFor := func(obj types.Object) (objectpath.Path, error) {
+		objpathMu.Lock()
+		defer objpathMu.Unlock()
+		return objpathEnc.For(obj)
+	}
 	post := func(i int, pkg *Package) {
-		indexes[i] = xrefIndex{mp: pkg.metadata, idx: pkg.pkg.xrefs()}
+		indexes[i] = xrefIndex{mp: pkg.metadata, idx: pkg.pkg.xrefs(objectpathFor)}
 	}
 	return indexes, s.forEachPackage(ctx, ids, pre, post)
 }

--- a/gopls/internal/cache/xrefs/xrefs.go
+++ b/gopls/internal/cache/xrefs/xrefs.go
@@ -23,7 +23,12 @@ import (
 
 // NewIndex constructs an index of outbound cross-references for the
 // specified type-checked package.
-func NewIndex(files []*parsego.File, pkg *types.Package, info *types.Info) *Index {
+//
+// objectpathFor encodes a referenced symbol's object path, typically
+// (*objectpath.Encoder).For. Callers indexing many packages should share one
+// Encoder across them so a heavily-referenced package's object paths are encoded
+// once rather than once per referencing package.
+func NewIndex(files []*parsego.File, pkg *types.Package, info *types.Info, objectpathFor func(types.Object) (objectpath.Path, error)) *Index {
 	// pkgObjects maps each referenced package Q to a mapping:
 	// from each referenced symbol in Q to the ordered list
 	// of references to that symbol from this package.
@@ -40,8 +45,6 @@ func NewIndex(files []*parsego.File, pkg *types.Package, info *types.Info) *Inde
 		}
 		return objects
 	}
-
-	objectpathFor := new(objectpath.Encoder).For
 
 	for fileIndex, pgf := range files {
 		// Walk with a transient ast.Preorder rather than pgf.Cursor(): Cursor()

--- a/gopls/internal/cache/xrefs/xrefs.go
+++ b/gopls/internal/cache/xrefs/xrefs.go
@@ -44,8 +44,15 @@ func NewIndex(files []*parsego.File, pkg *types.Package, info *types.Info) *Inde
 	objectpathFor := new(objectpath.Encoder).For
 
 	for fileIndex, pgf := range files {
-		for cur := range pgf.Cursor().Preorder((*ast.Ident)(nil), (*ast.ImportSpec)(nil)) {
-			switch n := cur.Node().(type) {
+		// Walk with a transient ast.Preorder rather than pgf.Cursor(): Cursor()
+		// lazily builds and permanently caches an inspector on the File, and the
+		// xref index is rebuilt for every package during type-checking, so across
+		// a large reverse-dependency re-check that cached inspector data retained
+		// a lot of memory. This loop only needs each node, so a plain walk that
+		// allocates nothing outliving it suffices. Open files still get a cached
+		// cursor on demand from interactive features.
+		for n := range ast.Preorder(pgf.File) {
+			switch n := n.(type) {
 			case *ast.Ident:
 				// Report a reference for each identifier that
 				// uses a symbol exported from another package.

--- a/gopls/internal/doc/api.json
+++ b/gopls/internal/doc/api.json
@@ -2323,6 +2323,20 @@
 				"DeprecationMessage": ""
 			},
 			{
+				"Name": "memoryLimit",
+				"Type": "int64",
+				"Doc": "memoryLimit sets a soft memory limit (in bytes) for the gopls process, via\nruntime/debug.SetMemoryLimit. If zero (the default), no limit is set.\n\nOn large workspaces, a single edit that invalidates many packages (for\nexample a syntax error in a widely-imported package) can make the heap\nbriefly grow well above the steady-state working set before the garbage\ncollector catches up, spiking memory and, on memory-constrained machines,\ncausing swap. A soft limit makes the GC work harder to stay near the limit,\ntrading some CPU for a lower memory peak.\n\nThe limit is soft and may be exceeded; set it comfortably above the\nsteady-state working set, as too low a value causes excessive GC.\n",
+				"EnumKeys": {
+					"ValueType": "",
+					"Keys": null
+				},
+				"EnumValues": null,
+				"Default": "0",
+				"Status": "experimental",
+				"Hierarchy": "",
+				"DeprecationMessage": ""
+			},
+			{
 				"Name": "verboseOutput",
 				"Type": "bool",
 				"Doc": "verboseOutput enables additional debug logging.\n",

--- a/gopls/internal/server/general.go
+++ b/gopls/internal/server/general.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	rdebug "runtime/debug"
 	"slices"
 	"sort"
 	"strings"
@@ -73,6 +74,9 @@ func (s *server) Initialize(ctx context.Context, params *protocol.ParamInitializ
 
 	if options.MaxFileCacheBytes > 0 {
 		filecache.SetBudget(options.MaxFileCacheBytes)
+	}
+	if options.MemoryLimit > 0 {
+		rdebug.SetMemoryLimit(options.MemoryLimit)
 	}
 
 	if options.ShowBugReports {

--- a/gopls/internal/server/workspace.go
+++ b/gopls/internal/server/workspace.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	rdebug "runtime/debug"
 	"strings"
 	"sync"
 
@@ -146,6 +147,9 @@ func (s *server) DidChangeConfiguration(ctx context.Context, _ *protocol.DidChan
 
 	if options.MaxFileCacheBytes > 0 {
 		filecache.SetBudget(options.MaxFileCacheBytes)
+	}
+	if options.MemoryLimit > 0 {
+		rdebug.SetMemoryLimit(options.MemoryLimit)
 	}
 
 	return nil

--- a/gopls/internal/settings/settings.go
+++ b/gopls/internal/settings/settings.go
@@ -695,6 +695,20 @@ type UserOptions struct {
 	// as measured by du(1) may be significantly higher.
 	MaxFileCacheBytes int64 `status:"experimental"`
 
+	// MemoryLimit sets a soft memory limit (in bytes) for the gopls process, via
+	// runtime/debug.SetMemoryLimit. If zero (the default), no limit is set.
+	//
+	// On large workspaces, a single edit that invalidates many packages (for
+	// example a syntax error in a widely-imported package) can make the heap
+	// briefly grow well above the steady-state working set before the garbage
+	// collector catches up, spiking memory and, on memory-constrained machines,
+	// causing swap. A soft limit makes the GC work harder to stay near the limit,
+	// trading some CPU for a lower memory peak.
+	//
+	// The limit is soft and may be exceeded; set it comfortably above the
+	// steady-state working set, as too low a value causes excessive GC.
+	MemoryLimit int64 `status:"experimental"`
+
 	// VerboseOutput enables additional debug logging.
 	VerboseOutput bool `status:"debug"`
 }
@@ -1327,6 +1341,9 @@ func (o *Options) setOne(name string, value any) (applied []CounterPath, _ error
 
 	case "maxFileCacheBytes":
 		return setInt64(&o.MaxFileCacheBytes, value)
+
+	case "memoryLimit":
+		return setInt64(&o.MemoryLimit, value)
 
 	case "verboseOutput":
 		return setBool(&o.VerboseOutput, value)


### PR DESCRIPTION
Reduces gopls memory when an edit invalidates a large reverse-dependency closure
(forcing many packages to be re-type-checked), motivated by large monorepos.

Each commit stands alone:

- **xrefs**: build the index with a transient `ast.Preorder` walk instead of the
  cached per-file inspector (which was retained across a whole re-check).
- **cache**: reuse a package's in-batch type-check result when importing it,
  rather than type-checking it a second time.
- **cache**: share one `objectpath.Encoder` per type-check batch so a
  heavily-imported package's object paths are encoded once.
- **settings**: add an opt-in `memoryLimit` setting (soft `debug.SetMemoryLimit`).

Draft for discussion. `cache`, `settings`, `doc/generate`, `marker`, and the
references/rename integration tests pass.