### PR TITLE
cmd/goyacc: don't panic on grammar files ending without a newline

### DIFF
--- a/cmd/goyacc/yacc.go
+++ b/cmd/goyacc/yacc.go
@@ -3156,6 +3156,13 @@ func ungetrune(f *bufio.Reader, c rune) {
 	if f != finput {
 		panic("ungetc - not finput")
 	}
+	if c == EOF {
+		// getrune keeps EOF sticky in peekrune, so re-ungetting EOF (e.g.
+		// from gettok's IDENTIFIER/IDENTCOLON look-ahead at end of file)
+		// must not trip the single-slot check; an exhausted reader returns
+		// EOF again anyway.
+		return
+	}
 	if peekrune != 0 {
 		panic("ungetc - 2nd unget")
 	}


### PR DESCRIPTION
Fixes golang/go#81182.

`getrune` keeps EOF sticky in the single-slot `peekrune` buffer (it returns EOF without clearing the slot). When `gettok`'s IDENTIFIER/IDENTCOLON look-ahead reaches end-of-file and ungets the EOF rune, `ungetrune` hits its single-slot "2nd unget" panic — a 10-byte grammar with no trailing newline crashes:

```
$ printf '%%\nS: A; B' > v2.y && goyacc -o /dev/null v2.y
panic: ungetc - 2nd unget

goroutine 1 [running]:
main.ungetrune(...)
	cmd/goyacc/yacc.go:3160
main.gettok()
	cmd/goyacc/yacc.go:990
```

Make ungetting EOF a no-op: an exhausted reader returns EOF again on the next read regardless, so behavior for well-formed files is unchanged. With the fix the example reports the proper `illegal rule: missing semicolon or |` error and exits 1, and a valid grammar compiles to identical output.