### PR TITLE
go/ssa: allow transient untyped integer values

### DIFF
--- a/go/ssa/builder_test.go
+++ b/go/ssa/builder_test.go
@@ -1037,6 +1037,7 @@ func TestFixedBugs(t *testing.T) {
 		"issue66783a",
 		"issue66783b",
 		"issue73594",
+		"issue77067",
 		"issue78110",
 		"issue73871",
 	} {

--- a/go/ssa/sanity.go
+++ b/go/ssa/sanity.go
@@ -233,13 +233,17 @@ func (s *sanity) checkInstr(idx int, instr Instruction) {
 		t := v.Type()
 		if t == nil {
 			s.errorf("no type: %s = %s", v.Name(), v)
-		} else if b, ok := t.Underlying().(*types.Basic); ok && b.Info()&types.IsUntyped != 0 {
+		} else if b, ok := t.Underlying().(*types.Basic); ok &&
+			b.Info()&types.IsUntyped != 0 && b.Info()&types.IsInteger == 0 {
+			// Non-constant untyped integer values may arise transiently
+			// while evaluating shift expressions.
 			s.errorf("instruction has 'untyped' result: %s = %s : %s", v.Name(), v, t)
 		}
 		s.checkReferrerList(v)
 	}
 
-	// Untyped constants are legal as instruction Operands(),
+	// Untyped constants and transient untyped integer values are legal
+	// as instruction Operands(),
 	// for example:
 	//   _ = "foo"[0]
 	// or:
@@ -367,10 +371,11 @@ func (s *sanity) checkBlock(b *BasicBlock, index int) {
 				continue // a nil operand is ok
 			}
 
-			// Check that "untyped" types only appear on constant operands.
+			// Check that "untyped" types only appear on constant operands
+			// or transient integer values produced by shift expressions.
 			if _, ok := (*op).(*Const); !ok {
 				if basic, ok := (*op).Type().Underlying().(*types.Basic); ok {
-					if basic.Info()&types.IsUntyped != 0 {
+					if basic.Info()&types.IsUntyped != 0 && basic.Info()&types.IsInteger == 0 {
 						s.errorf("operand #%d of %s is untyped: %s", i, instr, basic)
 					}
 				}

--- a/go/ssa/testdata/fixedbugs/issue77067.go
+++ b/go/ssa/testdata/fixedbugs/issue77067.go
@@ -1,0 +1,18 @@
+// This program produces non-constant untyped integer values while
+// evaluating shift expressions. These values are permitted transiently
+// by the Go specification and must be accepted by the SSA sanity check.
+
+package issue77067
+
+func nestedShift(bytes []byte) uint32 {
+	value := uint32(1)
+	return value << (1 << bytes[3])
+}
+
+func arithmeticShiftCount(value uint) uint {
+	return value >> ((1 >> value) + (1 >> value))
+}
+
+func runeShiftCount(value uint) uint {
+	return value >> ('a' << value)
+}


### PR DESCRIPTION
Non-constant untyped integer values may arise transiently while
evaluating shift expressions. The builder already preserves these values,
but the sanity checker rejects them as invalid SSA.

Permit untyped integer instruction results and operands, while retaining
the checks for all other non-constant untyped values. Add examples that
exercise nested, arithmetic, and untyped-rune shift counts.

This follows the conclusion in golang/go#77067 and the specification
clarification tracked by golang/go#77117.

Fixes golang/go#77067.