### PR TITLE
go/ssa: canonicalize selection types before the isParameterized check

### DIFF
--- a/go/ssa/methods.go
+++ b/go/ssa/methods.go
@@ -32,7 +32,10 @@ func (prog *Program) MethodValue(sel *types.Selection) *Function {
 		return nil // interface method or type parameter
 	}
 
-	if prog.isParameterized(T, sel.Type()) {
+	// Selection.Type allocates a new Signature on each call, and
+	// isParameterized memoizes by type identity, so an uncanonicalized
+	// argument would add one permanently retained entry per call (#81308).
+	if prog.isParameterized(T, prog.canon.Type(sel.Type())) {
 		return nil // method on generic type or generic method
 	}
 


### PR DESCRIPTION
MethodValue calls prog.isParameterized(T, sel.Type()) for every (type, method) pair, sel.Type() allocates a fresh Signature each time, and isParameterized memoizes by type identity in a map that's never cleared

Fixes golang/go#81308