### PR TITLE
gopls/internal/golang: suggest smart variable names during extract refactoring

### DIFF
--- a/gopls/internal/golang/extract.go
+++ b/gopls/internal/golang/extract.go
@@ -16,6 +16,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/ast/edge"
@@ -76,8 +77,9 @@ func extractVariable(pkg *cache.Package, pgf *parsego.File, start, end token.Pos
 	}
 	constant := info.Types[expr0].Value != nil
 
-	// Generate name(s) for new declaration.
-	baseName := cond(constant, "newConst", "newVar")
+	// Generate name for new declaration.
+	rawBaseName := suggestBaseName(info, expr0)
+	baseName := cleanVarName(rawBaseName, constant)
 	var lhsNames []string
 	switch expr := expr0.(type) {
 	case *ast.CallExpr:
@@ -90,11 +92,25 @@ func extractVariable(pkg *cache.Package, pgf *parsego.File, start, end token.Pos
 
 		} else {
 			// call with multiple results
-			idx := 0
-			for range tup.Len() {
-				// Generate a unique variable for each result.
-				var name string
-				name, idx = generateName(idx, baseName, hasCollision)
+			usedNames := make(map[string]bool)
+			collisionWithUsed := func(name string) bool {
+				return usedNames[name] || hasCollision(name)
+			}
+
+			for idx := range tup.Len() {
+				v := tup.At(idx)
+				var elemBaseName string
+
+				if idx == 0 && rawBaseName != "" {
+					elemBaseName = baseName
+				}
+
+				if elemBaseName == "" {
+					elemBaseName = cleanVarName(suggestBaseNameFromType(v.Type()), false)
+				}
+
+				name, _ := generateName(0, elemBaseName, collisionWithUsed)
+				usedNames[name] = true
 				lhsNames = append(lhsNames, name)
 			}
 		}
@@ -262,6 +278,183 @@ Outer:
 	return fset, &analysis.SuggestedFix{
 		TextEdits: textEdits,
 	}, nil
+}
+
+// cleanVarName returns a formatted lower camelCase variable name derived from raw.
+// If raw is empty, it falls back to a default name ("newConst" if constant is true, otherwise "newVar").
+func cleanVarName(raw string, constant bool) string {
+	if raw != "" {
+		return lowerName(raw)
+	}
+
+	return cond(constant, "newConst", "newVar")
+}
+
+// suggestBaseName returns a raw candidate variable name for an expression.
+// To avoid generating noisy names, it returns "" unless it finds a high-confidence match.
+//
+// Checks in order:
+//  1. Function calls: extracts the name only if it starts with a recognized prefix
+//     (like "get" or "fetch") and strips it ('getUsers()' -> 'Users').
+//  2. Field selectors: uses the field name, ignoring method calls ('user.Name' -> 'Name').
+//  3. Identifiers: uses the name as-is.
+//  4. Expression type: falls back to [suggestBaseNameFromType].
+//
+// The returned string is raw and should be passed to [cleanVarName].
+func suggestBaseName(info *types.Info, expr ast.Expr) string {
+	if call, ok := expr.(*ast.CallExpr); ok {
+		var funcName string
+		switch fn := call.Fun.(type) {
+		case *ast.Ident:
+			funcName = fn.Name
+		case *ast.SelectorExpr:
+			funcName = fn.Sel.Name
+		}
+
+		if funcName != "" {
+			if cleaned := stripFuncPrefixes(funcName); cleaned != "" {
+				return cleaned
+			}
+		}
+	}
+
+	if sel, ok := expr.(*ast.SelectorExpr); ok {
+		if tv, ok := info.Types[sel]; ok && tv.IsValue() {
+			if _, isSelection := info.Selections[sel]; !isSelection || info.Selections[sel].Kind() != types.MethodVal {
+				return sel.Sel.Name
+			}
+		}
+	}
+
+	if id, ok := expr.(*ast.Ident); ok {
+		return id.Name
+	}
+
+	if tv, ok := info.Types[expr]; ok && tv.Type != nil {
+		if tName := suggestBaseNameFromType(tv.Type); tName != "" {
+			return tName
+		}
+	}
+
+	return ""
+}
+
+// prefixes is a list of common action prefixes stripped from function names
+// to produce cleaner candidate variable names.
+var prefixes = []string{"get", "fetch", "read", "parse", "extract", "calculate", "new", "create"}
+
+// stripFuncPrefixes removes common action prefixes (such as "get", "fetch", "new")
+// from a function name to produce a cleaner variable name.
+func stripFuncPrefixes(name string) string {
+	lowerName := strings.ToLower(name)
+
+	for _, p := range prefixes {
+		if strings.HasPrefix(lowerName, p) && len(name) > len(p) {
+			return name[len(p):]
+		}
+	}
+
+	return ""
+}
+
+// suggestBaseNameFromType returns a raw candidate variable name based on type t.
+// It returns "" for anonymous or vague types where a candidate name would likely be noise.
+//
+// Checks in order:
+//  1. Known types: returns idiomatic names ('error' -> 'err').
+//  2. Named types: uses the type name ('User' -> 'User').
+//  3. Pointers: unwraps element type ('*Config' -> 'Config' -> 'Config').
+//  4. Containers: delegates to [containerVarName] ('[]Item' -> 'Items').
+//
+// The returned string is raw and should be passed to [cleanVarName].
+func suggestBaseNameFromType(t types.Type) string {
+	if t == nil {
+		return ""
+	}
+
+	if s := wellKnownVarName(t); s != "" {
+		return s
+	}
+
+	switch tt := t.(type) {
+	case *types.Named:
+		return tt.Obj().Name()
+	case *types.Pointer:
+		return suggestBaseNameFromType(tt.Elem())
+	}
+
+	if s := containerVarName(t); s != "" {
+		return s
+	}
+
+	return ""
+}
+
+// wellKnownVarName returns idiomatic variable names for well-known types,
+// such as "err" for error types.
+func wellKnownVarName(t types.Type) string {
+	if types.Identical(t, errorType) {
+		return "err"
+	}
+
+	return ""
+}
+
+// containerVarName returns a name for slices, arrays, and channels.
+// Slices and arrays get an "s" suffix ('Item' -> 'Items'), while channels
+// use the element name as-is ('Event' -> 'Event').
+//
+// Simple "s" suffixing stays lightweight and avoids complex pluralization rules,
+// even if it occasionally produces minor typos (e.g., "entitys").
+func containerVarName(t types.Type) string {
+	switch tt := t.Underlying().(type) {
+	case *types.Array:
+		if elemName := suggestBaseNameFromType(tt.Elem()); elemName != "" {
+			return elemName + "s"
+		}
+	case *types.Slice:
+		if elemName := suggestBaseNameFromType(tt.Elem()); elemName != "" {
+			return elemName + "s"
+		}
+	case *types.Chan:
+		if elemName := suggestBaseNameFromType(tt.Elem()); elemName != "" {
+			return elemName
+		}
+	}
+
+	return ""
+}
+
+// lowerName converts an initial upper-case segment or acronym in s to lower case,
+// preserving camelCase formatting (e.g., "URLString" becomes "urlString", "HTTP" becomes "http").
+func lowerName(s string) string {
+	if s == "" {
+		return ""
+	}
+
+	runes := []rune(s)
+	n := 0
+	for n < len(runes) && unicode.IsUpper(runes[n]) {
+		n++
+	}
+
+	if n == 0 {
+		return s
+	}
+
+	if n == len(runes) {
+		return strings.ToLower(s)
+	}
+
+	if n > 1 {
+		n--
+	}
+
+	for i := 0; i < n; i++ {
+		runes[i] = unicode.ToLower(runes[i])
+	}
+
+	return string(runes)
 }
 
 // stmtToInsertVarBefore returns the ast.Stmt before which we can safely insert a new variable,
@@ -529,11 +722,23 @@ func freshNameOutsideRange(info *types.Info, file *ast.File, pos, start, end tok
 	})
 }
 
+// generateName attempts to form a unique, valid variable name by appending a numeric
+// suffix (derived from idx) to the given prefix.
+//
+// It automatically increments the suffix index if the generated name collides with a Go keyword
+// or if hasCollision returns true for that name (indicating a collision with an existing variable
+// or another variable generated in the same scope).
+//
+// Returns the unique name and the next available index to use for subsequent name generations.
 func generateName(idx int, prefix string, hasCollision func(string) bool) (string, int) {
 	name := prefix
 	if idx != 0 {
 		name += fmt.Sprintf("%d", idx)
+	} else if token.IsKeyword(name) {
+		idx++
+		name = fmt.Sprintf("%v%d", prefix, idx)
 	}
+
 	for hasCollision(name) {
 		idx++
 		name = fmt.Sprintf("%v%d", prefix, idx)

--- a/gopls/internal/test/marker/testdata/codeaction/extract_variable-67905.txt
+++ b/gopls/internal/test/marker/testdata/codeaction/extract_variable-67905.txt
@@ -25,5 +25,5 @@ func main() {
 -- @type_switch_func_call/extract_switch.go --
 @@ -10 +10,2 @@
 -	switch r := f().(type) { //@codeaction("f()", "refactor.extract.variable", edit=type_switch_func_call)
-+	newVar := f()
-+	switch r := newVar.(type) { //@codeaction("f()", "refactor.extract.variable", edit=type_switch_func_call)
++	reader := f()
++	switch r := reader.(type) { //@codeaction("f()", "refactor.extract.variable", edit=type_switch_func_call)

--- a/gopls/internal/test/marker/testdata/codeaction/extract_variable.txt
+++ b/gopls/internal/test/marker/testdata/codeaction/extract_variable.txt
@@ -51,8 +51,8 @@ func _() {
 -- @func_call2/func_call.go --
 @@ -8 +8,2 @@
 -	b, err := strconv.Atoi(str) //@codeaction("strconv.Atoi(str)", "refactor.extract.variable", edit=func_call2)
-+	newVar, newVar1 := strconv.Atoi(str)
-+	b, err := newVar, newVar1 //@codeaction("strconv.Atoi(str)", "refactor.extract.variable", edit=func_call2)
++	newVar, err1 := strconv.Atoi(str)
++	b, err := newVar, err1 //@codeaction("strconv.Atoi(str)", "refactor.extract.variable", edit=func_call2)
 -- scope.go --
 package extract
 
@@ -71,8 +71,8 @@ func _() {
 -- @scope1/scope.go --
 @@ -8 +8,2 @@
 -		y := ast.CompositeLit{} //@codeaction("ast.CompositeLit{}", "refactor.extract.variable", edit=scope1)
-+		newVar := ast.CompositeLit{}
-+		y := newVar //@codeaction("ast.CompositeLit{}", "refactor.extract.variable", edit=scope1)
++		compositeLit := ast.CompositeLit{}
++		y := compositeLit //@codeaction("ast.CompositeLit{}", "refactor.extract.variable", edit=scope1)
 -- @scope2/scope.go --
 @@ -11 +11,2 @@
 -		x := !false //@codeaction("!false", "refactor.extract.constant", edit=scope2)

--- a/gopls/internal/test/marker/testdata/codeaction/extract_variable_all.txt
+++ b/gopls/internal/test/marker/testdata/codeaction/extract_variable_all.txt
@@ -113,11 +113,11 @@ func _() {
 -- @sel/selector.go --
 @@ -9 +9,2 @@
 -	v := s.Value //@codeaction("s.Value", "refactor.extract.variable-all", edit=sel)
-+	newVar := s.Value
-+	v := newVar //@codeaction("s.Value", "refactor.extract.variable-all", edit=sel)
++	value := s.Value
++	v := value //@codeaction("s.Value", "refactor.extract.variable-all", edit=sel)
 @@ -11 +12 @@
 -		w := s.Value //@codeaction("s.Value", "refactor.extract.variable-all", edit=sel)
-+		w := newVar //@codeaction("s.Value", "refactor.extract.variable-all", edit=sel)
++		w := value //@codeaction("s.Value", "refactor.extract.variable-all", edit=sel)
 -- index.go --
 package extract_all
 

--- a/gopls/internal/test/marker/testdata/codeaction/extract_variable_all_resolve.txt
+++ b/gopls/internal/test/marker/testdata/codeaction/extract_variable_all_resolve.txt
@@ -114,11 +114,11 @@ func _() {
 -- @sel/selector.go --
 @@ -9 +9,2 @@
 -	v := s.Value //@codeaction("s.Value", "refactor.extract.variable-all", edit=sel)
-+	newVar := s.Value
-+	v := newVar //@codeaction("s.Value", "refactor.extract.variable-all", edit=sel)
++	value := s.Value
++	v := value //@codeaction("s.Value", "refactor.extract.variable-all", edit=sel)
 @@ -11 +12 @@
 -		w := s.Value //@codeaction("s.Value", "refactor.extract.variable-all", edit=sel)
-+		w := newVar //@codeaction("s.Value", "refactor.extract.variable-all", edit=sel)
++		w := value //@codeaction("s.Value", "refactor.extract.variable-all", edit=sel)
 -- index.go --
 package extract_all
 

--- a/gopls/internal/test/marker/testdata/codeaction/extract_variable_naming.txt
+++ b/gopls/internal/test/marker/testdata/codeaction/extract_variable_naming.txt
@@ -1,0 +1,188 @@
+This test checks the 'extract variable' code action naming heuristics
+and edge cases (keywords, acronyms, prefixes, tuples, indexing custom & builtin types).
+
+-- go.mod --
+module example.com/extract
+
+go 1.21
+
+-- structs.go --
+package extract
+
+type MyItem struct{}
+
+type Struct struct {
+	MyField error
+	len     int
+}
+
+-- indexing.go --
+package extract
+
+func _() {
+	items := []MyItem{{}}
+	_ = items[0] //@codeaction("items[0]", "refactor.extract.variable", edit=array_item)
+
+	numbers := []int{1}
+	_ = numbers[0] //@codeaction("numbers[0]", "refactor.extract.variable", edit=array_item_fallback)
+}
+
+-- @array_item/indexing.go --
+@@ -5 +5,2 @@
+-	_ = items[0] //@codeaction("items[0]", "refactor.extract.variable", edit=array_item)
++	myItem := items[0]
++	_ = myItem //@codeaction("items[0]", "refactor.extract.variable", edit=array_item)
+-- @array_item_fallback/indexing.go --
+@@ -8 +8,2 @@
+-	_ = numbers[0] //@codeaction("numbers[0]", "refactor.extract.variable", edit=array_item_fallback)
++	newVar := numbers[0]
++	_ = newVar //@codeaction("numbers[0]", "refactor.extract.variable", edit=array_item_fallback)
+-- keywords.go --
+package extract
+
+func _() {
+	_ = Struct{} //@codeaction("Struct{}", "refactor.extract.variable", edit=keyword)
+}
+
+-- @keyword/keywords.go --
+@@ -4 +4,2 @@
+-	_ = Struct{} //@codeaction("Struct{}", "refactor.extract.variable", edit=keyword)
++	struct1 := Struct{}
++	_ = struct1 //@codeaction("Struct{}", "refactor.extract.variable", edit=keyword)
+-- prefixes.go --
+package extract
+
+func parseConfig() string { return "" }
+
+func GetURL() string { return "" }
+
+func GetMySpecialError() error { return nil }
+
+func FetchURLConfigHelloWorld() string { return "" }
+
+func NoPrefix() string { return "" }
+
+func _() {
+	_ = parseConfig() //@codeaction("parseConfig()", "refactor.extract.variable", edit=strip_prefix)
+
+	_ = GetURL() //@codeaction("GetURL()", "refactor.extract.variable", edit=all_upper)
+
+	_ = GetMySpecialError() //@codeaction("GetMySpecialError()", "refactor.extract.variable", edit=prefix_prority)
+
+	_ = FetchURLConfigHelloWorld() //@codeaction("FetchURLConfigHelloWorld()", "refactor.extract.variable", edit=upper)
+
+	_ = NoPrefix() //@codeaction("NoPrefix()", "refactor.extract.variable", edit=no_prefix)
+}
+
+-- @all_upper/prefixes.go --
+@@ -16 +16,2 @@
+-	_ = GetURL() //@codeaction("GetURL()", "refactor.extract.variable", edit=all_upper)
++	url := GetURL()
++	_ = url //@codeaction("GetURL()", "refactor.extract.variable", edit=all_upper)
+-- @no_prefix/prefixes.go --
+@@ -22 +22,2 @@
+-	_ = NoPrefix() //@codeaction("NoPrefix()", "refactor.extract.variable", edit=no_prefix)
++	newVar := NoPrefix()
++	_ = newVar //@codeaction("NoPrefix()", "refactor.extract.variable", edit=no_prefix)
+-- @prefix_prority/prefixes.go --
+@@ -18 +18,2 @@
+-	_ = GetMySpecialError() //@codeaction("GetMySpecialError()", "refactor.extract.variable", edit=prefix_prority)
++	mySpecialError := GetMySpecialError()
++	_ = mySpecialError //@codeaction("GetMySpecialError()", "refactor.extract.variable", edit=prefix_prority)
+-- @strip_prefix/prefixes.go --
+@@ -14 +14,2 @@
+-	_ = parseConfig() //@codeaction("parseConfig()", "refactor.extract.variable", edit=strip_prefix)
++	config := parseConfig()
++	_ = config //@codeaction("parseConfig()", "refactor.extract.variable", edit=strip_prefix)
+-- @upper/prefixes.go --
+@@ -20 +20,2 @@
+-	_ = FetchURLConfigHelloWorld() //@codeaction("FetchURLConfigHelloWorld()", "refactor.extract.variable", edit=upper)
++	urlConfigHelloWorld := FetchURLConfigHelloWorld()
++	_ = urlConfigHelloWorld //@codeaction("FetchURLConfigHelloWorld()", "refactor.extract.variable", edit=upper)
+-- tuples.go --
+package extract
+
+func multiReturn() (Struct, MyItem) { return Struct{}, MyItem{} }
+
+func GetFirstReturn() (error, string) { return nil, "" }
+
+func GetUsername() (string, string) { return "", "" }
+
+func multiPrimitive() (string, string) { return "", "" }
+
+func multiErrors() (error, error) { return nil, nil }
+
+func _() {
+	_, _ = multiReturn() //@codeaction("multiReturn()", "refactor.extract.variable", edit=multi)
+
+	_, _ = GetFirstReturn() //@codeaction("GetFirstReturn()", "refactor.extract.variable", edit=first_return)
+
+	_, _ = GetUsername() //@codeaction("GetUsername()", "refactor.extract.variable", edit=strip_prefix_on_multi)
+
+	_, _ = multiPrimitive() //@codeaction("multiPrimitive()", "refactor.extract.variable", edit=multi_primitive)
+
+	_, _ = multiErrors() //@codeaction("multiErrors()", "refactor.extract.variable", edit=multi_errors)
+}
+-- @first_return/tuples.go --
+@@ -16 +16,2 @@
+-	_, _ = GetFirstReturn() //@codeaction("GetFirstReturn()", "refactor.extract.variable", edit=first_return)
++	firstReturn, newVar := GetFirstReturn()
++	_, _ = firstReturn, newVar //@codeaction("GetFirstReturn()", "refactor.extract.variable", edit=first_return)
+-- @multi/tuples.go --
+@@ -14 +14,2 @@
+-	_, _ = multiReturn() //@codeaction("multiReturn()", "refactor.extract.variable", edit=multi)
++	struct1, myItem := multiReturn()
++	_, _ = struct1, myItem //@codeaction("multiReturn()", "refactor.extract.variable", edit=multi)
+-- @multi_errors/tuples.go --
+@@ -22 +22,2 @@
+-	_, _ = multiErrors() //@codeaction("multiErrors()", "refactor.extract.variable", edit=multi_errors)
++	err, err1 := multiErrors()
++	_, _ = err, err1 //@codeaction("multiErrors()", "refactor.extract.variable", edit=multi_errors)
+-- @multi_primitive/tuples.go --
+@@ -20 +20,2 @@
+-	_, _ = multiPrimitive() //@codeaction("multiPrimitive()", "refactor.extract.variable", edit=multi_primitive)
++	newVar, newVar1 := multiPrimitive()
++	_, _ = newVar, newVar1 //@codeaction("multiPrimitive()", "refactor.extract.variable", edit=multi_primitive)
+-- @strip_prefix_on_multi/tuples.go --
+@@ -18 +18,2 @@
+-	_, _ = GetUsername() //@codeaction("GetUsername()", "refactor.extract.variable", edit=strip_prefix_on_multi)
++	username, newVar := GetUsername()
++	_, _ = username, newVar //@codeaction("GetUsername()", "refactor.extract.variable", edit=strip_prefix_on_multi)
+-- fields.go --
+package extract
+
+func (s Struct) GetName() string { return "" }
+func (s Struct) Process() error { return nil }
+
+func _() {
+	s := Struct{}
+
+	_ = s.MyField //@codeaction("s.MyField", "refactor.extract.variable", edit=field_priority)
+
+	_ = s.len //@codeaction("s.len", "refactor.extract.variable", edit=field_builtin)
+
+	_ = s.GetName() //@codeaction("s.GetName()", "refactor.extract.variable", edit=method)
+
+	_ = s.Process() //@codeaction("s.Process()", "refactor.extract.variable", edit=method_priority)
+}
+
+-- @field_builtin/fields.go --
+@@ -11 +11,2 @@
+-	_ = s.len //@codeaction("s.len", "refactor.extract.variable", edit=field_builtin)
++	len1 := s.len
++	_ = len1 //@codeaction("s.len", "refactor.extract.variable", edit=field_builtin)
+-- @field_priority/fields.go --
+@@ -9 +9,2 @@
+-	_ = s.MyField //@codeaction("s.MyField", "refactor.extract.variable", edit=field_priority)
++	myField := s.MyField
++	_ = myField //@codeaction("s.MyField", "refactor.extract.variable", edit=field_priority)
+-- @method/fields.go --
+@@ -13 +13,2 @@
+-	_ = s.GetName() //@codeaction("s.GetName()", "refactor.extract.variable", edit=method)
++	name := s.GetName()
++	_ = name //@codeaction("s.GetName()", "refactor.extract.variable", edit=method)
+-- @method_priority/fields.go --
+@@ -15 +15,2 @@
+-	_ = s.Process() //@codeaction("s.Process()", "refactor.extract.variable", edit=method_priority)
++	err := s.Process()
++	_ = err //@codeaction("s.Process()", "refactor.extract.variable", edit=method_priority)

--- a/gopls/internal/test/marker/testdata/codeaction/extract_variable_naming_all.txt
+++ b/gopls/internal/test/marker/testdata/codeaction/extract_variable_naming_all.txt
@@ -1,0 +1,119 @@
+This test checks the 'refactor.extract.variable-all' and 'refactor.extract.constant-all'
+code action naming heuristics and edge cases when replacing multiple occurrences.
+
+-- go.mod --
+module example.com/extract
+
+go 1.21
+
+-- structs.go --
+package extract
+
+type MyItem struct{}
+
+type Struct struct {
+	MyField error
+	len     int
+}
+
+-- keywords.go --
+package extract
+
+func _() {
+	_ = Struct{} //@codeaction("Struct{}", "refactor.extract.variable-all", edit=keyword)
+	_ = Struct{}
+}
+
+-- @keyword/keywords.go --
+@@ -4,2 +4,3 @@
+-	_ = Struct{} //@codeaction("Struct{}", "refactor.extract.variable-all", edit=keyword)
+-	_ = Struct{}
++	struct1 := Struct{}
++	_ = struct1 //@codeaction("Struct{}", "refactor.extract.variable-all", edit=keyword)
++	_ = struct1
+-- prefixes.go --
+package extract
+
+func parseConfig() string { return "" }
+
+func GetURL() string { return "" }
+
+func FetchURLConfigHelloWorld() string { return "" }
+
+func _() {
+	_ = parseConfig() + parseConfig() //@codeaction("parseConfig()", "refactor.extract.variable-all", edit=strip_prefix)
+
+	_ = GetURL() + GetURL() //@codeaction("GetURL()", "refactor.extract.variable-all", edit=all_upper)
+
+	_ = FetchURLConfigHelloWorld() + FetchURLConfigHelloWorld() //@codeaction("FetchURLConfigHelloWorld()", "refactor.extract.variable-all", edit=upper)
+}
+
+-- @all_upper/prefixes.go --
+@@ -12 +12,2 @@
+-	_ = GetURL() + GetURL() //@codeaction("GetURL()", "refactor.extract.variable-all", edit=all_upper)
++	url := GetURL()
++	_ = url + url //@codeaction("GetURL()", "refactor.extract.variable-all", edit=all_upper)
+-- @strip_prefix/prefixes.go --
+@@ -10 +10,2 @@
+-	_ = parseConfig() + parseConfig() //@codeaction("parseConfig()", "refactor.extract.variable-all", edit=strip_prefix)
++	config := parseConfig()
++	_ = config + config //@codeaction("parseConfig()", "refactor.extract.variable-all", edit=strip_prefix)
+-- @upper/prefixes.go --
+@@ -14 +14,2 @@
+-	_ = FetchURLConfigHelloWorld() + FetchURLConfigHelloWorld() //@codeaction("FetchURLConfigHelloWorld()", "refactor.extract.variable-all", edit=upper)
++	urlConfigHelloWorld := FetchURLConfigHelloWorld()
++	_ = urlConfigHelloWorld + urlConfigHelloWorld //@codeaction("FetchURLConfigHelloWorld()", "refactor.extract.variable-all", edit=upper)
+-- fields.go --
+package extract
+
+func (s Struct) GetName() string { return "" }
+func (s Struct) Process() error { return nil }
+
+func _() {
+	s := Struct{}
+
+	_ = s.GetName() + s.GetName() //@codeaction("s.GetName()", "refactor.extract.variable-all", edit=method)
+
+	_ = s.Process() //@codeaction("s.Process()", "refactor.extract.variable-all", edit=method_priority)
+	_ = s.Process()
+}
+
+-- @method/fields.go --
+@@ -9 +9,2 @@
+-	_ = s.GetName() + s.GetName() //@codeaction("s.GetName()", "refactor.extract.variable-all", edit=method)
++	name := s.GetName()
++	_ = name + name //@codeaction("s.GetName()", "refactor.extract.variable-all", edit=method)
+-- @method_priority/fields.go --
+@@ -11,2 +11,3 @@
+-	_ = s.Process() //@codeaction("s.Process()", "refactor.extract.variable-all", edit=method_priority)
+-	_ = s.Process()
++	err := s.Process()
++	_ = err //@codeaction("s.Process()", "refactor.extract.variable-all", edit=method_priority)
++	_ = err
+-- constants.go --
+package extract
+
+import "fmt"
+
+func _() {
+	fmt.Println("http://localhost:8080") //@codeaction("\"http://localhost:8080\"", "refactor.extract.constant-all", edit=const_str)
+	fmt.Println("http://localhost:8080")
+
+	_ = 1024 * 1024 //@codeaction("1024 * 1024", "refactor.extract.constant-all", edit=const_expr)
+	_ = 1024 * 1024
+}
+
+-- @const_str/constants.go --
+@@ -6,2 +6,3 @@
+-	fmt.Println("http://localhost:8080") //@codeaction("\"http://localhost:8080\"", "refactor.extract.constant-all", edit=const_str)
+-	fmt.Println("http://localhost:8080")
++	const newConst = "http://localhost:8080"
++	fmt.Println(newConst) //@codeaction("\"http://localhost:8080\"", "refactor.extract.constant-all", edit=const_str)
++	fmt.Println(newConst)
+-- @const_expr/constants.go --
+@@ -9,2 +9,3 @@
+-	_ = 1024 * 1024 //@codeaction("1024 * 1024", "refactor.extract.constant-all", edit=const_expr)
+-	_ = 1024 * 1024
++	const newConst = 1024 * 1024
++	_ = newConst //@codeaction("1024 * 1024", "refactor.extract.constant-all", edit=const_expr)
++	_ = newConst

--- a/gopls/internal/test/marker/testdata/codeaction/extract_variable_resolve.txt
+++ b/gopls/internal/test/marker/testdata/codeaction/extract_variable_resolve.txt
@@ -41,8 +41,8 @@ func _() {
 -- @func_call2/func_call.go --
 @@ -8 +8,2 @@
 -	b, err := strconv.Atoi(str) //@codeaction("strconv.Atoi(str)", "refactor.extract.variable", edit=func_call2)
-+	newVar, newVar1 := strconv.Atoi(str)
-+	b, err := newVar, newVar1 //@codeaction("strconv.Atoi(str)", "refactor.extract.variable", edit=func_call2)
++	newVar, err1 := strconv.Atoi(str)
++	b, err := newVar, err1 //@codeaction("strconv.Atoi(str)", "refactor.extract.variable", edit=func_call2)
 -- scope.go --
 package extract
 
@@ -61,8 +61,8 @@ func _() {
 -- @scope1/scope.go --
 @@ -8 +8,2 @@
 -		y := ast.CompositeLit{} //@codeaction("ast.CompositeLit{}", "refactor.extract.variable", edit=scope1)
-+		newVar := ast.CompositeLit{}
-+		y := newVar //@codeaction("ast.CompositeLit{}", "refactor.extract.variable", edit=scope1)
++		compositeLit := ast.CompositeLit{}
++		y := compositeLit //@codeaction("ast.CompositeLit{}", "refactor.extract.variable", edit=scope1)
 -- @scope2/scope.go --
 @@ -11 +11,2 @@
 -		x := !false //@codeaction("!false", "refactor.extract.constant", edit=scope2)


### PR DESCRIPTION
Improve the variable and constant naming logic in 'extract variable' code
actions. Instead of defaulting to generic names like 'newVar', gopls now
derives candidate variable names based on:

- Stripping action prefixes from call expressions
  ```go
  config := parseConfig()
	```
- Selector/field names for field expressions
- Type names, unwrapped pointers, and pluralized slice/array containers
- Special well-known types (e.g. `error` -> `err`)
- Converting acronyms/initialisms to lowerCamelCase
  ```go
  url := GetURL()
  ```
