### PR TITLE
go/analysis/passes/unusedresult: don't report calls in b.Loop bodies

### DIFF
--- a/go/analysis/passes/unusedresult/testdata/src/a/a.go
+++ b/go/analysis/passes/unusedresult/testdata/src/a/a.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	. "fmt"
+	"testing"
 )
 
 func _() {
@@ -28,4 +29,20 @@ func _() {
 
 	Sprint("")  // want "result of fmt.Sprint call not used"
 	Sprintf("") // want "result of fmt.Sprintf call not used"
+}
+
+func _(b *testing.B) {
+	var buf bytes.Buffer
+	buf.String() // want `result of \(\*bytes.Buffer\).String call not used`
+
+	for b.Loop() {
+		// b.Loop keeps the results of these calls alive; not a mistake.
+		buf.String()
+		fmt.Sprint("")
+	}
+
+	// Only b.Loop is special; an ordinary loop still reports.
+	for i := 0; i < 2; i++ {
+		buf.String() // want `result of \(\*bytes.Buffer\).String call not used`
+	}
 }

--- a/go/analysis/passes/unusedresult/unusedresult.go
+++ b/go/analysis/passes/unusedresult/unusedresult.go
@@ -139,16 +139,22 @@ func run(pass *analysis.Pass) (any, error) {
 	nodeFilter := []ast.Node{
 		(*ast.ExprStmt)(nil),
 	}
-	inspect.Preorder(nodeFilter, func(n ast.Node) {
-		call, ok := ast.Unparen(n.(*ast.ExprStmt).X).(*ast.CallExpr)
+	for cur := range inspect.Root().Preorder(nodeFilter...) {
+		call, ok := ast.Unparen(cur.Node().(*ast.ExprStmt).X).(*ast.CallExpr)
 		if !ok {
-			return // not a call statement
+			continue // not a call statement
+		}
+
+		// A call in the body of a "for b.Loop() {…}" benchmark loop
+		// keeps its result alive by design, so it is not a mistake.
+		if inBenchmarkLoop(pass.TypesInfo, cur) {
+			continue
 		}
 
 		// Call to function or method?
 		fn, ok := typeutil.Callee(pass.TypesInfo, call).(*types.Func)
 		if !ok {
-			return // e.g. var or builtin
+			continue // e.g. var or builtin
 		}
 		if sig := fn.Signature(); sig.Recv() != nil {
 			// method (e.g. foo.String())
@@ -167,8 +173,29 @@ func run(pass *analysis.Pass) (any, error) {
 					fn.Pkg().Path(), fn.Name())
 			}
 		}
-	})
+	}
 	return nil, nil
+}
+
+// inBenchmarkLoop reports whether cur, an *ast.ExprStmt, is a statement in
+// the body of a "for b.Loop() {…}" loop, where b has type *testing.B.
+// testing.B.Loop keeps the results of such calls alive, so they are
+// intentionally unused.
+func inBenchmarkLoop(info *types.Info, cur inspector.Cursor) bool {
+	// The statement's parent is the loop body; its grandparent is the loop.
+	if _, ok := cur.Parent().Node().(*ast.BlockStmt); !ok {
+		return false
+	}
+	loop, ok := cur.Parent().Parent().Node().(*ast.ForStmt)
+	if !ok {
+		return false
+	}
+	cond, ok := ast.Unparen(loop.Cond).(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	fn, ok := typeutil.Callee(info, cond).(*types.Func)
+	return ok && typesinternal.IsMethodNamed(fn, "testing", "B", "Loop")
 }
 
 // func() string


### PR DESCRIPTION
The testing.B.Loop method keeps the results of calls in the benchmark
loop body alive, so a bare call whose result is unused inside such a
loop is intentional rather than a mistake. Suppress the diagnostic for
a call statement directly in the body of a for loop whose condition
calls the Loop method of testing.B.

Calls nested more deeply, for example inside a further if statement or
loop, are left unchanged.

Fixes golang/go#76308
