### PR TITLE
gopls/internal/golang/completion: report types in unimported completion

### DIFF
--- a/gopls/internal/cache/symbols/symbols.go
+++ b/gopls/internal/cache/symbols/symbols.go
@@ -93,8 +93,6 @@ func symbolizeFile(pgf *parsego.File) []Symbol {
 						kind = protocol.Interface
 					case *ast.StructType:
 						kind = protocol.Struct
-					case *ast.FuncType:
-						kind = protocol.Function
 					}
 					w.declare(spec.Name.Name, kind, spec.Name)
 					w.walkType(spec.Type, spec.Name)

--- a/gopls/internal/golang/completion/unimported.go
+++ b/gopls/internal/golang/completion/unimported.go
@@ -233,9 +233,15 @@ func (c *completer) pkgIDmatches(ctx context.Context, ids []metadata.PackageID, 
 					}
 					kind = protocol.FunctionCompletion
 					detail = fmt.Sprintf("func (from %q)", pkg.PkgPath)
-				case protocol.Variable, protocol.Struct:
+				case protocol.Variable:
 					kind = protocol.VariableCompletion
 					detail = fmt.Sprintf("var (from %q)", pkg.PkgPath)
+				case protocol.Interface:
+					kind = protocol.InterfaceCompletion
+					detail = fmt.Sprintf("type (from %q)", pkg.PkgPath)
+				case protocol.Struct, protocol.Class:
+					kind = protocol.ClassCompletion
+					detail = fmt.Sprintf("type (from %q)", pkg.PkgPath)
 				case protocol.Constant:
 					kind = protocol.ConstantCompletion
 					detail = fmt.Sprintf("const (from %q)", pkg.PkgPath)
@@ -284,7 +290,7 @@ func (c *completer) stdlibMatches(pkgs []metadata.PackagePath, pkg metadata.Pack
 					kind = protocol.VariableCompletion
 					detail = fmt.Sprintf("var (from %q)", candpkg)
 				case stdlib.Type:
-					kind = protocol.VariableCompletion
+					kind = protocol.ClassCompletion
 					detail = fmt.Sprintf("type (from %q)", candpkg)
 				default:
 					continue
@@ -331,7 +337,7 @@ func (c *completer) modcacheMatches(pkg metadata.PackageName, prefix string) ([]
 			kind = protocol.ConstantCompletion
 			detail = fmt.Sprintf("const (from %s)", cand.ImportPath)
 		case modindex.Type: // might be a type alias
-			kind = protocol.VariableCompletion
+			kind = protocol.ClassCompletion
 			detail = fmt.Sprintf("type (from %s)", cand.ImportPath)
 		default:
 			continue

--- a/gopls/internal/golang/symbols.go
+++ b/gopls/internal/golang/symbols.go
@@ -249,10 +249,6 @@ func typeDetails(m *protocol.Mapper, tf *token.File, typExpr ast.Expr) (kind pro
 			detail = "interface{}"
 		}
 
-	case *ast.FuncType:
-		kind = protocol.Function
-		detail = types.ExprString(typExpr)
-
 	default:
 		kind = protocol.Class // catch-all, for cases where we don't know the kind syntactically
 		detail = types.ExprString(typExpr)

--- a/gopls/internal/test/integration/misc/package_symbols_test.go
+++ b/gopls/internal/test/integration/misc/package_symbols_test.go
@@ -26,6 +26,7 @@ package a
 
 var A = "var"
 type S struct{}
+type FuncType func(int) int
 
 func (s *S) M1() {}
 -- b.go --
@@ -67,6 +68,7 @@ var Unloaded int
 			Symbols: []command.PackageSymbol{
 				{Name: "A", Kind: protocol.Variable, File: 0},
 				{Name: "F", Kind: protocol.Function, File: 1},
+				{Name: "FuncType", Kind: protocol.Class, File: 0},
 				{Name: "S", Kind: protocol.Struct, File: 0, Children: []command.PackageSymbol{
 					{Name: "M1", Kind: protocol.Method, File: 0},
 					{Name: "M2", Kind: protocol.Method, File: 1},

--- a/gopls/internal/test/marker/testdata/completion/unimported.txt
+++ b/gopls/internal/test/marker/testdata/completion/unimported.txt
@@ -21,6 +21,11 @@ func Foo() {}
 package foo
 
 type StructFoo struct{ F int }
+type ArrayFoo [16]byte
+type InterfaceFoo interface{}
+type FuncFoo func(int)
+
+func FuncDeclFoo(i int) {}
 
 -- baz/baz.go --
 package baz
@@ -41,6 +46,10 @@ func _() {
 	signature.Foo //@complete(re"()Foo", signaturefoo)
 
 	context.Bac //@complete(re"() \\/\\/", contextBackground)
+
+	// Types of a workspace package that is not imported yet, and a function
+	// declaration to tell apart from the named function type.
+	foo. //@complete(re"foo.() \\/\\/", fooArray, fooFuncDecl, fooFunc, fooInterface, fooStruct)
 }
 
 // Create markers for unimported std lib packages. Only for use by this test.
@@ -49,7 +58,13 @@ func _() {
 /* httptrace */ //@item(httptrace, "httptrace", "\"net/http/httptrace\"", "package")
 /* httputil */ //@item(httputil, "httputil", "\"net/http/httputil\"", "package")
 
-/* ring.Ring */ //@item(ringring, "Ring", "type (from \"container/ring\")", "var")
+/* ring.Ring */ //@item(ringring, "Ring", "type (from \"container/ring\")", "type")
+
+/* foo.ArrayFoo */ //@item(fooArray, "ArrayFoo", "type (from \"unimported.test/foo\")", "type")
+/* foo.FuncDeclFoo */ //@item(fooFuncDecl, "FuncDeclFoo", "func (from \"unimported.test/foo\")", "func")
+/* foo.FuncFoo */ //@item(fooFunc, "FuncFoo", "type (from \"unimported.test/foo\")", "type")
+/* foo.InterfaceFoo */ //@item(fooInterface, "InterfaceFoo", "type (from \"unimported.test/foo\")", "interface")
+/* foo.StructFoo */ //@item(fooStruct, "StructFoo", "type (from \"unimported.test/foo\")", "type")
 
 /* signature.Foo */ //@item(signaturefoo, "Foo", "func (from \"unimported.test/signature\")", "func")
 


### PR DESCRIPTION
pkgIDmatches handled only the Function, Variable, Struct and Constant symbol
kinds, so an interface or a named non-struct type from a workspace package
was dropped, and a struct type was reported as "var". Report every type as
"type (from ...)", as the other two search paths already do.

All three paths gave a type VariableCompletion, so editors drew a variable
icon beside an item whose detail read "type". Use InterfaceCompletion for an
interface and ClassCompletion otherwise. The standard library and module
cache indexes do not record whether a type is an interface, so those two
paths always use ClassCompletion.

Fixes golang/go#81369
