### PR TITLE
gopls: support assembly References for labels and asm-only symbols

### DIFF
--- a/gopls/doc/features/assembly.md
+++ b/gopls/doc/features/assembly.md
@@ -31,8 +31,10 @@ The following requests are currently supported:
   ```
 
 - References (`textDocument/references`): finds all references to the
-  symbol under the cursor, in both Go and assembly files within the
-  same package.
+  symbol under the cursor. It supports symbols declared in Go, symbols
+  declared only in assembly, and control labels. Assembly-only symbols
+  are searched within the package, file-local `<>` symbols within their
+  source file, and labels within the enclosing TEXT function.
 
 - Hover (`textDocument/hover`): reports the signature and doc comment
   of the symbol's Go declaration.

--- a/gopls/doc/release/v0.24.0.md
+++ b/gopls/doc/release/v0.24.0.md
@@ -47,6 +47,9 @@ register under the cursor are highlighted within the enclosing TEXT
 function, with definitions classified as writes and references as
 reads.
 
+The `textDocument/references` request in Go assembly files now supports
+control labels and symbols that have no corresponding Go declaration.
+
 ## Analysis features
 
 <!-- TODO Gopls is now using staticcheck [v0.8.0-rc1](https://github.com/dominikh/go-tools/releases/tag/2026.2rc1). -->

--- a/gopls/internal/goasm/references.go
+++ b/gopls/internal/goasm/references.go
@@ -12,7 +12,6 @@ import (
 	"go/ast"
 	"go/types"
 	"slices"
-	"sort"
 
 	"golang.org/x/tools/go/types/objectpath"
 	"golang.org/x/tools/gopls/internal/cache"
@@ -54,24 +53,63 @@ func References(ctx context.Context, snapshot *cache.Snapshot, fh file.Handle, p
 		return nil, err
 	}
 
-	// Figure out the selected symbol.
-	// For now, just find the identifier around the cursor.
-	var found *asm.Ident
-	for _, id := range asmFile.Idents {
-		if id.Offset <= offset && offset <= id.End() {
-			found = &id
-			break
-		}
-	}
+	found := asmFile.IdentAt(offset, offset)
 	if found == nil {
 		return nil, fmt.Errorf("not an identifier")
 	}
 
 	var locations []protocol.Location
 
+	// Labels are scoped to the enclosing TEXT function.
+	if asmFile.IsLabel(*found) {
+		lo, hi := asmFile.FunctionRange(found.Offset)
+		for _, id := range asmFile.Idents {
+			if id.Name != found.Name ||
+				!(lo <= id.Offset && id.Offset < hi) ||
+				(id.Kind != asm.Label && (id.Kind != asm.Ref || !id.Bare)) ||
+				(!includeDeclaration && id.Kind == asm.Label) {
+				continue
+			}
+			loc, err := asmFile.IdentLocation(id)
+			if err != nil {
+				return nil, err
+			}
+			locations = append(locations, loc)
+		}
+		slices.SortFunc(locations, protocol.CompareLocation)
+		return slices.Compact(locations), nil
+	}
+
 	pkgpath, name, ok := morestrings.CutLast(found.Name, ".")
 	if !ok {
-		return nil, fmt.Errorf("not found")
+		pkgpath, name = "", found.Name
+	}
+	if found.Local {
+		// A file-local <> symbol is always defined in the current file,
+		// even if its name contains a dot (e.g. "foo·bar<>").
+		pkgpath = ""
+	}
+	samePackage := pkgpath == "" || pkgpath == string(mp.PkgPath)
+	// matchesSymbol reports whether id refers to the selected symbol.
+	// inDeclPkg is true when the scanned file belongs to the declaring
+	// package, in which case a package-qualified name also matches the
+	// "."-prefixed form of a package-level declaration ("pkg.foo" and
+	// "·foo" denote the same symbol; a bare name never does, since
+	// cmd/asm qualifies only names starting with "."). A control label
+	// is handled by the label path above.
+	dotName := "." + name
+	matchesSymbol := func(file *asm.File, id asm.Ident, inDeclPkg bool) bool {
+		if id.Kind == asm.Label || id.Local != found.Local {
+			return false
+		}
+		if id.Name != found.Name && !(inDeclPkg && pkgpath != "" && !id.Local && id.Name == dotName) {
+			return false
+		}
+		return !file.IsLabel(id)
+	}
+	asmFiles := pkg.AsmFiles()
+	if found.Local {
+		asmFiles = []*asm.File{asmFile}
 	}
 
 	// Determine the declaring package for this symbol.
@@ -80,9 +118,11 @@ func References(ctx context.Context, snapshot *cache.Snapshot, fh file.Handle, p
 		declMP    = mp
 		symbolObj types.Object
 	)
-	if pkgpath == "" || pkgpath == string(mp.PkgPath) {
-		// Same-package reference: look up in the current package.
-		symbolObj = pkg.Types().Scope().Lookup(name)
+	if samePackage {
+		if !found.Local {
+			// Same-package reference: look up in the current package.
+			symbolObj = pkg.Types().Scope().Lookup(name)
+		}
 	} else {
 		// Cross-package reference: find the declaring package.
 		// See goasm.Definition for the same approach.
@@ -105,7 +145,48 @@ func References(ctx context.Context, snapshot *cache.Snapshot, fh file.Handle, p
 		symbolObj = declPkg.Types().Scope().Lookup(name)
 	}
 	if symbolObj == nil {
-		return nil, fmt.Errorf("symbol %q not found in package %q", name, pkgpath)
+		// Assembly-only TEXT/GLOBL symbols have no Go object. Scan the
+		// asm files of the declaring package for the declaration and its
+		// references; for a file-local <> symbol, asmFiles is already
+		// restricted to the source file.
+		hasDeclaration := false
+		scan := func(files []*asm.File, inDeclPkg bool) error {
+			for _, file := range files {
+				for _, id := range file.Idents {
+					if !matchesSymbol(file, id, inDeclPkg) {
+						continue
+					}
+					if id.Kind == asm.Text || id.Kind == asm.Global {
+						hasDeclaration = true
+						if !includeDeclaration {
+							continue
+						}
+					}
+					loc, err := file.IdentLocation(id)
+					if err != nil {
+						return err
+					}
+					locations = append(locations, loc)
+				}
+			}
+			return nil
+		}
+		if !samePackage {
+			if err := scan(declPkg.AsmFiles(), true); err != nil {
+				return nil, err
+			}
+		}
+		if err := scan(asmFiles, samePackage); err != nil {
+			return nil, err
+		}
+		if !hasDeclaration && len(locations) <= 1 {
+			// The only match, if any, is the identifier under the
+			// cursor: the symbol has no declaration or other
+			// references, so the reference is dangling.
+			return nil, fmt.Errorf("symbol %q not found in package %q", name, pkgpath)
+		}
+		slices.SortFunc(locations, protocol.CompareLocation)
+		return slices.Compact(locations), nil
 	}
 
 	// Scan Go files in the declaring package for references to the symbol.
@@ -122,7 +203,7 @@ func References(ctx context.Context, snapshot *cache.Snapshot, fh file.Handle, p
 				// and should be excluded when not including declarations.
 				// For same-package references, the asm TEXT line
 				// is the declaration, so Go Defs are reference targets.
-				if pkgpath != "" && pkgpath != string(mp.PkgPath) {
+				if !samePackage {
 					continue
 				}
 			}
@@ -136,17 +217,14 @@ func References(ctx context.Context, snapshot *cache.Snapshot, fh file.Handle, p
 
 	// For cross-package references, also scan assembly files
 	// in the declaring package.
-	if pkgpath != "" && pkgpath != string(mp.PkgPath) {
-		for _, asmFile := range declPkg.AsmFiles() {
-			for _, id := range asmFile.Idents {
-				if id.Name == found.Name {
-					if id.Kind == asm.Label {
-						continue
-					}
+	if !samePackage {
+		for _, file := range declPkg.AsmFiles() {
+			for _, id := range file.Idents {
+				if matchesSymbol(file, id, true) {
 					if !includeDeclaration && (id.Kind == asm.Text || id.Kind == asm.Global) {
 						continue
 					}
-					if loc, err := asmFile.IdentLocation(id); err == nil {
+					if loc, err := file.IdentLocation(id); err == nil {
 						locations = append(locations, loc)
 					}
 				}
@@ -155,16 +233,13 @@ func References(ctx context.Context, snapshot *cache.Snapshot, fh file.Handle, p
 	}
 
 	// Scan asm files in the current package for matching identifiers.
-	for _, asmFile := range pkg.AsmFiles() {
-		for _, id := range asmFile.Idents {
-			if id.Name == found.Name {
-				if id.Kind == asm.Label {
-					continue
-				}
+	for _, file := range asmFiles {
+		for _, id := range file.Idents {
+			if matchesSymbol(file, id, samePackage) {
 				if !includeDeclaration && (id.Kind == asm.Text || id.Kind == asm.Global) {
 					continue
 				}
-				if loc, err := asmFile.IdentLocation(id); err == nil {
+				if loc, err := file.IdentLocation(id); err == nil {
 					locations = append(locations, loc)
 				}
 			}
@@ -218,9 +293,7 @@ func References(ctx context.Context, snapshot *cache.Snapshot, fh file.Handle, p
 	}
 
 	// Deduplicate by location.
-	sort.Slice(locations, func(i, j int) bool {
-		return protocol.CompareLocation(locations[i], locations[j]) < 0
-	})
+	slices.SortFunc(locations, protocol.CompareLocation)
 	locations = slices.Compact(locations)
 
 	return locations, nil

--- a/gopls/internal/goasm/references.go
+++ b/gopls/internal/goasm/references.go
@@ -66,8 +66,8 @@ func References(ctx context.Context, snapshot *cache.Snapshot, fh file.Handle, p
 		for _, id := range asmFile.Idents {
 			if id.Name != found.Name ||
 				!(lo <= id.Offset && id.Offset < hi) ||
-				(id.Kind != asm.Label && (id.Kind != asm.Ref || !id.Bare)) ||
-				(!includeDeclaration && id.Kind == asm.Label) {
+				id.Kind != asm.Label && (id.Kind != asm.Ref || !id.Bare) ||
+				!includeDeclaration && id.Kind == asm.Label {
 				continue
 			}
 			loc, err := asmFile.IdentLocation(id)
@@ -76,8 +76,7 @@ func References(ctx context.Context, snapshot *cache.Snapshot, fh file.Handle, p
 			}
 			locations = append(locations, loc)
 		}
-		slices.SortFunc(locations, protocol.CompareLocation)
-		return slices.Compact(locations), nil
+		return locations, nil
 	}
 
 	pkgpath, name, ok := strings.CutLast(found.Name, ".")
@@ -185,8 +184,7 @@ func References(ctx context.Context, snapshot *cache.Snapshot, fh file.Handle, p
 			// references, so the reference is dangling.
 			return nil, fmt.Errorf("symbol %q not found in package %q", name, pkgpath)
 		}
-		slices.SortFunc(locations, protocol.CompareLocation)
-		return slices.Compact(locations), nil
+		return locations, nil
 	}
 
 	// Scan Go files in the declaring package for references to the symbol.

--- a/gopls/internal/goasm/references.go
+++ b/gopls/internal/goasm/references.go
@@ -12,7 +12,6 @@ import (
 	"go/ast"
 	"go/types"
 	"slices"
-	"sort"
 	"strings"
 
 	"golang.org/x/tools/go/types/objectpath"
@@ -21,7 +20,6 @@ import (
 	"golang.org/x/tools/gopls/internal/file"
 	"golang.org/x/tools/gopls/internal/protocol"
 	"golang.org/x/tools/gopls/internal/util/asm"
-
 	"golang.org/x/tools/internal/event"
 )
 
@@ -55,24 +53,63 @@ func References(ctx context.Context, snapshot *cache.Snapshot, fh file.Handle, p
 		return nil, err
 	}
 
-	// Figure out the selected symbol.
-	// For now, just find the identifier around the cursor.
-	var found *asm.Ident
-	for _, id := range asmFile.Idents {
-		if id.Offset <= offset && offset <= id.End() {
-			found = &id
-			break
-		}
-	}
+	found := asmFile.IdentAt(offset, offset)
 	if found == nil {
 		return nil, fmt.Errorf("not an identifier")
 	}
 
 	var locations []protocol.Location
 
+	// Labels are scoped to the enclosing TEXT function.
+	if asmFile.IsLabel(*found) {
+		lo, hi := asmFile.FunctionRange(found.Offset)
+		for _, id := range asmFile.Idents {
+			if id.Name != found.Name ||
+				!(lo <= id.Offset && id.Offset < hi) ||
+				(id.Kind != asm.Label && (id.Kind != asm.Ref || !id.Bare)) ||
+				(!includeDeclaration && id.Kind == asm.Label) {
+				continue
+			}
+			loc, err := asmFile.IdentLocation(id)
+			if err != nil {
+				return nil, err
+			}
+			locations = append(locations, loc)
+		}
+		slices.SortFunc(locations, protocol.CompareLocation)
+		return slices.Compact(locations), nil
+	}
+
 	pkgpath, name, ok := strings.CutLast(found.Name, ".")
 	if !ok {
-		return nil, fmt.Errorf("not found")
+		pkgpath, name = "", found.Name
+	}
+	if found.Local {
+		// A file-local <> symbol is always defined in the current file,
+		// even if its name contains a dot (e.g. "foo·bar<>").
+		pkgpath = ""
+	}
+	samePackage := pkgpath == "" || pkgpath == string(mp.PkgPath)
+	// matchesSymbol reports whether id refers to the selected symbol.
+	// inDeclPkg is true when the scanned file belongs to the declaring
+	// package, in which case a package-qualified name also matches the
+	// "."-prefixed form of a package-level declaration ("pkg.foo" and
+	// "·foo" denote the same symbol; a bare name never does, since
+	// cmd/asm qualifies only names starting with "."). A control label
+	// is handled by the label path above.
+	dotName := "." + name
+	matchesSymbol := func(file *asm.File, id asm.Ident, inDeclPkg bool) bool {
+		if id.Kind == asm.Label || id.Local != found.Local {
+			return false
+		}
+		if id.Name != found.Name && !(inDeclPkg && pkgpath != "" && !id.Local && id.Name == dotName) {
+			return false
+		}
+		return !file.IsLabel(id)
+	}
+	asmFiles := pkg.AsmFiles()
+	if found.Local {
+		asmFiles = []*asm.File{asmFile}
 	}
 
 	// Determine the declaring package for this symbol.
@@ -81,9 +118,11 @@ func References(ctx context.Context, snapshot *cache.Snapshot, fh file.Handle, p
 		declMP    = mp
 		symbolObj types.Object
 	)
-	if pkgpath == "" || pkgpath == string(mp.PkgPath) {
-		// Same-package reference: look up in the current package.
-		symbolObj = pkg.Types().Scope().Lookup(name)
+	if samePackage {
+		if !found.Local {
+			// Same-package reference: look up in the current package.
+			symbolObj = pkg.Types().Scope().Lookup(name)
+		}
 	} else {
 		// Cross-package reference: find the declaring package.
 		// See goasm.Definition for the same approach.
@@ -106,7 +145,48 @@ func References(ctx context.Context, snapshot *cache.Snapshot, fh file.Handle, p
 		symbolObj = declPkg.Types().Scope().Lookup(name)
 	}
 	if symbolObj == nil {
-		return nil, fmt.Errorf("symbol %q not found in package %q", name, pkgpath)
+		// Assembly-only TEXT/GLOBL symbols have no Go object. Scan the
+		// asm files of the declaring package for the declaration and its
+		// references; for a file-local <> symbol, asmFiles is already
+		// restricted to the source file.
+		hasDeclaration := false
+		scan := func(files []*asm.File, inDeclPkg bool) error {
+			for _, file := range files {
+				for _, id := range file.Idents {
+					if !matchesSymbol(file, id, inDeclPkg) {
+						continue
+					}
+					if id.Kind == asm.Text || id.Kind == asm.Global {
+						hasDeclaration = true
+						if !includeDeclaration {
+							continue
+						}
+					}
+					loc, err := file.IdentLocation(id)
+					if err != nil {
+						return err
+					}
+					locations = append(locations, loc)
+				}
+			}
+			return nil
+		}
+		if !samePackage {
+			if err := scan(declPkg.AsmFiles(), true); err != nil {
+				return nil, err
+			}
+		}
+		if err := scan(asmFiles, samePackage); err != nil {
+			return nil, err
+		}
+		if !hasDeclaration && len(locations) <= 1 {
+			// The only match, if any, is the identifier under the
+			// cursor: the symbol has no declaration or other
+			// references, so the reference is dangling.
+			return nil, fmt.Errorf("symbol %q not found in package %q", name, pkgpath)
+		}
+		slices.SortFunc(locations, protocol.CompareLocation)
+		return slices.Compact(locations), nil
 	}
 
 	// Scan Go files in the declaring package for references to the symbol.
@@ -123,7 +203,7 @@ func References(ctx context.Context, snapshot *cache.Snapshot, fh file.Handle, p
 				// and should be excluded when not including declarations.
 				// For same-package references, the asm TEXT line
 				// is the declaration, so Go Defs are reference targets.
-				if pkgpath != "" && pkgpath != string(mp.PkgPath) {
+				if !samePackage {
 					continue
 				}
 			}
@@ -137,17 +217,14 @@ func References(ctx context.Context, snapshot *cache.Snapshot, fh file.Handle, p
 
 	// For cross-package references, also scan assembly files
 	// in the declaring package.
-	if pkgpath != "" && pkgpath != string(mp.PkgPath) {
-		for _, asmFile := range declPkg.AsmFiles() {
-			for _, id := range asmFile.Idents {
-				if id.Name == found.Name {
-					if id.Kind == asm.Label {
-						continue
-					}
+	if !samePackage {
+		for _, file := range declPkg.AsmFiles() {
+			for _, id := range file.Idents {
+				if matchesSymbol(file, id, true) {
 					if !includeDeclaration && (id.Kind == asm.Text || id.Kind == asm.Global) {
 						continue
 					}
-					if loc, err := asmFile.IdentLocation(id); err == nil {
+					if loc, err := file.IdentLocation(id); err == nil {
 						locations = append(locations, loc)
 					}
 				}
@@ -156,16 +233,13 @@ func References(ctx context.Context, snapshot *cache.Snapshot, fh file.Handle, p
 	}
 
 	// Scan asm files in the current package for matching identifiers.
-	for _, asmFile := range pkg.AsmFiles() {
-		for _, id := range asmFile.Idents {
-			if id.Name == found.Name {
-				if id.Kind == asm.Label {
-					continue
-				}
+	for _, file := range asmFiles {
+		for _, id := range file.Idents {
+			if matchesSymbol(file, id, samePackage) {
 				if !includeDeclaration && (id.Kind == asm.Text || id.Kind == asm.Global) {
 					continue
 				}
-				if loc, err := asmFile.IdentLocation(id); err == nil {
+				if loc, err := file.IdentLocation(id); err == nil {
 					locations = append(locations, loc)
 				}
 			}
@@ -219,9 +293,7 @@ func References(ctx context.Context, snapshot *cache.Snapshot, fh file.Handle, p
 	}
 
 	// Deduplicate by location.
-	sort.Slice(locations, func(i, j int) bool {
-		return protocol.CompareLocation(locations[i], locations[j]) < 0
-	})
+	slices.SortFunc(locations, protocol.CompareLocation)
 	locations = slices.Compact(locations)
 
 	return locations, nil

--- a/gopls/internal/test/marker/testdata/references/asm.txt
+++ b/gopls/internal/test/marker/testdata/references/asm.txt
@@ -1,22 +1,77 @@
 Test of asm references.
 
+-- go.mod --
+module example.com
+go 1.24
+
+-- example/example.go --
+package example
+
 -- example/label_example.s --
 TEXT ·JumpDemo(SB), $0-0
-label1: //@loc(defLabel, "label1")
-    JMP label1 //@loc(refLabel, "label1")
+label1: //@loc(defLabel, "label1"), refs("label1", defLabel, refLabel)
+    JMP label1 //@loc(refLabel, "label1"), refs("label1", defLabel, refLabel)
+
+TEXT ·OtherJumpDemo(SB), $0-0
+label1: //@loc(otherDefLabel, "label1"), refs("label1", otherDefLabel, otherRefLabel)
+    JMP label1 //@loc(otherRefLabel, "label1"), refs("label1", otherDefLabel, otherRefLabel)
+
+TEXT ·LabelAndSymbol(SB), $0-0
+collisionSymbol: //@loc(defCollisionLabel, "collisionSymbol"), refs("collisionSymbol", defCollisionLabel, refCollisionLabel)
+    JMP collisionSymbol //@loc(refCollisionLabel, "collisionSymbol"), refs("collisionSymbol", defCollisionLabel, refCollisionLabel)
+    CALL collisionSymbol(SB) //@loc(callCollisionSymbol, "collisionSymbol"), refs("collisionSymbol", defCollisionSymbol, callCollisionSymbol)
 
 -- example/in_package_ref.s --
-TEXT ·Foo(SB), $0-8 //@loc(defFooAsm, "·Foo")
+TEXT ·Foo(SB), $0-8 //@loc(defFooAsm, "·Foo"), refs("·Foo", defFooAsm, callFooAsm)
     RET
 
+TEXT bareText(SB), $0-0 //@loc(defBareText, "bareText"), refs("bareText", defBareText, callBareText)
+    RET
+
+TEXT collisionSymbol(SB), $0-0 //@loc(defCollisionSymbol, "collisionSymbol"), refs("collisionSymbol", defCollisionSymbol, callCollisionSymbol)
+    RET
+
+TEXT doneSymbol(SB), $0-0 //@loc(defDoneSymbol, "doneSymbol"), refs("doneSymbol", defDoneSymbol, jmpDoneBare)
+    RET
+
+-- example/in_package_use.s --
 TEXT ·Bar(SB), $0-8
-    CALL ·Foo(SB) //@loc(callFooAsm, "·Foo")
+    CALL ·Foo(SB) //@loc(callFooAsm, "·Foo"), refs("·Foo", defFooAsm, callFooAsm)
+    CALL bareText(SB) //@loc(callBareText, "bareText"), refs("bareText", defBareText, callBareText)
+    RET
+
+TEXT ·UseDone(SB), $0-0
+    JMP doneSymbol //@loc(jmpDoneBare, "doneSymbol"), refs("doneSymbol", defDoneSymbol, jmpDoneBare)
     RET
 
 -- example/example_data.s --
-DATA ·myGlobal+0(SB)/8, $42
-GLOBL ·myGlobal(SB), NOPTR, 8
+DATA ·myGlobal+0(SB)/8, $42 //@loc(dataMyGlobal, "·myGlobal"), refs("·myGlobal", defMyGlobal, dataMyGlobal, refMyGlobal)
+GLOBL ·myGlobal(SB), NOPTR, 8 //@loc(defMyGlobal, "·myGlobal"), refs("·myGlobal", defMyGlobal, dataMyGlobal, refMyGlobal)
 
 TEXT ·UseGlobal(SB), $0-0
-    MOVQ ·myGlobal(SB), AX //@loc(refMyGlobal, "·myGlobal")
+    MOVQ ·myGlobal(SB), AX //@loc(refMyGlobal, "·myGlobal"), refs("·myGlobal", defMyGlobal, dataMyGlobal, refMyGlobal)
+    RET
+
+-- example/static_one.s --
+DATA table<>+0(SB)/8, $1 //@loc(dataStaticOne, "table"), refs("table", defStaticOne, dataStaticOne, refStaticOne)
+GLOBL table<>(SB), RODATA, 8 //@loc(defStaticOne, "table"), refs("table", defStaticOne, dataStaticOne, refStaticOne)
+
+TEXT ·UseStaticOne(SB), $0-0
+    MOVQ table<>(SB), AX //@loc(refStaticOne, "table"), refs("table", defStaticOne, dataStaticOne, refStaticOne)
+    RET
+
+-- example/static_two.s --
+DATA table<>+0(SB)/8, $2 //@loc(dataStaticTwo, "table"), refs("table", defStaticTwo, dataStaticTwo, refStaticTwo)
+GLOBL table<>(SB), RODATA, 8 //@loc(defStaticTwo, "table"), refs("table", defStaticTwo, dataStaticTwo, refStaticTwo)
+
+TEXT ·UseStaticTwo(SB), $0-0
+    MOVQ table<>(SB), AX //@loc(refStaticTwo, "table"), refs("table", defStaticTwo, dataStaticTwo, refStaticTwo)
+    RET
+
+-- example/dotted_local.s --
+DATA foo·bar<>+0(SB)/8, $3 //@loc(dataDottedLocal, "foo·bar"), refs("foo·bar", defDottedLocal, dataDottedLocal, refDottedLocal)
+GLOBL foo·bar<>(SB), RODATA, 8 //@loc(defDottedLocal, "foo·bar"), refs("foo·bar", defDottedLocal, dataDottedLocal, refDottedLocal)
+
+TEXT ·UseDotted(SB), $0-0
+    MOVQ foo·bar<>(SB), AX //@loc(refDottedLocal, "foo·bar"), refs("foo·bar", defDottedLocal, dataDottedLocal, refDottedLocal)
     RET

--- a/gopls/internal/test/marker/testdata/references/asm_cross_pkg.txt
+++ b/gopls/internal/test/marker/testdata/references/asm_cross_pkg.txt
@@ -9,6 +9,10 @@ package lib
 
 func Helper() int { return 42 } //@loc(defHelper, "Helper"), refs("Helper", defHelper, goCallHelper, asmCallHelper)
 
+-- lib/asm_only.s --
+TEXT ·Only(SB), $0-0 //@loc(defOnlyAsm, "·Only")
+    RET
+
 -- caller/caller.go --
 package caller
 
@@ -21,4 +25,8 @@ func Use() {
 -- caller/impl.s --
 TEXT ·Wrapper(SB), $0-0
     CALL example·com∕lib·Helper(SB) //@loc(asmCallHelper, "example·com∕lib·Helper"), refs("Helper", defHelper, goCallHelper, asmCallHelper)
+    RET
+
+TEXT ·WrapperOnly(SB), $0-0
+    CALL example·com∕lib·Only(SB) //@loc(asmCallOnly, "example·com∕lib·Only"), refs("Only", defOnlyAsm, asmCallOnly)
     RET

--- a/gopls/internal/test/marker/testdata/references/asm_go.txt
+++ b/gopls/internal/test/marker/testdata/references/asm_go.txt
@@ -11,7 +11,7 @@ func Add(a, b int) int //@loc(defAddGo, "Add"), refs("Add", defAddGo, callAddGo)
 func UseAdd() int {
     return Add(1, 2) //@loc(callAddGo, "Add")
 }
-var myGlobal int64 //@loc(defMyGlobalGo, "myGlobal"), refs("myGlobal", defMyGlobalGo, refMyGlobal, refMyGlobalGo)
+var myGlobal int64 //@loc(defMyGlobalGo, "myGlobal"), refs("myGlobal", defMyGlobalGo, dataMyGlobalAsm, refMyGlobal, refMyGlobalGo)
 var _ = myGlobal   //@loc(refMyGlobalGo, "myGlobal")
 
 -- go_call_asm/example_asm.s --
@@ -20,7 +20,7 @@ TEXT ·Add(SB), $0-24 //@loc(defAddGoAsm, "·Add"), refs("Add", defAddGoAsm, def
     ADDQ b+8(FP), AX
     RET
 
-DATA ·myGlobal+0(SB)/8, $42
+DATA ·myGlobal+0(SB)/8, $42 //@loc(dataMyGlobalAsm, "·myGlobal")
 GLOBL ·myGlobal(SB), NOPTR, 8
 TEXT ·UseGlobal(SB), $0-0
     MOVQ ·myGlobal(SB), AX //@loc(refMyGlobal, "·myGlobal")

--- a/gopls/internal/util/asm/parse.go
+++ b/gopls/internal/util/asm/parse.go
@@ -84,6 +84,27 @@ func (f *File) IdentAt(start, end int) *Ident {
 	return nil
 }
 
+// IsLabel reports whether id denotes a control label: it is a label
+// definition, or a bare reference to a label of the same name defined
+// within the enclosing TEXT function.
+func (f *File) IsLabel(id Ident) bool {
+	if id.Kind == Label {
+		return true
+	}
+	if id.Kind != Ref || !id.Bare {
+		return false
+	}
+	lo, hi := f.FunctionRange(id.Offset)
+	for _, label := range f.Idents {
+		if label.Kind == Label &&
+			label.Name == id.Name &&
+			lo <= label.Offset && label.Offset < hi {
+			return true
+		}
+	}
+	return false
+}
+
 // FunctionRange returns the byte range [start, end) of the TEXT function
 // enclosing offset: start is the beginning of the line containing the
 // enclosing TEXT directive, end is the beginning of the line containing
@@ -121,6 +142,8 @@ type Ident struct {
 	Offset  int    // zero-based byte offset
 	OrigLen int    // original length of the symbol name (before cleanup)
 	Kind    Kind
+	Local   bool // whether the symbol uses the file-local <> suffix
+	Bare    bool // whether a reference is an unadorned control-label candidate
 }
 
 // End returns the identifier's end offset.
@@ -148,7 +171,9 @@ func Parse(uri protocol.DocumentURI, content []byte) *File {
 			continue
 		}
 
-		// Check for label definitions (ending with colon).
+		// Check for label definitions (ending with colon); the rest of
+		// the line (e.g. "loop: JMP loop") is scanned for references
+		// below.
 		if colon := strings.IndexByte(line, ':'); colon > 0 {
 			label := strings.TrimSpace(line[:colon])
 			if isIdent(label) {
@@ -158,7 +183,6 @@ func Parse(uri protocol.DocumentURI, content []byte) *File {
 					OrigLen: len(label),
 					Kind:    Label,
 				})
-				continue
 			}
 		}
 
@@ -183,17 +207,24 @@ func Parse(uri protocol.DocumentURI, content []byte) *File {
 			}
 			if kind != Invalid {
 				sym := words[1]
-				sym = cutBefore(sym, ",") // strip ",NOSPLIT,$12" etc
-				sym = cutBefore(sym, "(") // "sym(SB)" -> "sym"
-				sym = cutBefore(sym, "<") // "sym<ABIInternal>" -> "sym"
+				sym = cutBefore(sym, ",")             // strip ",NOSPLIT,$12" etc
+				sym = cutBefore(sym, "(")             // "sym(SB)" -> "sym"
+				sym = cutBefore(sym, "+")             // "sym+8(SB)" -> "sym"
+				local := strings.HasSuffix(sym, "<>") // "table<>+0(SB)" -> "table<>"
+				sym = cutBefore(sym, "<")             // "sym<ABIInternal>" -> "sym"
 				sym = strings.TrimSpace(sym)
 				if isIdent(sym) {
-					// (The Index call assumes sym is not itself "TEXT" etc.)
+					// The symbol is a prefix of the declaration token, so its
+					// position is that of words[1]; indexing the line by the
+					// shortened name alone could hit an earlier occurrence
+					// (e.g. the "T" inside "DATA T+0(SB)").
+					tokenPos := strings.Index(line, words[1])
 					idents = append(idents, Ident{
 						Name:    cleanup(sym),
 						Kind:    kind,
-						Offset:  offset + strings.Index(line, sym),
+						Offset:  offset + tokenPos,
 						OrigLen: len(sym),
+						Local:   local,
 					})
 				}
 				continue
@@ -217,7 +248,8 @@ func Parse(uri protocol.DocumentURI, content []byte) *File {
 				continue
 			}
 
-			if word[0] == '$' {
+			immediate := word[0] == '$'
+			if immediate {
 				word = word[1:]
 				tokenPos++
 
@@ -246,15 +278,19 @@ func Parse(uri protocol.DocumentURI, content []byte) *File {
 			//    MOVD	$runtime·g0(SB), g      // pseudoreg
 			//    MOVD	R0, g_stackguard0(g)    // field ref
 
-			sym := cutBefore(word, "(") // "·sym(SB)" => "sym"
-			sym = cutBefore(sym, "+")   // "sym+8(FP)" => "sym"
-			sym = cutBefore(sym, "<")   // "sym<ABIInternal>" =>> "sym"
+			sym := cutBefore(word, "(")           // "·sym(SB)" => "sym"
+			sym = cutBefore(sym, "+")             // "sym+8(FP)" => "sym"
+			local := strings.HasSuffix(sym, "<>") // "table<>(SB)" -> "table<>"
+			sym = cutBefore(sym, "<")             // "sym<ABIInternal>" =>> "sym"
+			bare := !immediate && sym == word
 			if isIdent(sym) {
 				idents = append(idents, Ident{
 					Name:    cleanup(sym),
 					Kind:    Ref,
 					Offset:  offset + tokenPos,
 					OrigLen: len(sym),
+					Local:   local,
+					Bare:    bare,
 				})
 			}
 		}

--- a/gopls/internal/util/asm/parse.go
+++ b/gopls/internal/util/asm/parse.go
@@ -90,15 +90,14 @@ func (f *File) IsLabel(id Ident) bool {
 	if id.Kind == Label {
 		return true
 	}
-	if id.Kind != Ref || !id.Bare {
-		return false
-	}
-	lo, hi := f.FunctionRange(id.Offset)
-	for _, label := range f.Idents {
-		if label.Kind == Label &&
-			label.Name == id.Name &&
-			lo <= label.Offset && label.Offset < hi {
-			return true
+	if id.Kind == Ref && id.Bare {
+		lo, hi := f.FunctionRange(id.Offset)
+		for _, label := range f.Idents {
+			if label.Kind == Label &&
+				label.Name == id.Name &&
+				lo <= label.Offset && label.Offset < hi {
+				return true
+			}
 		}
 	}
 	return false

--- a/gopls/internal/util/asm/parse.go
+++ b/gopls/internal/util/asm/parse.go
@@ -83,6 +83,27 @@ func (f *File) IdentAt(start, end int) *Ident {
 	return nil
 }
 
+// IsLabel reports whether id denotes a control label: it is a label
+// definition, or a bare reference to a label of the same name defined
+// within the enclosing TEXT function.
+func (f *File) IsLabel(id Ident) bool {
+	if id.Kind == Label {
+		return true
+	}
+	if id.Kind != Ref || !id.Bare {
+		return false
+	}
+	lo, hi := f.FunctionRange(id.Offset)
+	for _, label := range f.Idents {
+		if label.Kind == Label &&
+			label.Name == id.Name &&
+			lo <= label.Offset && label.Offset < hi {
+			return true
+		}
+	}
+	return false
+}
+
 // FunctionRange returns the byte range [start, end) of the TEXT function
 // enclosing offset: start is the beginning of the line containing the
 // enclosing TEXT directive, end is the beginning of the line containing
@@ -120,6 +141,8 @@ type Ident struct {
 	Offset  int    // zero-based byte offset
 	OrigLen int    // original length of the symbol name (before cleanup)
 	Kind    Kind
+	Local   bool // whether the symbol uses the file-local <> suffix
+	Bare    bool // whether a reference is an unadorned control-label candidate
 }
 
 // End returns the identifier's end offset.
@@ -151,7 +174,9 @@ func Parse(uri protocol.DocumentURI, content []byte) *File {
 			continue
 		}
 
-		// Check for label definitions (ending with colon).
+		// Check for label definitions (ending with colon); the rest of
+		// the line (e.g. "loop: JMP loop") is scanned for references
+		// below.
 		if colon := strings.IndexByte(line, ':'); colon > 0 {
 			label := strings.TrimSpace(line[:colon])
 			if isIdent(label) {
@@ -161,7 +186,6 @@ func Parse(uri protocol.DocumentURI, content []byte) *File {
 					OrigLen: len(label),
 					Kind:    Label,
 				})
-				continue
 			}
 		}
 
@@ -186,17 +210,24 @@ func Parse(uri protocol.DocumentURI, content []byte) *File {
 			}
 			if kind != Invalid {
 				sym := words[1]
-				sym = cutBefore(sym, ",") // strip ",NOSPLIT,$12" etc
-				sym = cutBefore(sym, "(") // "sym(SB)" -> "sym"
-				sym = cutBefore(sym, "<") // "sym<ABIInternal>" -> "sym"
+				sym = cutBefore(sym, ",")             // strip ",NOSPLIT,$12" etc
+				sym = cutBefore(sym, "(")             // "sym(SB)" -> "sym"
+				sym = cutBefore(sym, "+")             // "sym+8(SB)" -> "sym"
+				local := strings.HasSuffix(sym, "<>") // "table<>+0(SB)" -> "table<>"
+				sym = cutBefore(sym, "<")             // "sym<ABIInternal>" -> "sym"
 				sym = strings.TrimSpace(sym)
 				if isIdent(sym) {
-					// (The Index call assumes sym is not itself "TEXT" etc.)
+					// The symbol is a prefix of the declaration token, so its
+					// position is that of words[1]; indexing the line by the
+					// shortened name alone could hit an earlier occurrence
+					// (e.g. the "T" inside "DATA T+0(SB)").
+					tokenPos := strings.Index(line, words[1])
 					idents = append(idents, Ident{
 						Name:    cleanup(sym),
 						Kind:    kind,
-						Offset:  lineOffset + strings.Index(line, sym),
+						Offset:  lineOffset + tokenPos,
 						OrigLen: len(sym),
+						Local:   local,
 					})
 				}
 				continue
@@ -220,7 +251,8 @@ func Parse(uri protocol.DocumentURI, content []byte) *File {
 				continue
 			}
 
-			if word[0] == '$' {
+			immediate := word[0] == '$'
+			if immediate {
 				word = word[1:]
 				tokenPos++
 
@@ -249,15 +281,19 @@ func Parse(uri protocol.DocumentURI, content []byte) *File {
 			//    MOVD	$runtime·g0(SB), g      // pseudoreg
 			//    MOVD	R0, g_stackguard0(g)    // field ref
 
-			sym := cutBefore(word, "(") // "·sym(SB)" => "sym"
-			sym = cutBefore(sym, "+")   // "sym+8(FP)" => "sym"
-			sym = cutBefore(sym, "<")   // "sym<ABIInternal>" =>> "sym"
+			sym := cutBefore(word, "(")           // "·sym(SB)" => "sym"
+			sym = cutBefore(sym, "+")             // "sym+8(FP)" => "sym"
+			local := strings.HasSuffix(sym, "<>") // "table<>(SB)" -> "table<>"
+			sym = cutBefore(sym, "<")             // "sym<ABIInternal>" =>> "sym"
+			bare := !immediate && sym == word
 			if isIdent(sym) {
 				idents = append(idents, Ident{
 					Name:    cleanup(sym),
 					Kind:    Ref,
 					Offset:  lineOffset + tokenPos,
 					OrigLen: len(sym),
+					Local:   local,
+					Bare:    bare,
 				})
 			}
 		}

--- a/gopls/internal/util/asm/parse_test.go
+++ b/gopls/internal/util/asm/parse_test.go
@@ -65,3 +65,67 @@ asm.s:18:11-24:	ref "g_stackguard0"
 		t.Errorf("got:\n%s\nwant:\n%s\ndiff:\n%s", got, want, cmp.Diff(want, got))
 	}
 }
+
+func TestIdentProperties(t *testing.T) {
+	src := []byte(`
+TEXT ·f(SB), $0-0
+loop:
+	JMP loop
+	CALL loop(SB)
+	MOVQ $table<>(SB), AX
+DATA table<>+0(SB)/8, $1
+GLOBL table<>(SB), RODATA, $8
+DATA ·global+0(SB)/8, $1
+DATA T+0(SB)/8, $1
+spin: JMP spin
+MOVQ foo<>bar(SB), AX
+`[1:])
+	file := asm.Parse(protocol.URIFromPath("asm.s"), src)
+
+	type ident struct {
+		Name  string
+		Kind  asm.Kind
+		Local bool
+		Bare  bool
+	}
+	var got []ident
+	for _, id := range file.Idents {
+		got = append(got, ident{
+			Name:  id.Name,
+			Kind:  id.Kind,
+			Local: id.Local,
+			Bare:  id.Bare,
+		})
+	}
+	want := []ident{
+		{Name: ".f", Kind: asm.Text},
+		{Name: "loop", Kind: asm.Label},
+		{Name: "loop", Kind: asm.Ref, Bare: true},
+		{Name: "loop", Kind: asm.Ref},
+		{Name: "table", Kind: asm.Ref, Local: true},
+		{Name: "table", Kind: asm.Data, Local: true},
+		{Name: "table", Kind: asm.Global, Local: true},
+		{Name: ".global", Kind: asm.Data},
+		{Name: "T", Kind: asm.Data},
+		{Name: "spin", Kind: asm.Label},
+		{Name: "spin", Kind: asm.Ref, Bare: true},
+		{Name: "foo", Kind: asm.Ref},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("identifier properties mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// TestDataPlusOffset checks that a DATA symbol with a +offset is located
+// at the symbol, not at an earlier occurrence of its shortened name
+// (e.g. the "T" inside "DATA").
+func TestDataPlusOffset(t *testing.T) {
+	src := []byte("DATA T+0(SB)/8, $1\n")
+	file := asm.Parse(protocol.URIFromPath("asm.s"), src)
+	want := []asm.Ident{
+		{Name: "T", Offset: 5, OrigLen: 1, Kind: asm.Data},
+	}
+	if diff := cmp.Diff(want, file.Idents); diff != "" {
+		t.Errorf("idents mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/gopls/internal/util/asm/parse_test.go
+++ b/gopls/internal/util/asm/parse_test.go
@@ -128,3 +128,67 @@ TEXT ·baz(SB)
 		})
 	}
 }
+
+func TestIdentProperties(t *testing.T) {
+	src := []byte(`
+TEXT ·f(SB), $0-0
+loop:
+	JMP loop
+	CALL loop(SB)
+	MOVQ $table<>(SB), AX
+DATA table<>+0(SB)/8, $1
+GLOBL table<>(SB), RODATA, $8
+DATA ·global+0(SB)/8, $1
+DATA T+0(SB)/8, $1
+spin: JMP spin
+MOVQ foo<>bar(SB), AX
+`[1:])
+	file := asm.Parse(protocol.URIFromPath("asm.s"), src)
+
+	type ident struct {
+		Name  string
+		Kind  asm.Kind
+		Local bool
+		Bare  bool
+	}
+	var got []ident
+	for _, id := range file.Idents {
+		got = append(got, ident{
+			Name:  id.Name,
+			Kind:  id.Kind,
+			Local: id.Local,
+			Bare:  id.Bare,
+		})
+	}
+	want := []ident{
+		{Name: ".f", Kind: asm.Text},
+		{Name: "loop", Kind: asm.Label},
+		{Name: "loop", Kind: asm.Ref, Bare: true},
+		{Name: "loop", Kind: asm.Ref},
+		{Name: "table", Kind: asm.Ref, Local: true},
+		{Name: "table", Kind: asm.Data, Local: true},
+		{Name: "table", Kind: asm.Global, Local: true},
+		{Name: ".global", Kind: asm.Data},
+		{Name: "T", Kind: asm.Data},
+		{Name: "spin", Kind: asm.Label},
+		{Name: "spin", Kind: asm.Ref, Bare: true},
+		{Name: "foo", Kind: asm.Ref},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("identifier properties mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// TestDataPlusOffset checks that a DATA symbol with a +offset is located
+// at the symbol, not at an earlier occurrence of its shortened name
+// (e.g. the "T" inside "DATA").
+func TestDataPlusOffset(t *testing.T) {
+	src := []byte("DATA T+0(SB)/8, $1\n")
+	file := asm.Parse(protocol.URIFromPath("asm.s"), src)
+	want := []asm.Ident{
+		{Name: "T", Offset: 5, OrigLen: 1, Kind: asm.Data},
+	}
+	if diff := cmp.Diff(want, file.Idents); diff != "" {
+		t.Errorf("idents mismatch (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
Extend textDocument/references in Go assembly files to support control labels, file-local symbols, and symbols without Go declarations.
Control labels are scoped to the enclosing TEXT function, and file-local <> symbols are scoped to their source file.

For golang/go#71754