### PR TITLE
cmd/present: fix outdated flag name in security warning message

### DIFF
--- a/cmd/present/main.go
+++ b/cmd/present/main.go
@@ -117,7 +117,7 @@ and is configured to run code snippets locally. Anyone with access to this addre
 and port will have access to this machine as the user running present.
 
 To avoid this message, listen on localhost, run with -play=false, or run with
--play_socket=false.
+-use_playground=true.
 
 If you don't understand this message, hit Control-C to terminate this process.
 

--- a/cmd/present/main_test.go
+++ b/cmd/present/main_test.go
@@ -1,0 +1,38 @@
+// Copyright 2025 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"flag"
+	"regexp"
+	"testing"
+)
+
+// TestLocalhostWarningFlags verifies that every flag name mentioned in the
+// localhostWarning message is actually defined, so the warning remains
+// accurate when flags are added or removed.
+func TestLocalhostWarningFlags(t *testing.T) {
+	// Register the flags that main() defines so they are visible to flag.Lookup.
+	// flag.CommandLine is shared across tests, so guard against double-registration.
+	if flag.Lookup("play") == nil {
+		flag.BoolVar(new(bool), "play", true, "")
+	}
+	if flag.Lookup("use_playground") == nil {
+		flag.Bool("use_playground", false, "")
+	}
+
+	// Match flag references like "-flagname" or "-flagname=value" that appear
+	// at the start of a word (preceded by whitespace or newline), to avoid
+	// matching things like "Control-C".
+	re := regexp.MustCompile(`(?m)(?:^|\s)-([A-Za-z][A-Za-z0-9_]*)`)
+	matches := re.FindAllStringSubmatch(localhostWarning, -1)
+
+	for _, m := range matches {
+		flagName := m[1]
+		if flag.Lookup(flagName) == nil {
+			t.Errorf("localhostWarning references undefined flag %q", flagName)
+		}
+	}
+}


### PR DESCRIPTION
The localhostWarning string referenced -play_socket=false as a way to suppress the warning, but that flag has not existed in this binary for some time. The currently available flags are -play and -use_playground.

The condition that triggers the warning is:
  !IsLoopback() && present.PlayEnabled && !*usePlayground

Setting -use_playground=true makes !*usePlayground false, which silences the warning. Replace the stale suggestion with the correct -use_playground=true.

Add a test that parses every flag token out of localhostWarning and asserts each one is registered with the flag package, so this class of mistake is caught automatically in the future.

Fixes golang/go#80569

