### PR TITLE
gopls/internal/vulncheck/scan: pass the pattern after "--"

### DIFF
--- a/gopls/internal/vulncheck/scan/command.go
+++ b/gopls/internal/vulncheck/scan/command.go
@@ -51,7 +51,9 @@ func RunGovulncheck(ctx context.Context, pattern string, snapshot *cache.Snapsho
 	if db := cache.GetEnv(snapshot, "GOVULNDB"); db != "" {
 		vulncheckargs = append(vulncheckargs, "-db", db)
 	}
-	vulncheckargs = append(vulncheckargs, pattern)
+	// Pass the pattern after an end-of-options separator, so that it is
+	// always interpreted as a package pattern.
+	vulncheckargs = append(vulncheckargs, "--", pattern)
 	// TODO: support -tags. need to compute tags args from opts.BuildFlags.
 	// TODO: support -test.
 


### PR DESCRIPTION
RunGovulncheck appends the caller-supplied package pattern to the
govulncheck argument vector without an end-of-options separator, so a
pattern beginning with "-" is parsed by govulncheck's flag set rather
than treated as a package pattern.

Appending "--" before the pattern makes it always positional.

Tested with go test ./gopls/internal/vulncheck/... and the -run Vuln
integration test in gopls/internal/test/integration/misc; both pass
with the change applied.