### PR TITLE
go/ssa: don't add parameterized MakeInterface operands to RuntimeTypes

### DIFF
--- a/go/ssa/builder_test.go
+++ b/go/ssa/builder_test.go
@@ -270,6 +270,10 @@ func TestRuntimeTypes(t *testing.T) {
 		{`package N; var g interface{}; func f[S any]() { var v []S; g = v }; `,
 			nil,
 		},
+		// ...including a parameterized type boxed by a closure in the body of a method of a generic type (go.dev/issue/80055).
+		{`package O; type box[N any] struct{ n N }; type holder[N any] struct{}; func (h *holder[N]) get() any { f := func() any { return &box[N]{} }; return f() }`,
+			nil,
+		},
 	}
 	for _, test := range tests {
 		// Parse the file.

--- a/go/ssa/emit.go
+++ b/go/ssa/emit.go
@@ -247,8 +247,19 @@ func emitConv(f *Function, val Value, typ types.Type) Value {
 
 		// Record the types of operands to MakeInterface, if
 		// non-parameterized, as they are the set of runtime types.
+		//
+		// We must consult isParameterized even when f.hasTypeParams()
+		// reports false: an anonymous function nested within a method of
+		// a generic type does not itself carry the enclosing method's
+		// receiver type parameters (the closure built in (*builder).expr0
+		// inherits the parent's typeparams/typeargs but not its
+		// recvtypeparams), so f.hasTypeParams() is false for such a
+		// closure even though its body may box a parameterized type such
+		// as *box[N] into an interface. Recording that type would later
+		// cause Program.RuntimeTypes (via ForEachElement) to panic on the
+		// bare type parameter. See go.dev/issue/80055.
 		t := val.Type()
-		if !f.hasTypeParams() || !f.Prog.isParameterized(t) {
+		if !f.Prog.isParameterized(t) {
 			addMakeInterfaceType(f.Prog, t)
 		}
 


### PR DESCRIPTION
emitConv recorded a MakeInterface operand as a runtime type whenever
the enclosing function had no type parameters. That is wrong for a
closure nested in a method of a generic type: such a closure inherits
the parent's typeparams but not its recvtypeparams, so hasTypeParams
reports false even though its body may box a parameterized type like
*box[N]. Recording it later made Program.RuntimeTypes (via
ForEachElement) panic:

	panic: ForEachElement called on type containing *types.TypeParam

fix is to switch only on isParameterized, the invariant ForEachElement requires.

Fixes golang/go#80055
Updates golang/go#80059