### PR TITLE
gopls: escape source link filenames in package doc HTML

### DIFF
--- a/gopls/internal/golang/freesymbols.go
+++ b/gopls/internal/golang/freesymbols.go
@@ -416,5 +416,5 @@ func sourceLink(text, url string) string {
 	// We keep the href attribute as it causes the <a> to render
 	// as a link: blue, underlined, with URL hover information.
 	return fmt.Sprintf(`<a href="%[1]s" onclick='return httpGET("%[1]s")'>%[2]s</a>`,
-		html.EscapeString(url), text)
+		html.EscapeString(url), html.EscapeString(text))
 }

--- a/gopls/internal/golang/freesymbols_test.go
+++ b/gopls/internal/golang/freesymbols_test.go
@@ -130,3 +130,11 @@ func TestFreeRefs(t *testing.T) {
 		})
 	}
 }
+
+func TestSourceLinkSanitizesText(t *testing.T) {
+	got := sourceLink("<img src=x onerror=alert(1)>", "/src?file=x%2Fbad.go&line=1&col=1")
+	want := `<a href="/src?file=x%2Fbad.go&amp;line=1&amp;col=1" onclick='return httpGET("/src?file=x%2Fbad.go&amp;line=1&amp;col=1")'>&lt;img src=x onerror=alert(1)&gt;</a>`
+	if got != want {
+		t.Fatalf("got %q\nwant %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
Escape filenames used in source links in package documentation HTML generation for gopls.

## Changes
- Update package doc HTML link generation to properly escape source filenames.
- Ensure generated links remain valid and safe for filenames with special characters.

## Testing
- Not run (documentation rendering / HTML escaping fix, behavior validated by code review).