### PR TITLE
go/ssa: use valid types for synthetic values

### DIFF
--- a/go/ssa/builder.go
+++ b/go/ssa/builder.go
@@ -89,11 +89,6 @@ import (
 	"golang.org/x/tools/internal/versions"
 )
 
-type opaqueType struct{ name string }
-
-func (t *opaqueType) String() string         { return t.name }
-func (t *opaqueType) Underlying() types.Type { return t }
-
 var (
 	varOk    = newVar("ok", tBool)
 	varIndex = newVar("index", tInt)
@@ -107,8 +102,10 @@ var (
 	tString     = types.Typ[types.String]
 	tUntypedNil = types.Typ[types.UntypedNil]
 
-	tRangeIter  = &opaqueType{"iter"}                         // the type of all "range" iterators
-	tDeferStack = types.NewPointer(&opaqueType{"deferStack"}) // the type of a "deferStack" from ssa:deferstack()
+	// These synthetic values have inaccurate but valid Go types so that
+	// clients can safely use them with APIs that accept types.Type.
+	tRangeIter  = types.NewTuple()                            // the type of all "range" iterators
+	tDeferStack = types.NewPointer(types.NewStruct(nil, nil)) // the type of a "deferStack" from ssa:deferstack()
 	tEface      = types.NewInterfaceType(nil, nil).Complete()
 
 	// SSA Value constants.

--- a/go/ssa/builder_test.go
+++ b/go/ssa/builder_test.go
@@ -28,6 +28,7 @@ import (
 	"golang.org/x/tools/go/packages"
 	"golang.org/x/tools/go/ssa"
 	"golang.org/x/tools/go/ssa/ssautil"
+	"golang.org/x/tools/go/types/typeutil"
 	"golang.org/x/tools/internal/expect"
 	"golang.org/x/tools/internal/testenv"
 )
@@ -1080,6 +1081,58 @@ func TestFixedBugs(t *testing.T) {
 				t.Error(err)
 			}
 		})
+	}
+}
+
+func TestSyntheticValueTypes(t *testing.T) {
+	const source = `package p
+
+func rangeMap(m map[string]int) {
+	for range m {
+	}
+}
+
+func rangeFunc(seq func(func() bool)) {
+	for range seq {
+		defer func() {}()
+	}
+}
+`
+
+	pkg, _ := buildPackage(t, source, ssa.SanityCheckFunctions)
+	var rangeType, deferStackType types.Type
+	for fn := range ssautil.AllFunctions(pkg.Prog) {
+		for _, block := range fn.Blocks {
+			for _, instr := range block.Instrs {
+				switch instr := instr.(type) {
+				case *ssa.Range:
+					rangeType = instr.Type()
+				case *ssa.Defer:
+					if instr.DeferStack != nil {
+						deferStackType = instr.DeferStack.Type()
+					}
+				}
+			}
+		}
+	}
+
+	if tuple, ok := rangeType.(*types.Tuple); !ok || tuple.Len() != 0 {
+		t.Fatalf("Range type = %v (%T), want ()", rangeType, rangeType)
+	}
+	ptr, ok := deferStackType.(*types.Pointer)
+	if !ok {
+		t.Fatalf("DeferStack type = %v (%T), want *struct{}", deferStackType, deferStackType)
+	}
+	if strct, ok := ptr.Elem().Underlying().(*types.Struct); !ok || strct.NumFields() != 0 {
+		t.Errorf("DeferStack type = %v, want *struct{}", deferStackType)
+	}
+
+	// Synthetic types should work with utilities that accept go/types types.
+	var typeMap typeutil.Map
+	typeMap.Set(rangeType, true)
+	typeMap.Set(deferStackType, true)
+	if typeMap.Len() != 2 {
+		t.Errorf("type map contains %d entries, want 2", typeMap.Len())
 	}
 }
 

--- a/go/ssa/sanity.go
+++ b/go/ssa/sanity.go
@@ -233,8 +233,6 @@ func (s *sanity) checkInstr(idx int, instr Instruction) {
 		t := v.Type()
 		if t == nil {
 			s.errorf("no type: %s = %s", v.Name(), v)
-		} else if t == tRangeIter || t == tDeferStack {
-			// not a proper type; ignore.
 		} else if b, ok := t.Underlying().(*types.Basic); ok && b.Info()&types.IsUntyped != 0 {
 			s.errorf("instruction has 'untyped' result: %s = %s : %s", v.Name(), v, t)
 		}

--- a/go/ssa/subst.go
+++ b/go/ssa/subst.go
@@ -158,9 +158,6 @@ func (subst *subster) typ(t types.Type) (res types.Type) {
 	case *types.Named:
 		return subst.named(t)
 
-	case *opaqueType:
-		return t // opaque types are never substituted
-
 	default:
 		panic("unreachable")
 	}


### PR DESCRIPTION
Range iterator and defer stack values currently use a private
opaqueType. It is not a valid go/types type, so ordinary type utilities
may panic and clients must detect it through implementation details.
LLGo currently uses reflection for this purpose.

Use inaccurate but valid Go types instead: () for range iterators and
*struct{} for defer stacks. These are the directions suggested in the
existing issue discussions. Remove the now-unneeded substitution and
sanity-check exceptions, and verify both values work with typeutil.Map.

This would let LLGo remove its private-type reflection workaround added
in xgo-dev/llgo#1826.

Fixes golang/go#19670.
Fixes golang/go#72914.