### PR TITLE
gopls/doc: fix broken links in editor and release docs

### DIFF
--- a/gopls/doc/editor/emacs.md
+++ b/gopls/doc/editor/emacs.md
@@ -59,7 +59,7 @@ Mode, this behavior can be configured using the `lsp-auto-guess-root` setting.
 
 ### Configuring `gopls` via LSP Mode
 
-See [settings](../settings) for information about available gopls settings.
+See [settings](../settings.md) for information about available gopls settings.
 
 Stable gopls settings have corresponding configuration variables in `lsp-mode`.
 For example, `(setq lsp-gopls-use-placeholders nil)` will disable placeholders
@@ -123,7 +123,7 @@ Eglot.
 
 ### Configuring `gopls` via Eglot
 
-See [settings](../settings) for information about available gopls settings.
+See [settings](../settings.md) for information about available gopls settings.
 
 LSP server settings are controlled by the `eglot-workspace-configuration`
 variable, which can be set either globally in `.emacs` or in a `.dir-locals.el` file in the project root.

--- a/gopls/doc/editor/vim.md
+++ b/gopls/doc/editor/vim.md
@@ -131,7 +131,7 @@ a `go.mod` file. See the
 [coc.nvim documentation](https://github.com/neoclide/coc.nvim/wiki/Using-workspaceFolders)
 for more details.
 
-Other [settings](../settings) can be added in `initializationOptions` too.
+Other [settings](../settings.md) can be added in `initializationOptions` too.
 
 The `editor.action.organizeImport` code action will auto-format code and add missing imports. To run this automatically on save, add the following line to your `init.vim`:
 

--- a/gopls/doc/release/v0.17.0.md
+++ b/gopls/doc/release/v0.17.0.md
@@ -48,7 +48,7 @@ automatic toolchain upgrades (see above).
 
 Starting with gopls@v0.18.0, we will officially support integrating with only
 the 2 most recent major versions of the `go` command. This is consistent with
-the Go support policy. See [issue 69321](/issue/69321) (or [this
+the Go support policy. See [issue 69321](https://go.dev/issue/69321) (or [this
 comment](https://github.com/golang/go/issues/69321#issuecomment-2344996677)
 specifically) for details.
 


### PR DESCRIPTION
The vim and emacs editor docs link to `../settings` (3 occurrences), which does not resolve on GitHub's rendered view — the file is `gopls/doc/settings.md`.

The v0.17.0 release notes link issue 69321 with the site-absolute path `/issue/69321`, which only resolves when the page is served on go.dev; the doc is read on GitHub, so use the full `https://go.dev/issue/69321` URL (matching the adjacent full-URL link in the same sentence).

Docs-only; verified each target exists. Found via a mechanical link audit that resolves every relative markdown link against the filesystem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)