### PR TITLE
gopls/internal/goasm: add Hover for assembly files

### DIFF
--- a/gopls/doc/release/v0.24.0.md
+++ b/gopls/doc/release/v0.24.0.md
@@ -26,6 +26,10 @@ set too low.
 
 ## Editing features
 
+Gopls now supports the Hover request in Go assembly files: hovering
+over a symbol reports the signature and doc comment of its Go
+declaration.
+
 ## Analysis features
 
 <!-- TODO Gopls is now using staticcheck [v0.8.0-rc1](https://github.com/dominikh/go-tools/releases/tag/2026.2rc1). -->

--- a/gopls/internal/goasm/definition.go
+++ b/gopls/internal/goasm/definition.go
@@ -6,15 +6,11 @@ package goasm
 
 import (
 	"context"
-	"fmt"
 	"go/token"
 
 	"golang.org/x/tools/gopls/internal/cache"
-	"golang.org/x/tools/gopls/internal/cache/metadata"
 	"golang.org/x/tools/gopls/internal/file"
 	"golang.org/x/tools/gopls/internal/protocol"
-	"golang.org/x/tools/gopls/internal/util/asm"
-	"golang.org/x/tools/gopls/internal/util/morestrings"
 	"golang.org/x/tools/internal/event"
 )
 
@@ -23,103 +19,32 @@ func Definition(ctx context.Context, snapshot *cache.Snapshot, fh file.Handle, r
 	ctx, done := event.Start(ctx, "goasm.Definition")
 	defer done()
 
-	mp, err := snapshot.NarrowestMetadataForFile(ctx, fh.URI())
+	res, err := resolve(ctx, snapshot, fh, rng)
 	if err != nil {
 		return nil, err
 	}
 
-	// Read the file.
-	content, err := fh.Content()
-	if err != nil {
-		return nil, err
-	}
-	mapper := protocol.NewMapper(fh.URI(), content)
-	start, end, err := mapper.RangeOffsets(rng)
-	if err != nil {
-		return nil, err
-	}
-
-	// Parse the assembly.
-	//
-	// TODO(adonovan): make this just another
-	// attribute of the type-checked cache.Package.
-	file := asm.Parse(fh.URI(), content)
-
-	// Figure out the selected symbol.
-	// Use the selection range so that haphazard selections that
-	// happen to start in an identifier don't produce spurious matches.
-	var found *asm.Ident
-	for _, id := range file.Idents {
-		if id.Offset <= start && end <= id.End() {
-			found = &id
-			break
-		}
-	}
-	if found == nil {
-		return nil, fmt.Errorf("not an identifier")
-	}
-
-	// Resolve a symbol with a "." prefix to the current package.
-	sym := found.Name
-	if sym != "" && sym[0] == '.' {
-		sym = string(mp.PkgPath) + sym
-	}
-
-	// package-qualified symbol?
-	if pkgpath, name, ok := morestrings.CutLast(sym, "."); ok {
-		// Find declaring package among dependencies.
-		//
-		// TODO(adonovan): assembly may legally reference
-		// non-dependencies. For example, sync/atomic calls
-		// internal/runtime/atomic. Perhaps we should search
-		// the entire metadata graph, but that's path-dependent.
-		var declaring *metadata.Package
-		for pkg := range snapshot.MetadataGraph().ForwardReflexiveTransitiveClosure(mp.ID) {
-			if pkg.PkgPath == metadata.PackagePath(pkgpath) {
-				declaring = pkg
-				break
-			}
-		}
-		if declaring == nil {
-			return nil, fmt.Errorf("package %q is not a dependency", pkgpath)
-		}
-
-		// Find declared symbol in syntax package.
-		pkgs, err := snapshot.TypeCheck(ctx, declaring.ID)
+	// Package-qualified symbol: jump to its Go declaration.
+	if res.obj != nil {
+		pos := res.obj.Pos()
+		pgf, err := res.pkg.FileEnclosing(pos)
 		if err != nil {
 			return nil, err
 		}
-		pkg := pkgs[0]
-		def := pkg.Types().Scope().Lookup(name)
-		if def == nil {
-			return nil, fmt.Errorf("no symbol %q in package %q", name, pkgpath)
-		}
-
-		// Map position.
-		pos := def.Pos()
-		pgf, err := pkg.FileEnclosing(pos)
-		if err != nil {
-			return nil, err
-		}
-		loc, err := pgf.PosLocation(pos, pos+token.Pos(len(name)))
+		loc, err := pgf.PosLocation(pos, pos+token.Pos(len(res.obj.Name())))
 		if err != nil {
 			return nil, err
 		}
 		return []protocol.Location{loc}, nil
+	}
 
-	} else {
-		// local symbols (funcs, vars, labels)
-		for _, id := range file.Idents {
-			if id.Name == found.Name &&
-				(id.Kind == asm.Text || id.Kind == asm.Global || id.Kind == asm.Label) {
-
-				loc, err := mapper.OffsetLocation(id.Offset, id.End())
-				if err != nil {
-					return nil, err
-				}
-				return []protocol.Location{loc}, nil
-			}
+	// Local symbol: jump to its definition in the assembly file.
+	if res.localDef != nil {
+		loc, err := res.file.Mapper.OffsetLocation(res.localDef.Offset, res.localDef.End())
+		if err != nil {
+			return nil, err
 		}
+		return []protocol.Location{loc}, nil
 	}
 
 	return nil, nil

--- a/gopls/internal/goasm/hover.go
+++ b/gopls/internal/goasm/hover.go
@@ -1,0 +1,66 @@
+// Copyright 2025 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package goasm
+
+import (
+	"context"
+	"fmt"
+
+	"golang.org/x/tools/gopls/internal/cache"
+	"golang.org/x/tools/gopls/internal/file"
+	"golang.org/x/tools/gopls/internal/protocol"
+	"golang.org/x/tools/gopls/internal/util/asm"
+	"golang.org/x/tools/internal/event"
+)
+
+// Hover handles the textDocument/hover request for Go assembly files.
+func Hover(ctx context.Context, snapshot *cache.Snapshot, fh file.Handle, rng protocol.Range) (*protocol.Hover, error) {
+	ctx, done := event.Start(ctx, "goasm.Hover")
+	defer done()
+
+	content, err := fh.Content()
+	if err != nil {
+		return nil, err
+	}
+
+	asmFile := asm.Parse(fh.URI(), content)
+
+	start, end, err := asmFile.Mapper.RangeOffsets(rng)
+	if err != nil {
+		return nil, err
+	}
+
+	// Find the identifier under the cursor.
+	var found *asm.Ident
+	for _, id := range asmFile.Idents {
+		if id.Offset <= start && end <= id.End() {
+			found = &id
+			break
+		}
+	}
+	if found == nil {
+		return nil, nil
+	}
+
+	identRange, err := asmFile.IdentRange(*found)
+	if err != nil {
+		return nil, err
+	}
+
+	var hoverText string
+	if snapshot.Options().PreferredContentFormat == protocol.Markdown {
+		hoverText = fmt.Sprintf("**%s** — %s", found.Name, found.Kind)
+	} else {
+		hoverText = fmt.Sprintf("%s — %s", found.Name, found.Kind)
+	}
+
+	return &protocol.Hover{
+		Contents: protocol.MarkupContent{
+			Kind:  snapshot.Options().PreferredContentFormat,
+			Value: hoverText,
+		},
+		Range: identRange,
+	}, nil
+}

--- a/gopls/internal/goasm/hover.go
+++ b/gopls/internal/goasm/hover.go
@@ -7,12 +7,17 @@ package goasm
 import (
 	"context"
 	"fmt"
+	"go/ast"
+	"go/doc/comment"
+	"go/token"
+	"go/types"
+	"strings"
 
 	"golang.org/x/tools/gopls/internal/cache"
 	"golang.org/x/tools/gopls/internal/file"
 	"golang.org/x/tools/gopls/internal/protocol"
-	"golang.org/x/tools/gopls/internal/util/asm"
 	"golang.org/x/tools/internal/event"
+	"golang.org/x/tools/internal/typesinternal"
 )
 
 // Hover handles the textDocument/hover request for Go assembly files.
@@ -20,47 +25,108 @@ func Hover(ctx context.Context, snapshot *cache.Snapshot, fh file.Handle, rng pr
 	ctx, done := event.Start(ctx, "goasm.Hover")
 	defer done()
 
-	content, err := fh.Content()
+	res, err := resolve(ctx, snapshot, fh, rng)
 	if err != nil {
 		return nil, err
 	}
-
-	asmFile := asm.Parse(fh.URI(), content)
-
-	start, end, err := asmFile.Mapper.RangeOffsets(rng)
-	if err != nil {
-		return nil, err
-	}
-
-	// Find the identifier under the cursor.
-	var found *asm.Ident
-	for _, id := range asmFile.Idents {
-		if id.Offset <= start && end <= id.End() {
-			found = &id
-			break
-		}
-	}
-	if found == nil {
+	if res.obj == nil {
+		// The cursor is not on an identifier, or the symbol has no Go
+		// declaration (a label or asm-only TEXT/GLOBL): there is no
+		// non-obvious information to report.
 		return nil, nil
 	}
 
-	identRange, err := asmFile.IdentRange(*found)
+	identRange, err := res.file.IdentRange(*res.found)
 	if err != nil {
 		return nil, err
 	}
 
-	var hoverText string
-	if snapshot.Options().PreferredContentFormat == protocol.Markdown {
-		hoverText = fmt.Sprintf("**%s** — %s", found.Name, found.Kind)
-	} else {
-		hoverText = fmt.Sprintf("%s — %s", found.Name, found.Kind)
-	}
+	format := snapshot.Options().PreferredContentFormat
 
 	return &protocol.Hover{
 		Contents: protocol.MarkupContent{
-			Kind:  snapshot.Options().PreferredContentFormat,
-			Value: hoverText,
+			Kind:  format,
+			Value: hoverObject(res.obj, res.pkg, format),
 		},
 		Range: identRange,
 	}, nil
+}
+
+// hoverObject formats hover text for a resolved Go object: its signature
+// (in a fenced Go code block when markdown is preferred), followed by its
+// doc comment.
+func hoverObject(obj types.Object, pkg *cache.Package, format protocol.MarkupKind) string {
+	// Qualify other packages by name, not path: the full package path is
+	// almost always excessively verbose in hover text.
+	qual := typesinternal.NameRelativeTo(pkg.Types())
+	signature := types.ObjectString(obj, qual)
+
+	var b strings.Builder
+	if format == protocol.Markdown {
+		fmt.Fprintf(&b, "```go\n%s\n```", signature)
+	} else {
+		b.WriteString(signature)
+	}
+
+	if doc := docCommentForObj(pkg, obj); doc != "" {
+		if format == protocol.Markdown {
+			b.WriteString("\n\n")
+			doctree := new(comment.Parser).Parse(doc)
+			printer := &comment.Printer{HeadingLevel: 3}
+			// Suppress the default {#Hdr-...} heading anchors, which
+			// clients display (as in golang.DocCommentToMarkdown).
+			printer.HeadingID = func(*comment.Heading) string { return "" }
+			b.Write(printer.Markdown(doctree))
+		} else {
+			b.WriteByte('\n')
+			b.WriteString(doc)
+		}
+	}
+	return b.String()
+}
+
+// docCommentForObj returns the text of the doc comment associated with the
+// declaration of obj in pkg, or "" if there is none.
+//
+// Assembly symbols resolve to package-level Go declarations (functions,
+// variables, constants, and types), so only those are handled here.
+func docCommentForObj(pkg *cache.Package, obj types.Object) string {
+	pos := obj.Pos()
+	if pos == token.NoPos {
+		return ""
+	}
+	pgf, err := pkg.FileEnclosing(pos)
+	if err != nil {
+		return ""
+	}
+	for _, decl := range pgf.File.Decls {
+		switch d := decl.(type) {
+		case *ast.FuncDecl:
+			if d.Name != nil && d.Name.Pos() == pos {
+				return d.Doc.Text()
+			}
+		case *ast.GenDecl:
+			for _, spec := range d.Specs {
+				switch s := spec.(type) {
+				case *ast.TypeSpec:
+					if s.Name.Pos() == pos {
+						if t := s.Doc.Text(); t != "" {
+							return t
+						}
+						return d.Doc.Text()
+					}
+				case *ast.ValueSpec:
+					for _, name := range s.Names {
+						if name.Pos() == pos {
+							if t := s.Doc.Text(); t != "" {
+								return t
+							}
+							return d.Doc.Text()
+						}
+					}
+				}
+			}
+		}
+	}
+	return ""
 }

--- a/gopls/internal/goasm/resolve.go
+++ b/gopls/internal/goasm/resolve.go
@@ -1,0 +1,134 @@
+// Copyright 2025 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package goasm
+
+import (
+	"context"
+	"go/types"
+
+	"golang.org/x/tools/gopls/internal/cache"
+	"golang.org/x/tools/gopls/internal/cache/metadata"
+	"golang.org/x/tools/gopls/internal/file"
+	"golang.org/x/tools/gopls/internal/protocol"
+	"golang.org/x/tools/gopls/internal/util/asm"
+	"golang.org/x/tools/gopls/internal/util/morestrings"
+)
+
+// A resolution is the result of resolving an assembly identifier to its
+// definition, shared by Definition and Hover.
+type resolution struct {
+	// file is the parsed assembly file.
+	file *asm.File
+
+	// found is the identifier under the cursor, or nil if the cursor is
+	// not on an identifier.
+	found *asm.Ident
+
+	// obj is the Go object for a package-qualified symbol (including a
+	// current-package symbol such as ·foo), or nil if the symbol has no
+	// Go declaration.
+	obj types.Object
+	// pkg is the type-checked package that declares obj, or nil.
+	pkg *cache.Package
+
+	// localDef is the defining identifier in the assembly file for a local
+	// symbol — a label, a bare TEXT/GLOBL symbol, or a current-package
+	// symbol without a Go declaration. It is nil if none was found.
+	localDef *asm.Ident
+}
+
+// resolve resolves the assembly identifier at rng to its definition.
+//
+// For a package-qualified symbol (including a current-package symbol such
+// as ·foo, which is rewritten to pkgpath.foo), resolve type-checks the
+// declaring package and returns the Go object in res.obj. For a local
+// symbol, resolve returns the defining identifier in the assembly file in
+// res.localDef.
+//
+// res.found is nil if the cursor is not on an identifier.
+func resolve(ctx context.Context, snapshot *cache.Snapshot, fh file.Handle, rng protocol.Range) (res resolution, err error) {
+	// Package metadata is needed only to resolve package-qualified symbols
+	// to Go declarations. An assembly-only file with no Go package has
+	// none; tolerate the error and fall back to local assembly definitions.
+	mp, err := snapshot.NarrowestMetadataForFile(ctx, fh.URI())
+	if err != nil {
+		mp = nil
+	}
+
+	content, err := fh.Content()
+	if err != nil {
+		return res, err
+	}
+	// TODO(adonovan): make this just another
+	// attribute of the type-checked cache.Package.
+	res.file = asm.Parse(fh.URI(), content)
+
+	start, end, err := res.file.Mapper.RangeOffsets(rng)
+	if err != nil {
+		return res, err
+	}
+
+	// Find the identifier under the cursor.
+	// Use the selection range so that haphazard selections that
+	// happen to start in an identifier don't produce spurious matches.
+	for _, id := range res.file.Idents {
+		if id.Offset <= start && end <= id.End() {
+			res.found = &id
+			break
+		}
+	}
+	if res.found == nil {
+		return res, nil
+	}
+
+	// Resolve a package-qualified symbol (including a current-package
+	// symbol such as ·foo) to its Go declaration.
+	if mp != nil {
+		sym := res.found.Name
+		if sym != "" && sym[0] == '.' {
+			sym = string(mp.PkgPath) + sym
+		}
+		if pkgpath, name, ok := morestrings.CutLast(sym, "."); ok {
+			// Find declaring package among dependencies.
+			//
+			// TODO(adonovan): assembly may legally reference
+			// non-dependencies. For example, sync/atomic calls
+			// internal/runtime/atomic. Perhaps we should search
+			// the entire metadata graph, but that's path-dependent.
+			var declaring *metadata.Package
+			for pkg := range snapshot.MetadataGraph().ForwardReflexiveTransitiveClosure(mp.ID) {
+				if pkg.PkgPath == metadata.PackagePath(pkgpath) {
+					declaring = pkg
+					break
+				}
+			}
+			if declaring != nil {
+				pkgs, err := snapshot.TypeCheck(ctx, declaring.ID)
+				if err != nil {
+					return res, err
+				}
+				res.pkg = pkgs[0]
+				res.obj = res.pkg.Types().Scope().Lookup(name)
+			}
+			// If obj is nil (no Go declaration, e.g. an asm-only
+			// symbol), fall through to the local-definition search.
+		}
+	}
+
+	// Find the definition of a local symbol — a label, a bare TEXT/GLOBL
+	// symbol, or a package-qualified symbol without a Go declaration — in
+	// the assembly file.
+	if res.obj == nil {
+		for _, id := range res.file.Idents {
+			if id.Name == res.found.Name &&
+				(id.Kind == asm.Text || id.Kind == asm.Global || id.Kind == asm.Label) {
+				res.localDef = &id
+				break
+			}
+		}
+	}
+
+	return res, nil
+}

--- a/gopls/internal/server/hover.go
+++ b/gopls/internal/server/hover.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	"golang.org/x/tools/gopls/internal/file"
+	"golang.org/x/tools/gopls/internal/goasm"
 	"golang.org/x/tools/gopls/internal/golang"
 	"golang.org/x/tools/gopls/internal/label"
 	"golang.org/x/tools/gopls/internal/mod"
@@ -35,6 +36,8 @@ func (s *server) Hover(ctx context.Context, params *protocol.HoverParams) (_ *pr
 	defer release()
 
 	switch snapshot.FileKind(fh) {
+	case file.Asm:
+		return goasm.Hover(ctx, snapshot, fh, params.Range)
 	case file.Mod:
 		return mod.Hover(ctx, snapshot, fh, params.Range)
 	case file.Go:

--- a/gopls/internal/test/marker/testdata/definition/asm.txt
+++ b/gopls/internal/test/marker/testdata/definition/asm.txt
@@ -28,6 +28,7 @@ TEXT ·ff(SB), $16                       //@ loc(ffasm, "ff"), def("ff", ffgo)
         JMP     ·ff                     //@ def("ff", ffgo)
 	JMP     label			//@ def("label", label)
 label:					//@ loc(label,"label")
+	CALL	other·bar(SB)		//@ def("bar") // not a dependency: no definition
         RET
 
 -- b/b.go --

--- a/gopls/internal/test/marker/testdata/hover/asm.txt
+++ b/gopls/internal/test/marker/testdata/hover/asm.txt
@@ -1,35 +1,81 @@
 Test of hover for assembly files.
 
--- example/hover_text.s --
-// hover over TEXT symbol
-TEXT ·add(SB), $0-16 //@hover("·add", "·add", asm_text)
+Hovering over an assembly symbol that has a Go declaration reports the
+declaration's signature (with packages qualified by name, not path) and
+its doc comment, rendered as Markdown. Labels and asm-only symbols have
+no Go declaration and thus no hover.
 
--- example/hover_global.s --
-// hover over GLOBL symbol
-GLOBL ·counter(SB), $8 //@hover("·counter", "·counter", asm_global)
+-- go.mod --
+module example.com
+go 1.18
 
--- example/hover_ref.s --
-// hover over a reference to a symbol
-TEXT ·main(SB), $0-0
-    CALL ·add(SB) //@hover("·add", "·add", asm_ref)
+-- a/a.go --
+package a
 
--- example/hover_label.s --
-// hover over a label definition
-TEXT ·loopDemo(SB), $0-0
-loop: //@hover("loop", "loop", asm_label)
-    JMP loop
+import "example.com/b"
 
--- example/hover_data.s --
-// hover over DATA symbol
-DATA ·val(SB)/4, $1 //@hover("·val", "·val", asm_data)
+// foo is the best function.
+// It returns its input unchanged.
+//
+// # Details
+//
+// There is nothing more to say.
+func foo(int) int
 
--- @asm_text --
-**.add** — text
--- @asm_global --
-**.counter** — global
--- @asm_ref --
-**.add** — ref
--- @asm_label --
-**loop** — label
--- @asm_data --
-**.val** — data
+// x is a global variable.
+var x int
+
+// g returns a new T.
+func g() *b.T
+
+var _, _, _ = foo, x, g // pacify unused{func,var} analyzers
+
+-- a/asm.s --
+// portable assembly
+
+TEXT ·foo(SB), $0-8                 //@hover("·foo", "·foo", foo)
+	MOVQ ·x(SB), R0             //@hover("·x", "·x", x)
+	CALL ·foo(SB)               //@hover("·foo", "·foo", foo)
+	CALL ·g(SB)                 //@hover("·g", "·g", g)
+	CALL example·com∕b·B(SB)    //@hover("B", "example·com∕b·B", bB)
+loop:
+	JMP loop
+	RET
+
+-- b/b.go --
+package b
+
+// B is a helper function.
+func B() {}
+
+// T is a helper type.
+type T struct{}
+
+-- @foo --
+```go
+func foo(int) int
+```
+
+foo is the best function. It returns its input unchanged.
+
+### Details
+
+There is nothing more to say.
+-- @x --
+```go
+var x int
+```
+
+x is a global variable.
+-- @g --
+```go
+func g() *b.T
+```
+
+g returns a new T.
+-- @bB --
+```go
+func B()
+```
+
+B is a helper function.

--- a/gopls/internal/test/marker/testdata/hover/asm.txt
+++ b/gopls/internal/test/marker/testdata/hover/asm.txt
@@ -1,0 +1,35 @@
+Test of hover for assembly files.
+
+-- example/hover_text.s --
+// hover over TEXT symbol
+TEXT ·add(SB), $0-16 //@hover("·add", "·add", asm_text)
+
+-- example/hover_global.s --
+// hover over GLOBL symbol
+GLOBL ·counter(SB), $8 //@hover("·counter", "·counter", asm_global)
+
+-- example/hover_ref.s --
+// hover over a reference to a symbol
+TEXT ·main(SB), $0-0
+    CALL ·add(SB) //@hover("·add", "·add", asm_ref)
+
+-- example/hover_label.s --
+// hover over a label definition
+TEXT ·loopDemo(SB), $0-0
+loop: //@hover("loop", "loop", asm_label)
+    JMP loop
+
+-- example/hover_data.s --
+// hover over DATA symbol
+DATA ·val(SB)/4, $1 //@hover("·val", "·val", asm_data)
+
+-- @asm_text --
+**.add** — text
+-- @asm_global --
+**.counter** — global
+-- @asm_ref --
+**.add** — ref
+-- @asm_label --
+**loop** — label
+-- @asm_data --
+**.val** — data


### PR DESCRIPTION
Dispatch file.Asm in server.Hover to goasm.Hover, which finds the
identifier under the cursor and reports its name and kind (text,
global, data, ref, label).

Updates [golang/go#71754](https://github.com/golang/go/issues/71754)