### PR TITLE
go/analysis/passes/modernize: skip WaitGroup.Go rewrite when defer can recover

### DIFF
--- a/go/analysis/passes/modernize/modernize.go
+++ b/go/analysis/passes/modernize/modernize.go
@@ -132,6 +132,7 @@ var (
 	builtinMake    = types.Universe.Lookup("make")
 	builtinNew     = types.Universe.Lookup("new")
 	builtinNil     = types.Universe.Lookup("nil")
+	builtinRecover = types.Universe.Lookup("recover")
 	builtinString  = types.Universe.Lookup("string")
 	builtinTrue    = types.Universe.Lookup("true")
 	byteSliceType  = types.NewSlice(types.Typ[types.Byte])

--- a/go/analysis/passes/modernize/testdata/src/waitgroupgo/waitgroup.go
+++ b/go/analysis/passes/modernize/testdata/src/waitgroupgo/waitgroup.go
@@ -49,6 +49,45 @@ func _() {
 			wg.Done()
 		}()
 	}
+
+	wg.Add(1)
+	go func() { // want "Goroutine creation can be simplified using WaitGroup.Go"
+		defer func() {
+			println("cleanup")
+		}()
+		fmt.Println()
+		wg.Done()
+	}()
+
+	wg.Add(1)
+	go func() { // want "Goroutine creation can be simplified using WaitGroup.Go"
+		defer func() {
+			recover := func() {}
+			recover()
+		}()
+		fmt.Println()
+		wg.Done()
+	}()
+
+	wg.Add(1)
+	go func() { // want "Goroutine creation can be simplified using WaitGroup.Go"
+		defer func() {
+			func() {
+				recover()
+			}()
+		}()
+		fmt.Println()
+		wg.Done()
+	}()
+
+	wg.Add(1)
+	go func() { // want "Goroutine creation can be simplified using WaitGroup.Go"
+		func() {
+			defer cleanup()
+		}()
+		fmt.Println()
+		wg.Done()
+	}()
 }
 
 // this function puts some wrong usages but waitgroupgo modernizer will still offer fixes.
@@ -162,7 +201,25 @@ func _() {
 		wg.Done()
 		return 0
 	}()
+
+	wg.Add(1) // noop: deferred recover changes panic/Done semantics.
+	go func() {
+		defer func() {
+			recover()
+		}()
+		panic("x")
+		wg.Done()
+	}()
+
+	wg.Add(1) // noop: named-function defer may recover.
+	go func() {
+		defer cleanup()
+		fmt.Println()
+		wg.Done()
+	}()
 }
+
+func cleanup() {}
 
 type Server struct {
 	wg sync.WaitGroup

--- a/go/analysis/passes/modernize/testdata/src/waitgroupgo/waitgroup.go.golden
+++ b/go/analysis/passes/modernize/testdata/src/waitgroupgo/waitgroup.go.golden
@@ -37,6 +37,37 @@ func _() {
 			fmt.Println()
 		})
 	}
+
+	wg.Go(func() { // want "Goroutine creation can be simplified using WaitGroup.Go"
+		defer func() {
+			println("cleanup")
+		}()
+		fmt.Println()
+	})
+
+	wg.Go(func() { // want "Goroutine creation can be simplified using WaitGroup.Go"
+		defer func() {
+			recover := func() {}
+			recover()
+		}()
+		fmt.Println()
+	})
+
+	wg.Go(func() { // want "Goroutine creation can be simplified using WaitGroup.Go"
+		defer func() {
+			func() {
+				recover()
+			}()
+		}()
+		fmt.Println()
+	})
+
+	wg.Go(func() { // want "Goroutine creation can be simplified using WaitGroup.Go"
+		func() {
+			defer cleanup()
+		}()
+		fmt.Println()
+	})
 }
 
 // this function puts some wrong usages but waitgroupgo modernizer will still offer fixes.
@@ -144,7 +175,25 @@ func _() {
 		wg.Done()
 		return 0
 	}()
+
+	wg.Add(1) // noop: deferred recover changes panic/Done semantics.
+	go func() {
+		defer func() {
+			recover()
+		}()
+		panic("x")
+		wg.Done()
+	}()
+
+	wg.Add(1) // noop: named-function defer may recover.
+	go func() {
+		defer cleanup()
+		fmt.Println()
+		wg.Done()
+	}()
 }
+
+func cleanup() {}
 
 type Server struct {
 	wg sync.WaitGroup

--- a/go/analysis/passes/modernize/waitgroupgo.go
+++ b/go/analysis/passes/modernize/waitgroupgo.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"go/ast"
 	"go/printer"
+	"go/types"
 	"slices"
 
 	"golang.org/x/tools/go/analysis"
@@ -112,7 +113,7 @@ func waitgroup(pass *analysis.Pass) (any, error) {
 			astutil.EqualSyntax(ast.Unparen(deferStmt.Call.Fun).(*ast.SelectorExpr).X, addCallRecv) {
 			doneStmt = deferStmt // "defer wg.Done()"
 
-		} else if lastStmt, ok := list[len(list)-1].(*ast.ExprStmt); ok {
+		} else if lastStmt, ok := list[len(list)-1].(*ast.ExprStmt); ok && cannotRecover(lit.Body, info) {
 			if doneCall, ok := lastStmt.X.(*ast.CallExpr); ok &&
 				typeutil.Callee(info, doneCall) == syncWaitGroupDone &&
 				astutil.EqualSyntax(ast.Unparen(doneCall.Fun).(*ast.SelectorExpr).X, addCallRecv) {
@@ -174,4 +175,45 @@ func waitgroup(pass *analysis.Pass) (any, error) {
 		})
 	}
 	return nil, nil
+}
+
+// cannotRecover reports whether no panic arising in body can be
+// recovered. It conservatively treats a defer of anything but a
+// recover-free function literal (e.g. a named function) as able to recover.
+func cannotRecover(body *ast.BlockStmt, info *types.Info) bool {
+	res := true
+	ast.Inspect(body, func(n ast.Node) bool {
+		switch n := n.(type) {
+		case *ast.DeferStmt:
+			lit, ok := ast.Unparen(n.Call.Fun).(*ast.FuncLit)
+			if !ok || containsRecover(lit.Body, info) {
+				res = false
+			}
+			// Each defer is fully handled here; don't descend into it.
+			return false
+		case *ast.FuncLit:
+			// Defers in nested functions cannot recover panics from this body.
+			return false
+		}
+		return true
+	})
+	return res
+}
+
+func containsRecover(body *ast.BlockStmt, info *types.Info) bool {
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		switch n := n.(type) {
+		case *ast.CallExpr:
+			if typeutil.Callee(info, n) == builtinRecover {
+				found = true
+				return false
+			}
+		case *ast.FuncLit:
+			// Recover calls in nested functions cannot recover panics from body.
+			return false
+		}
+		return true
+	})
+	return found
 }


### PR DESCRIPTION
Rewriting a goroutine's trailing wg.Done() to WaitGroup.Go moves the
Done call into WaitGroup.Go's own deferred call. When the goroutine
can recover a panic, this changes behavior: the original may never
reach wg.Done(), leaving Wait blocked forever. Only apply the rewrite
when the goroutine cannot recover, that is, when every defer calls a
function literal whose body does not call the built-in recover.

Fixes golang/go#77559