### PR TITLE
go/ssa: distinguish goto from continue for range-over-func

### DIFF
--- a/go/ssa/builder.go
+++ b/go/ssa/builder.go
@@ -3015,7 +3015,8 @@ func (b *builder) buildYieldFunc(fn *Function) {
 			label:     label,
 			resolved:  true,
 			_continue: ycont,
-			// `break label` statement targets fn.parent.targets._break
+			// `goto label` searches the parent lblock, and
+			// `break label` targets fn.parent.targets._break.
 		}
 	}
 	fn.targets = &targets{

--- a/go/ssa/builder.go
+++ b/go/ssa/builder.go
@@ -3011,11 +3011,9 @@ func (b *builder) buildYieldFunc(fn *Function) {
 	ycont := fn.newBasicBlock("yield-continue")
 	// lblocks is either {} or is {label: nil} where label is the label of syntax.
 	for label := range fn.lblocks {
-		parentGoto := fn.parent.lblockOf(label)._goto
 		fn.lblocks[label] = &lblock{
 			label:     label,
 			resolved:  true,
-			_goto:     parentGoto,
 			_continue: ycont,
 			// `break label` statement targets fn.parent.targets._break
 		}

--- a/go/ssa/builder.go
+++ b/go/ssa/builder.go
@@ -3011,10 +3011,11 @@ func (b *builder) buildYieldFunc(fn *Function) {
 	ycont := fn.newBasicBlock("yield-continue")
 	// lblocks is either {} or is {label: nil} where label is the label of syntax.
 	for label := range fn.lblocks {
+		parentGoto := fn.parent.lblockOf(label)._goto
 		fn.lblocks[label] = &lblock{
 			label:     label,
 			resolved:  true,
-			_goto:     ycont,
+			_goto:     parentGoto,
 			_continue: ycont,
 			// `break label` statement targets fn.parent.targets._break
 		}

--- a/go/ssa/interp/rangefunc_test.go
+++ b/go/ssa/interp/rangefunc_test.go
@@ -97,6 +97,7 @@ func TestRangeFunc(t *testing.T) {
 		"TestReturns":               {"[-1 1 2 -10]", "[-1 1 2 -10]", RERR_DONE, "[-1 1 2 -10]", RERR_DONE},
 		"TestGotoA":                 {"testGotoA1[-1 1 2 -2 1 2 -3 1 2 -4 -30 -20 -10]", "testGotoA2[-1 1 2 -2 1 2 -3 1 2 -4 -30 -20 -10]", RERR_DONE, "testGotoA3[-1 1 2 -10]", RERR_DONE},
 		"TestGotoB":                 {"testGotoB1[-1 1 2 999 -10]", "testGotoB2[-1 1 2 -10]", RERR_DONE, "testGotoB3[-1 1 2 -10]", RERR_DONE},
+		"TestGotoRestart":           {"[1 1 1 2 3 4]"},
 		"TestPanicReturns": {
 			"Got expected 'f return'",
 			"Got expected 'g return'",

--- a/go/ssa/interp/testdata/rangefunc.go
+++ b/go/ssa/interp/testdata/rangefunc.go
@@ -51,6 +51,7 @@ func main() {
 	TestReturns("TestReturns")
 	TestGotoA("TestGotoA")
 	TestGotoB("TestGotoB")
+	TestGotoRestart("TestGotoRestart")
 	TestPanicReturns("TestPanicReturns")
 }
 
@@ -1679,6 +1680,21 @@ func TestGotoB(t testingT) {
 	} else {
 		matchErrorHelper(t, err, RERR_DONE)
 	}
+}
+
+func TestGotoRestart(t testingT) {
+	var result []int
+	restarts := 0
+
+again:
+	for _, x := range OfSliceIndex([]int{1, 2, 3, 4}) {
+		result = append(result, x)
+		if x == 1 && restarts < 2 {
+			restarts++
+			goto again
+		}
+	}
+	t.Log(result)
 }
 
 // once returns an iterator that runs its loop body once with the supplied value


### PR DESCRIPTION
go/ssa currently maps both goto L and continue L to the yield
continuation when L labels a range-over-func statement. A goto L must
instead stop the current iterator call and resume at the parent
function's label so that the range statement restarts.

Keep continue L targeting the yield continuation, but point goto L at
the parent's existing label block. The normal cross-function exit
lowering then records and resumes the jump correctly.

The interpreter regression test distinguishes the two operations by
restarting the same labeled range twice.

Fixes golang/go#80860.