### PR TITLE
go/ssa: skip Selection.Type in MethodValue for non-generic methods

### DIFF
--- a/go/ssa/methods.go
+++ b/go/ssa/methods.go
@@ -32,10 +32,18 @@ func (prog *Program) MethodValue(sel *types.Selection) *Function {
 		return nil // interface method or type parameter
 	}
 
-	// Selection.Type allocates a new Signature on each call, and
-	// isParameterized memoizes by type identity, so an uncanonicalized
+	// When the method has no type parameters of its own, the selection type
+	// is parameterized iff the receiver is, so the receiver check alone
+	// suffices and Selection.Type() — which allocates a new Signature on
+	// every call — need not be materialized. Only generic methods take the
+	// full check; there the type is canonicalized first, since
+	// isParameterized memoizes by type identity and an uncanonicalized
 	// argument would add one permanently retained entry per call (#81308).
-	if prog.isParameterized(T, prog.canon.Type(sel.Type())) {
+	if sel.Obj().(*types.Func).Signature().TypeParams().Len() == 0 {
+		if prog.isParameterized(T) {
+			return nil // method on generic type
+		}
+	} else if prog.isParameterized(T, prog.canon.Type(sel.Type())) {
 		return nil // method on generic type or generic method
 	}
 


### PR DESCRIPTION
Follow-up to CL 826224 (the #81308 memory fix). That fix stopped the
per-selection Signatures from being retained, but they were still
allocated: MethodValue materializes sel.Type() for every (type, method)
pair, and on large programs the churn is real GC load.

When the method has no type parameters of its own, a ground receiver
can't leave free type parameters in the selection type, so the
receiver-only check is equivalent and nothing needs to be materialized.
Generic methods keep the full canonicalized check.

Makes deadcode ~8% faster on a benchmark of kubernetes/cmd/kubelet
(7.15s to 6.55s)

Updates golang/go#81308
