### PR TITLE
go/ssa: preserve single-case receive assignment order

### DIFF
--- a/go/ssa/builder.go
+++ b/go/ssa/builder.go
@@ -1236,8 +1236,8 @@ func (b *builder) assignLHS(fn *Function, lhss []ast.Expr, isDef bool) ([]lvalue
 }
 
 // assignSelectRecvStmt emits a receive assignment from a single-case select.
-// Unlike an ordinary assignment, its right-hand side is evaluated and the
-// receive is performed before its left-hand side is evaluated.
+// Unlike an ordinary assignment, its (single expression) right-hand side is
+// evaluated and the receive is performed before its left-hand side is evaluated.
 func (b *builder) assignSelectRecvStmt(fn *Function, assign *ast.AssignStmt) {
 	var values []Value
 	if len(assign.Lhs) == 1 {

--- a/go/ssa/builder.go
+++ b/go/ssa/builder.go
@@ -1193,21 +1193,7 @@ func (b *builder) localValueSpec(fn *Function, spec *ast.ValueSpec) {
 // Note the similarity with localValueSpec.
 func (b *builder) assignStmt(fn *Function, lhss, rhss []ast.Expr, isDef bool) {
 	// Side effects of all LHSs and RHSs must occur in left-to-right order.
-	lvals := make([]lvalue, len(lhss))
-	isZero := make([]bool, len(lhss))
-	for i, lhs := range lhss {
-		var lval lvalue = blank{}
-		if !isBlankIdent(lhs) {
-			if isDef {
-				if obj, ok := fn.info.Defs[lhs.(*ast.Ident)].(*types.Var); ok {
-					emitLocalVar(fn, obj)
-					isZero[i] = true
-				}
-			}
-			lval = b.addr(fn, lhs, false) // non-escaping
-		}
-		lvals[i] = lval
-	}
+	lvals, isZero := b.assignLHS(fn, lhss, isDef)
 	if len(lhss) == len(rhss) {
 		// Simple assignment:   x     = f()        (!isDef)
 		// Parallel assignment: x, y  = f(), g()   (!isDef)
@@ -1227,6 +1213,46 @@ func (b *builder) assignStmt(fn *Function, lhss, rhss []ast.Expr, isDef bool) {
 		for i, lval := range lvals {
 			lval.store(fn, emitExtract(fn, tuple, i))
 		}
+	}
+}
+
+func (b *builder) assignLHS(fn *Function, lhss []ast.Expr, isDef bool) ([]lvalue, []bool) {
+	lvals := make([]lvalue, len(lhss))
+	isZero := make([]bool, len(lhss))
+	for i, lhs := range lhss {
+		var lval lvalue = blank{}
+		if !isBlankIdent(lhs) {
+			if isDef {
+				if obj, ok := fn.info.Defs[lhs.(*ast.Ident)].(*types.Var); ok {
+					emitLocalVar(fn, obj)
+					isZero[i] = true
+				}
+			}
+			lval = b.addr(fn, lhs, false) // non-escaping
+		}
+		lvals[i] = lval
+	}
+	return lvals, isZero
+}
+
+// assignSelectRecvStmt emits a receive assignment from a single-case select.
+// Unlike an ordinary assignment, its right-hand side is evaluated and the
+// receive is performed before its left-hand side is evaluated.
+func (b *builder) assignSelectRecvStmt(fn *Function, assign *ast.AssignStmt) {
+	var values []Value
+	if len(assign.Lhs) == 1 {
+		values = append(values, b.expr(fn, assign.Rhs[0]))
+	} else {
+		tuple := b.exprN(fn, assign.Rhs[0])
+		emitDebugRef(fn, assign.Rhs[0], tuple, false)
+		for i := range assign.Lhs {
+			values = append(values, emitExtract(fn, tuple, i))
+		}
+	}
+
+	lvals, _ := b.assignLHS(fn, assign.Lhs, assign.Tok == token.DEFINE)
+	for i, lval := range lvals {
+		lval.store(fn, values[i])
 	}
 }
 
@@ -1631,7 +1657,11 @@ func (b *builder) selectStmt(fn *Function, s *ast.SelectStmt, label *lblock) {
 	if len(s.Body.List) == 1 {
 		clause := s.Body.List[0].(*ast.CommClause)
 		if clause.Comm != nil {
-			b.stmt(fn, clause.Comm)
+			if recvAssign, ok := clause.Comm.(*ast.AssignStmt); ok {
+				b.assignSelectRecvStmt(fn, recvAssign)
+			} else {
+				b.stmt(fn, clause.Comm)
+			}
 			done := fn.newBasicBlock("select.done")
 			if label != nil {
 				label._break = done

--- a/go/ssa/interp/testdata/coverage.go
+++ b/go/ssa/interp/testdata/coverage.go
@@ -156,6 +156,39 @@ func main() {
 	_ = anint
 	_ = ok
 
+	// The left-hand side of a receive assignment in a select is
+	// evaluated after the receive, even when the select has one case.
+	order := [2]int{}
+	next := 0
+	recvch := make(chan int, 1)
+	recvch <- 1
+	channel := func() chan int {
+		order[next] = 1
+		next++
+		return recvch
+	}
+	address := func() *int {
+		order[next] = 2
+		next++
+		return &anint
+	}
+	select {
+	case *address() = <-channel():
+	}
+	if order != [2]int{1, 2} {
+		panic(order)
+	}
+	order = [2]int{}
+	next = 0
+	ok = false
+	recvch <- 2
+	select {
+	case *address(), ok = <-channel():
+	}
+	if order != [2]int{1, 2} || anint != 2 || !ok {
+		panic("two-result receive assignment")
+	}
+
 	// Anon structs with methods.
 	anon := struct{ T }{T: T{z: 1}}
 	if x := anon.f(); x != 1 {

--- a/go/ssa/interp/testdata/coverage.go
+++ b/go/ssa/interp/testdata/coverage.go
@@ -160,6 +160,7 @@ func main() {
 	// evaluated after the receive, even when the select has one case.
 	order := [2]int{}
 	next := 0
+	recvval := 0
 	recvch := make(chan int, 1)
 	recvch <- 1
 	channel := func() chan int {
@@ -170,13 +171,13 @@ func main() {
 	address := func() *int {
 		order[next] = 2
 		next++
-		return &anint
+		return &recvval
 	}
 	select {
 	case *address() = <-channel():
 	}
-	if order != [2]int{1, 2} {
-		panic(order)
+	if order != [2]int{1, 2} || recvval != 1 {
+		panic("single-result receive assignment")
 	}
 	order = [2]int{}
 	next = 0
@@ -185,8 +186,20 @@ func main() {
 	select {
 	case *address(), ok = <-channel():
 	}
-	if order != [2]int{1, 2} || anint != 2 || !ok {
+	if order != [2]int{1, 2} || recvval != 2 || !ok {
 		panic("two-result receive assignment")
+	}
+	order = [2]int{}
+	next = 0
+	recvch <- 3
+	select {
+	case recvval, recvOK := <-channel():
+		if recvval != 3 || !recvOK {
+			panic("receive short variable declaration")
+		}
+	}
+	if order != [2]int{1, 0} {
+		panic("receive short variable declaration order")
 	}
 
 	// Anon structs with methods.


### PR DESCRIPTION
A single-case select is optimized to a simple statement. For a receive
assignment, ordinary assignment lowering evaluates the left-hand side
before the receive. Select semantics require the receive expression and
communication to happen before the assignment left-hand side is
evaluated.

Evaluate the receive before constructing the assignment left-hand side,
while retaining the existing single-case fast path and SSA shape for the
other communication forms. Add interpreter coverage for both one-result
and two-result receive assignments.

Fixes golang/go#80863.