### PR TITLE
gopls: add function end name inlay hints

### DIFF
--- a/gopls/doc/features/index.md
+++ b/gopls/doc/features/index.md
@@ -30,7 +30,7 @@ when making significant changes to existing features or when adding new ones.
   - [Hover](passive.md#hover): information about the symbol under the cursor
   - [Signature Help](passive.md#signature-help): type information about the enclosing function call
   - [Document Highlight](passive.md#document-highlight): highlight identifiers referring to the same symbol
-  - [Inlay Hint](passive.md#inlay-hint): show implicit names of struct fields and parameter names
+  - [Inlay Hint](passive.md#inlay-hint): show implicit names, types, values, and function ends
   - [Semantic Tokens](passive.md#semantic-tokens): report syntax information used by editors to color the text
   - [Folding Range](passive.md#folding-range): report text regions that can be "folded" (expanded/collapsed) in an editor
   - [Document Link](passive.md#document-link): extracts URLs from doc comments, strings in current file so client can linkify

--- a/gopls/doc/features/passive.md
+++ b/gopls/doc/features/passive.md
@@ -181,6 +181,8 @@ Examples:
   variables k and v (`rangeVariableTypes`).
 - For a constant expression (perhaps using `iota`), a hint provides
   its computed value (`constantValues`).
+- At the closing brace of a function or method declaration, a hint provides
+  its name (`functionEndNames`).
 
 See [Inlay hints](../inlayHints.md) for a complete list with examples.
 

--- a/gopls/doc/inlayHints.md
+++ b/gopls/doc/inlayHints.md
@@ -60,6 +60,17 @@ from `gopls`.
 
 **Disabled by default. Enable it by setting `"hints": {"constantValues": true}`.**
 
+## **functionEndNames**
+
+`"functionEndNames"` controls inlay hints for function and method names at their closing braces:
+```go
+	func foo() {
+	}« // foo»
+```
+
+
+**Disabled by default. Enable it by setting `"hints": {"functionEndNames": true}`.**
+
 ## **functionTypeParameters**
 
 `"functionTypeParameters"` inlay hints for implicit type parameters on generic functions:

--- a/gopls/doc/release/v0.24.0.md
+++ b/gopls/doc/release/v0.24.0.md
@@ -37,6 +37,12 @@ can still be used by users to further restrict these lists.
 
 ## Editing features
 
+### `functionEndNames` inlay hint
+
+The new `functionEndNames` inlay hint shows the name of a function or method
+at its closing brace. Enable it using this configuration:
+`{"hints": {"functionEndNames": true}}`.
+
 Gopls now supports the Hover request in Go assembly files: hovering
 over a symbol reports the signature and doc comment of its Go
 declaration.

--- a/gopls/internal/doc/api.json
+++ b/gopls/internal/doc/api.json
@@ -2088,6 +2088,12 @@
 							"Status": ""
 						},
 						{
+							"Name": "\"functionEndNames\"",
+							"Doc": "`\"functionEndNames\"` controls inlay hints for function and method names at their closing braces:\n```go\n\tfunc foo() {\n\t}« // foo»\n```\n",
+							"Default": "false",
+							"Status": ""
+						},
+						{
 							"Name": "\"functionTypeParameters\"",
 							"Doc": "`\"functionTypeParameters\"` inlay hints for implicit type parameters on generic functions:\n```go\n\tmyFoo«[int, string]»(1, \"hello\")\n```\n",
 							"Default": "false",
@@ -3988,6 +3994,12 @@
 		{
 			"Name": "constantValues",
 			"Doc": "`\"constantValues\"` controls inlay hints for constant values:\n```go\n\tconst (\n\t\tKindNone   Kind = iota« = 0»\n\t\tKindPrint«  = 1»\n\t\tKindPrintf« = 2»\n\t\tKindErrorf« = 3»\n\t)\n```\n",
+			"Default": false,
+			"Status": ""
+		},
+		{
+			"Name": "functionEndNames",
+			"Doc": "`\"functionEndNames\"` controls inlay hints for function and method names at their closing braces:\n```go\n\tfunc foo() {\n\t}« // foo»\n```\n",
 			"Default": false,
 			"Status": ""
 		},

--- a/gopls/internal/golang/inlay_hint.go
+++ b/gopls/internal/golang/inlay_hint.go
@@ -88,7 +88,25 @@ var allInlayHints = map[settings.InlayHint]inlayHintFunc{
 	settings.CompositeLiteralTypes:      compositeLiteralTypes,
 	settings.CompositeLiteralFieldNames: compositeLiteralFields,
 	settings.FunctionTypeParameters:     funcTypeParams,
+	settings.FunctionEndNames:           functionEndNames,
 	settings.IgnoredError:               ignoredError,
+}
+
+func functionEndNames(info *types.Info, pgf *parsego.File, qual types.Qualifier, cur inspector.Cursor, add func(protocol.InlayHint)) {
+	for curFunc := range cur.Preorder((*ast.FuncDecl)(nil)) {
+		decl := curFunc.Node().(*ast.FuncDecl)
+		if decl.Body == nil {
+			continue
+		}
+		pos, err := pgf.PosPosition(decl.Body.End())
+		if err != nil {
+			continue
+		}
+		add(protocol.InlayHint{
+			Position: pos,
+			Label:    labelPart(" // " + decl.Name.Name),
+		})
+	}
 }
 
 func parameterNames(info *types.Info, pgf *parsego.File, qual types.Qualifier, cur inspector.Cursor, add func(protocol.InlayHint)) {

--- a/gopls/internal/settings/settings.go
+++ b/gopls/internal/settings/settings.go
@@ -631,6 +631,13 @@ const (
 	// ```
 	FunctionTypeParameters InlayHint = "functionTypeParameters"
 
+	// FunctionEndNames controls inlay hints for function and method names at their closing braces:
+	// ```go
+	// 	func foo() {
+	// 	}« // foo»
+	// ```
+	FunctionEndNames InlayHint = "functionEndNames"
+
 	// IgnoredError inlay hints for implicitly discarded errors:
 	// ```go
 	// 	f.Close()« // ignore error»

--- a/gopls/internal/test/marker/testdata/inlayhints/function-end-names.txt
+++ b/gopls/internal/test/marker/testdata/inlayhints/function-end-names.txt
@@ -1,0 +1,26 @@
+Test of the "function end names" inlay hint (#80465).
+
+-- settings.json --
+{"hints": {"functionEndNames": true}}
+
+-- p/p.go --
+package p //@inlayhints(out)
+
+type T struct{}
+
+func foo() {
+	func() {}
+}
+
+func (T) method() {}
+
+-- @out --
+package p //@inlayhints(out)
+
+type T struct{}
+
+func foo() {
+	func() {}
+}< // foo>
+
+func (T) method() {}< // method>


### PR DESCRIPTION
Add an opt-in functionEndNames inlay hint that annotates the closing
brace of named function and method declarations with their declared
names. Function literals are intentionally excluded.

Add marker coverage and document the setting in the feature index,
generated API reference, and v0.24.0 release notes.

Fixes golang/go#80465