### PR TITLE
internal/refactor/inline: make shadowMap gob encoding deterministic

### DIFF
--- a/internal/refactor/inline/callee.go
+++ b/internal/refactor/inline/callee.go
@@ -930,3 +930,48 @@ func (callee *Callee) GobEncode() ([]byte, error) {
 func (callee *Callee) GobDecode(data []byte) error {
 	return gob.NewDecoder(bytes.NewReader(data)).Decode(&callee.impl)
 }
+
+var (
+	_ gob.GobEncoder = shadowMap(nil)
+	_ gob.GobDecoder = (*shadowMap)(nil)
+)
+
+// shadowEntry is the serialized form of a single [shadowMap] entry.
+type shadowEntry struct {
+	Name  string
+	Index int
+}
+
+// GobEncode implements [gob.GobEncoder]. It encodes the map as a slice of
+// entries sorted by name, because the gob encoding of a Go map iterates its
+// keys in an unspecified order. The analysis framework requires the gob
+// encoding of a fact to be deterministic to avoid spurious cache misses in
+// build systems; see golang/go#80237.
+func (s shadowMap) GobEncode() ([]byte, error) {
+	entries := make([]shadowEntry, 0, len(s))
+	for name, index := range s {
+		entries = append(entries, shadowEntry{name, index})
+	}
+	slices.SortFunc(entries, func(x, y shadowEntry) int {
+		return strings.Compare(x.Name, y.Name)
+	})
+	var out bytes.Buffer
+	if err := gob.NewEncoder(&out).Encode(entries); err != nil {
+		return nil, err
+	}
+	return out.Bytes(), nil
+}
+
+// GobDecode implements [gob.GobDecoder].
+func (s *shadowMap) GobDecode(data []byte) error {
+	var entries []shadowEntry
+	if err := gob.NewDecoder(bytes.NewReader(data)).Decode(&entries); err != nil {
+		return err
+	}
+	m := make(shadowMap, len(entries))
+	for _, e := range entries {
+		m[e.Name] = e.Index
+	}
+	*s = m
+	return nil
+}

--- a/internal/refactor/inline/callee_test.go
+++ b/internal/refactor/inline/callee_test.go
@@ -1,0 +1,77 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package inline
+
+import (
+	"bytes"
+	"maps"
+	"testing"
+)
+
+// sampleCallee returns a Callee whose gob-serialized form includes several
+// non-empty shadowMaps (via both object.Shadow and paramInfo.Shadow), which
+// is where non-deterministic map encoding would show up.
+func sampleCallee() *Callee {
+	return &Callee{impl: gobCallee{
+		Name:    "f",
+		PkgPath: "example.com/p",
+		FreeObjs: []object{
+			{Name: "x", Kind: "var", Shadow: shadowMap{
+				"a": 1, "b": 2, "c": -1, "d": 3, "e": -1, "f": 4, "g": 5, "h": -1, "i": 6, "j": 7,
+			}},
+		},
+		Params: []*paramInfo{
+			{Name: "p", Shadow: shadowMap{
+				"k": 1, "l": -1, "m": 2, "n": 3, "o": -1, "q": 4, "r": 5, "s": -1, "t": 6, "u": 7,
+			}},
+		},
+	}}
+}
+
+// TestCalleeGobEncodeDeterministic verifies that the gob encoding of a Callee
+// is byte-for-byte stable across repeated encodings. The analysis framework
+// requires deterministic fact encoding to avoid spurious cache misses in build
+// systems (e.g. Bazel nogo). See golang/go#80237.
+func TestCalleeGobEncodeDeterministic(t *testing.T) {
+	callee := sampleCallee()
+
+	first, err := callee.GobEncode()
+	if err != nil {
+		t.Fatalf("GobEncode failed: %v", err)
+	}
+	for i := range 100 {
+		got, err := callee.GobEncode()
+		if err != nil {
+			t.Fatalf("GobEncode failed on iteration %d: %v", i, err)
+		}
+		if !bytes.Equal(first, got) {
+			t.Fatalf("GobEncode is non-deterministic: encoding %d differs from the first encoding", i)
+		}
+	}
+}
+
+// TestCalleeGobRoundTrip verifies that encoding then decoding a Callee
+// preserves the contents of its shadowMaps.
+func TestCalleeGobRoundTrip(t *testing.T) {
+	want := sampleCallee()
+
+	data, err := want.GobEncode()
+	if err != nil {
+		t.Fatalf("GobEncode failed: %v", err)
+	}
+	var got Callee
+	if err := got.GobDecode(data); err != nil {
+		t.Fatalf("GobDecode failed: %v", err)
+	}
+
+	if !maps.Equal(got.impl.FreeObjs[0].Shadow, want.impl.FreeObjs[0].Shadow) {
+		t.Errorf("object.Shadow round-trip mismatch:\n got %v\nwant %v",
+			got.impl.FreeObjs[0].Shadow, want.impl.FreeObjs[0].Shadow)
+	}
+	if !maps.Equal(got.impl.Params[0].Shadow, want.impl.Params[0].Shadow) {
+		t.Errorf("paramInfo.Shadow round-trip mismatch:\n got %v\nwant %v",
+			got.impl.Params[0].Shadow, want.impl.Params[0].Shadow)
+	}
+}


### PR DESCRIPTION
The inline analyzer serializes Callee values as analysis facts using
gob. The shadowMap type (map[string]int) relied on gob's default map
encoding, which iterates keys in an unspecified order and thus produced
non-deterministic output. This caused spurious cache misses in build
systems that rely on content-addressable fact storage, such as Bazel's
nogo runner.

Encode shadowMap as a slice of entries sorted by name so that the gob
encoding of a Callee fact is deterministic.

Fixes golang/go#80237
