### PR TITLE
gopls/internal/golang/completion: report label details for completion items

### DIFF
--- a/gopls/doc/release/v0.24.0.md
+++ b/gopls/doc/release/v0.24.0.md
@@ -50,6 +50,13 @@ reads.
 The `textDocument/references` request in Go assembly files now supports
 control labels and symbols that have no corresponding Go declaration.
 
+Completion items now report
+[`labelDetails`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocument_completion)
+to clients that advertise `completionItem.labelDetailsSupport`: `detail`
+holds the signature or the type of the item, and `description` holds the
+import path that accepting it adds to the file. Only an item that adds
+an import has a `description`, so a client can mark those items.
+
 ## Analysis features
 
 <!-- TODO Gopls is now using staticcheck [v0.8.0-rc1](https://github.com/dominikh/go-tools/releases/tag/2026.2rc1). -->

--- a/gopls/internal/golang/completion/completion.go
+++ b/gopls/internal/golang/completion/completion.go
@@ -58,6 +58,11 @@ type CompletionItem struct {
 	// This often contains the type or return type of the completion item.
 	Detail string
 
+	// LabelDetails is the same information split into the two fields that
+	// LSP 3.17 gives defined positions. It is sent only to clients that
+	// advertise labelDetailsSupport, and is nil when there is nothing to say.
+	LabelDetails *protocol.CompletionItemLabelDetails
+
 	// InsertText is the text to insert if this item is selected.
 	// Any of the prefix that has already been typed is not trimmed.
 	// The insert text does not contain snippets.

--- a/gopls/internal/golang/completion/format.go
+++ b/gopls/internal/golang/completion/format.go
@@ -28,6 +28,34 @@ var (
 	errLowScore = errors.New("not a high scoring candidate")
 )
 
+// labelDetails builds the LSP label details for a candidate. detail is the
+// type of the candidate, and description its import path, empty unless
+// accepting the candidate adds an import.
+//
+// The detail is rendered immediately after the label with no spacing, so a
+// function drops its "func" prefix and everything else gains a leading space.
+func labelDetails(kind protocol.CompletionItemKind, detail, description string) *protocol.CompletionItemLabelDetails {
+	switch kind {
+	case protocol.FunctionCompletion, protocol.MethodCompletion:
+		detail = strings.TrimPrefix(detail, "func")
+	case protocol.ModuleCompletion:
+		// The detail of a package is its quoted import path, which the
+		// description already reports.
+		detail = ""
+	default:
+		if detail != "" {
+			detail = " " + detail
+		}
+	}
+	if detail == "" && description == "" {
+		return nil
+	}
+	return &protocol.CompletionItemLabelDetails{
+		Detail:      detail,
+		Description: description,
+	}
+}
+
 // item formats a candidate to a CompletionItem.
 func (c *completer) item(ctx context.Context, cand candidate) (CompletionItem, error) {
 	obj := cand.obj
@@ -52,6 +80,7 @@ func (c *completer) item(ctx context.Context, cand candidate) (CompletionItem, e
 	var (
 		label         = cand.name
 		detail        = types.TypeString(obj.Type(), c.qual)
+		description   string // import path, if accepting the item adds an import
 		insert        = label
 		kind          = protocol.TextCompletion
 		snip          snippet.Builder
@@ -180,6 +209,10 @@ Suffixes:
 		}
 	}
 
+	// The label details hold the import path separately, so they use the
+	// detail from before the "(from ...)" text is appended to it.
+	labelDetail := detail
+
 	// If this candidate needs an additional import statement,
 	// add the additional text edits needed.
 	if cand.imp != nil {
@@ -190,6 +223,7 @@ Suffixes:
 		}
 
 		protocolEdits = append(protocolEdits, addlEdits...)
+		description = cand.imp.importPath
 		if kind != protocol.ModuleCompletion {
 			if detail != "" {
 				detail += " "
@@ -230,9 +264,11 @@ Suffixes:
 	}
 
 	detail = strings.TrimPrefix(detail, "untyped ")
+	labelDetail = strings.TrimPrefix(labelDetail, "untyped ")
 	// override computed detail with provided detail, if something is provided.
 	if cand.detail != "" {
 		detail = cand.detail
+		labelDetail = cand.detail
 	}
 
 	// When completing right after "//" (cursor at the slashes with no space),
@@ -247,6 +283,7 @@ Suffixes:
 		InsertText:          insert,
 		AdditionalTextEdits: protocolEdits,
 		Detail:              detail,
+		LabelDetails:        labelDetails(kind, labelDetail, description),
 		Kind:                kind,
 		Score:               cand.score,
 		Depth:               len(cand.path),

--- a/gopls/internal/golang/completion/labeldetails_test.go
+++ b/gopls/internal/golang/completion/labeldetails_test.go
@@ -1,0 +1,96 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package completion
+
+import (
+	"testing"
+
+	"golang.org/x/tools/gopls/internal/protocol"
+)
+
+func TestLabelDetails(t *testing.T) {
+	tests := []struct {
+		name            string
+		kind            protocol.CompletionItemKind
+		detail          string
+		description     string
+		wantNil         bool
+		wantDetail      string
+		wantDescription string
+	}{
+		{
+			name:       "function drops the func prefix",
+			kind:       protocol.FunctionCompletion,
+			detail:     "func(format string, a ...any) string",
+			wantDetail: "(format string, a ...any) string",
+		},
+		{
+			name:       "method drops the func prefix",
+			kind:       protocol.MethodCompletion,
+			detail:     "func() error",
+			wantDetail: "() error",
+		},
+		{
+			// A named function type has a detail of the same shape as a
+			// function, and must keep its prefix.
+			name:       "function type keeps the func prefix",
+			kind:       protocol.ClassCompletion,
+			detail:     "func(int)",
+			wantDetail: " func(int)",
+		},
+		{
+			name:       "other kinds gain a leading space",
+			kind:       protocol.ConstantCompletion,
+			detail:     "int",
+			wantDetail: " int",
+		},
+		{
+			name:            "package reports only the path",
+			kind:            protocol.ModuleCompletion,
+			detail:          `"os"`,
+			description:     "os",
+			wantDescription: "os",
+		},
+		{
+			name:    "imported package has nothing to add",
+			kind:    protocol.ModuleCompletion,
+			detail:  `"os"`,
+			wantNil: true,
+		},
+		{
+			name:            "import path becomes the description",
+			kind:            protocol.FunctionCompletion,
+			detail:          "func(v any) ([]byte, error)",
+			description:     "encoding/json",
+			wantDetail:      "(v any) ([]byte, error)",
+			wantDescription: "encoding/json",
+		},
+		{
+			name:    "nothing to report",
+			kind:    protocol.TextCompletion,
+			wantNil: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := labelDetails(test.kind, test.detail, test.description)
+			if test.wantNil {
+				if got != nil {
+					t.Fatalf("labelDetails(...) = %+v, want nil", *got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("labelDetails(...) = nil, want non-nil")
+			}
+			if got.Detail != test.wantDetail {
+				t.Errorf("Detail = %q, want %q", got.Detail, test.wantDetail)
+			}
+			if got.Description != test.wantDescription {
+				t.Errorf("Description = %q, want %q", got.Description, test.wantDescription)
+			}
+		})
+	}
+}

--- a/gopls/internal/golang/completion/literal.go
+++ b/gopls/internal/golang/completion/literal.go
@@ -113,6 +113,11 @@ func (c *completer) literal(ctx context.Context, literalType types.Type, imp *im
 		return
 	}
 
+	var importPath string
+	if imp != nil {
+		importPath = imp.importPath
+	}
+
 	// If prefix matches the type name, client may want a composite literal.
 	if score := c.matcher.Score(matchName); score > 0 {
 		if cand.hasMod(reference) {
@@ -133,9 +138,16 @@ func (c *completer) literal(ctx context.Context, literalType types.Type, imp *im
 			}
 		}
 
+		info := literalInfo{
+			typeName: typeName,
+			score:    float64(score),
+			edits:    addlEdits,
+			path:     importPath,
+		}
+
 		switch t := literalType.Underlying().(type) {
 		case *types.Struct, *types.Array, *types.Slice, *types.Map:
-			item := c.compositeLiteral(t, snip.Clone(), typeName, float64(score), addlEdits)
+			item := c.compositeLiteral(t, snip.Clone(), info)
 			item.addConversion(c, conversion)
 			c.items = append(c.items, item)
 		case *types.Signature:
@@ -143,7 +155,7 @@ func (c *completer) literal(ctx context.Context, literalType types.Type, imp *im
 			// an interface. For example, offer "http.HandlerFunc()" when
 			// expected type is "http.Handler".
 			if expType != nil && types.IsInterface(expType) {
-				if item, ok := c.basicLiteral(t, snip.Clone(), typeName, float64(score), addlEdits); ok {
+				if item, ok := c.basicLiteral(t, snip.Clone(), info); ok {
 					item.addConversion(c, conversion)
 					c.items = append(c.items, item)
 				}
@@ -154,7 +166,7 @@ func (c *completer) literal(ctx context.Context, literalType types.Type, imp *im
 			// implements http.FileSystem), or are identical to our expected
 			// type (i.e. yielding a type conversion such as "float64()").
 			if expType != nil && (types.IsInterface(expType) || types.Identical(expType, literalType)) {
-				if item, ok := c.basicLiteral(t, snip.Clone(), typeName, float64(score), addlEdits); ok {
+				if item, ok := c.basicLiteral(t, snip.Clone(), info); ok {
 					item.addConversion(c, conversion)
 					c.items = append(c.items, item)
 				}
@@ -166,16 +178,23 @@ func (c *completer) literal(ctx context.Context, literalType types.Type, imp *im
 	// invocation. We also include the type name to allow for more
 	// flexible fuzzy matching.
 	if score := c.matcher.Score("make." + matchName); !cand.hasMod(reference) && score > 0 {
+		info := literalInfo{
+			typeName: typeName,
+			score:    float64(score),
+			edits:    addlEdits,
+			path:     importPath,
+		}
+
 		switch literalType.Underlying().(type) {
 		case *types.Slice:
 			// The second argument to "make()" for slices is required, so default to "0".
-			item := c.makeCall(snip.Clone(), typeName, "0", float64(score), addlEdits)
+			item := c.makeCall(snip.Clone(), "0", info)
 			item.addConversion(c, conversion)
 			c.items = append(c.items, item)
 		case *types.Map, *types.Chan:
 			// Maps and channels don't require the second argument, so omit
 			// to keep things simple for now.
-			item := c.makeCall(snip.Clone(), typeName, "", float64(score), addlEdits)
+			item := c.makeCall(snip.Clone(), "", info)
 			item.addConversion(c, conversion)
 			c.items = append(c.items, item)
 		}
@@ -428,9 +447,23 @@ func abbreviateTypeName(s string) string {
 	return golang.AbbreviateVarName(s)
 }
 
+// literalInfo describes a literal completion item.
+type literalInfo struct {
+	typeName string
+	score    float64
+	edits    []protocol.TextEdit
+	path     string // import path the item adds, empty if it adds none
+}
+
+// labelDetails returns the label details of a literal item: the import path
+// alone, with no detail, since the label of a literal is already its type.
+func (info literalInfo) labelDetails(kind protocol.CompletionItemKind) *protocol.CompletionItemLabelDetails {
+	return labelDetails(kind, "", info.path)
+}
+
 // compositeLiteral returns a composite literal completion item for the given typeName.
 // T is an (unnamed, unaliased) struct, array, slice, or map type.
-func (c *completer) compositeLiteral(T types.Type, snip *snippet.Builder, typeName string, matchScore float64, edits []protocol.TextEdit) CompletionItem {
+func (c *completer) compositeLiteral(T types.Type, snip *snippet.Builder, info literalInfo) CompletionItem {
 	snip.WriteText("{")
 	// Don't put the tab stop inside the composite literal curlies "{}"
 	// for structs that have no accessible fields.
@@ -439,14 +472,15 @@ func (c *completer) compositeLiteral(T types.Type, snip *snippet.Builder, typeNa
 	}
 	snip.WriteText("}")
 
-	nonSnippet := typeName + "{}"
+	nonSnippet := info.typeName + "{}"
 
 	return CompletionItem{
 		Label:               nonSnippet,
 		InsertText:          nonSnippet,
-		Score:               matchScore * literalCandidateScore,
+		Score:               info.score * literalCandidateScore,
 		Kind:                protocol.VariableCompletion,
-		AdditionalTextEdits: edits,
+		AdditionalTextEdits: info.edits,
+		LabelDetails:        info.labelDetails(protocol.VariableCompletion),
 		snippet:             snip,
 	}
 }
@@ -455,7 +489,7 @@ func (c *completer) compositeLiteral(T types.Type, snip *snippet.Builder, typeNa
 // type name typeName.
 //
 // If T is untyped, this function returns false.
-func (c *completer) basicLiteral(T types.Type, snip *snippet.Builder, typeName string, matchScore float64, edits []protocol.TextEdit) (CompletionItem, bool) {
+func (c *completer) basicLiteral(T types.Type, snip *snippet.Builder, info literalInfo) (CompletionItem, bool) {
 	// Never give type conversions like "untyped int()".
 	if isUntyped(T) {
 		return CompletionItem{}, false
@@ -465,21 +499,22 @@ func (c *completer) basicLiteral(T types.Type, snip *snippet.Builder, typeName s
 	snip.WriteFinalTabstop()
 	snip.WriteText(")")
 
-	nonSnippet := typeName + "()"
+	nonSnippet := info.typeName + "()"
 
 	return CompletionItem{
 		Label:               nonSnippet,
 		InsertText:          nonSnippet,
 		Detail:              T.String(),
-		Score:               matchScore * literalCandidateScore,
+		Score:               info.score * literalCandidateScore,
 		Kind:                protocol.VariableCompletion,
-		AdditionalTextEdits: edits,
+		AdditionalTextEdits: info.edits,
+		LabelDetails:        info.labelDetails(protocol.VariableCompletion),
 		snippet:             snip,
 	}, true
 }
 
 // makeCall returns a completion item for a "make()" call given a specific type.
-func (c *completer) makeCall(snip *snippet.Builder, typeName string, secondArg string, matchScore float64, edits []protocol.TextEdit) CompletionItem {
+func (c *completer) makeCall(snip *snippet.Builder, secondArg string, info literalInfo) CompletionItem {
 	// Keep it simple and don't add any placeholders for optional "make()" arguments.
 
 	snip.PrependText("make(")
@@ -494,7 +529,7 @@ func (c *completer) makeCall(snip *snippet.Builder, typeName string, secondArg s
 	snip.WriteText(")")
 
 	var nonSnippet strings.Builder
-	nonSnippet.WriteString("make(" + typeName)
+	nonSnippet.WriteString("make(" + info.typeName)
 	if secondArg != "" {
 		nonSnippet.WriteString(", ")
 		nonSnippet.WriteString(secondArg)
@@ -505,9 +540,10 @@ func (c *completer) makeCall(snip *snippet.Builder, typeName string, secondArg s
 		Label:      nonSnippet.String(),
 		InsertText: nonSnippet.String(),
 		// make() should be just below other literal completions
-		Score:               matchScore * literalCandidateScore * 0.99,
+		Score:               info.score * literalCandidateScore * 0.99,
 		Kind:                protocol.FunctionCompletion,
-		AdditionalTextEdits: edits,
+		AdditionalTextEdits: info.edits,
+		LabelDetails:        info.labelDetails(protocol.FunctionCompletion),
 		snippet:             snip,
 	}
 }

--- a/gopls/internal/golang/completion/postfix_snippets.go
+++ b/gopls/internal/golang/completion/postfix_snippets.go
@@ -77,6 +77,7 @@ type postfixTmplArgs struct {
 	snip           snippet.Builder
 	importIfNeeded func(pkgPath string, scope *types.Scope) (name string, edits []protocol.TextEdit, err error)
 	edits          []protocol.TextEdit
+	paths          []string // import paths the edits add
 	qual           types.Qualifier
 	varNames       map[string]bool
 	placeholders   bool
@@ -398,6 +399,9 @@ func (a *postfixTmplArgs) Import(path string) (string, error) {
 		return "", fmt.Errorf("couldn't import %q: %w", path, err)
 	}
 	a.edits = append(a.edits, edits...)
+	if len(edits) > 0 {
+		a.paths = append(a.paths, path)
+	}
 
 	return name, nil
 }
@@ -634,6 +638,7 @@ func (c *completer) addPostfixSnippetCandidates(ctx context.Context, sel *ast.Se
 			Kind:                protocol.SnippetCompletion,
 			snippet:             &tmplArgs.snip,
 			AdditionalTextEdits: append(edits, tmplArgs.edits...),
+			LabelDetails:        labelDetails(protocol.SnippetCompletion, "", strings.Join(tmplArgs.paths, ", ")),
 		})
 	}
 }

--- a/gopls/internal/golang/completion/unimported.go
+++ b/gopls/internal/golang/completion/unimported.go
@@ -222,7 +222,7 @@ func (c *completer) pkgIDmatches(ctx context.Context, ids []metadata.PackageID, 
 				}
 				var params []string
 				var kind protocol.CompletionItemKind
-				var detail string
+				var detail, labelDetail string
 				switch sym.Kind {
 				case protocol.Function:
 					foundURI := pkgsyms.Files[np]
@@ -230,6 +230,7 @@ func (c *completer) pkgIDmatches(ctx context.Context, ids []metadata.PackageID, 
 					pgf, err := c.snapshot.ParseGo(ctx, fh, 0)
 					if err == nil {
 						params = funcParams(pgf.File, sym.Name)
+						labelDetail = funcSignature(pgf.File, sym.Name)
 					}
 					kind = protocol.FunctionCompletion
 					detail = fmt.Sprintf("func (from %q)", pkg.PkgPath)
@@ -243,12 +244,13 @@ func (c *completer) pkgIDmatches(ctx context.Context, ids []metadata.PackageID, 
 					continue
 				}
 				got = c.appendNewItem(got, symbolInfo{
-					name:   sym.Name,
-					kind:   kind,
-					detail: detail,
-					path:   pkg.PkgPath,
-					pkg:    pkgname,
-					params: params,
+					name:        sym.Name,
+					kind:        kind,
+					detail:      detail,
+					labelDetail: labelDetail,
+					path:        pkg.PkgPath,
+					pkg:         pkgname,
+					params:      params,
 				})
 			}
 		}
@@ -273,11 +275,12 @@ func (c *completer) stdlibMatches(pkgs []metadata.PackagePath, pkg metadata.Pack
 					continue
 				}
 				var kind protocol.CompletionItemKind
-				var detail string
+				var detail, labelDetail string
 				var params []string
 				switch sym.Kind {
 				case stdlib.Func:
 					params = parseSignature(sym.Signature)
+					labelDetail = strings.TrimPrefix(sym.Signature, "func")
 					kind = protocol.FunctionCompletion
 					detail = fmt.Sprintf("func (from %q)", candpkg)
 				case stdlib.Const:
@@ -293,12 +296,13 @@ func (c *completer) stdlibMatches(pkgs []metadata.PackagePath, pkg metadata.Pack
 					continue
 				}
 				got = c.appendNewItem(got, symbolInfo{
-					name:   sym.Name,
-					kind:   kind,
-					detail: detail,
-					path:   candpkg,
-					pkg:    pkg,
-					params: params,
+					name:        sym.Name,
+					kind:        kind,
+					detail:      detail,
+					labelDetail: labelDetail,
+					path:        candpkg,
+					pkg:         pkg,
+					params:      params,
 				})
 			}
 		}
@@ -322,12 +326,14 @@ func (c *completer) modcacheMatches(pkg metadata.PackageName, prefix string) ([]
 		}
 		var params []string
 		var kind protocol.CompletionItemKind
-		var detail string
+		var detail, labelDetail string
 		switch cand.Type {
 		case modindex.Func:
 			for _, f := range cand.Sig {
 				params = append(params, fmt.Sprintf("%s %s", f.Arg, f.Type))
 			}
+			// The index records the number of results but not their types.
+			labelDetail = "(" + strings.Join(params, ", ") + ")"
 			kind = protocol.FunctionCompletion
 			detail = fmt.Sprintf("func (from %s)", cand.ImportPath)
 		case modindex.Var:
@@ -343,12 +349,13 @@ func (c *completer) modcacheMatches(pkg metadata.PackageName, prefix string) ([]
 			continue
 		}
 		got = c.appendNewItem(got, symbolInfo{
-			name:   cand.Name,
-			kind:   kind,
-			detail: detail,
-			path:   metadata.PackagePath(cand.ImportPath),
-			pkg:    pkg,
-			params: params,
+			name:        cand.Name,
+			kind:        kind,
+			detail:      detail,
+			labelDetail: labelDetail,
+			path:        metadata.PackagePath(cand.ImportPath),
+			pkg:         pkg,
+			params:      params,
 		})
 	}
 	return got, nil
@@ -357,11 +364,17 @@ func (c *completer) modcacheMatches(pkg metadata.PackageName, prefix string) ([]
 // symbolInfo describes a symbol of an unimported package, found by one of the
 // three searches above.
 type symbolInfo struct {
-	name   string
-	kind   protocol.CompletionItemKind
-	detail string
-	path   metadata.PackagePath
-	pkg    metadata.PackageName
+	name string
+	kind protocol.CompletionItemKind
+
+	// detail is the text for clients that read CompletionItem.Detail, and
+	// labelDetail the signature for those that read CompletionItem.LabelDetails
+	// instead.
+	detail      string
+	labelDetail string
+
+	path metadata.PackagePath
+	pkg  metadata.PackageName
 
 	// params holds the parameters of a function, for the call snippet, and is
 	// nil for any other symbol.
@@ -375,6 +388,10 @@ func (c *completer) appendNewItem(got []CompletionItem, sym symbolInfo) []Comple
 		Detail:     sym.detail,
 		InsertText: sym.name,
 		Kind:       sym.kind,
+		LabelDetails: &protocol.CompletionItemLabelDetails{
+			Detail:      sym.labelDetail,
+			Description: string(sym.path),
+		},
 	}
 	imp := importInfo{
 		importPath: string(sym.path),
@@ -423,6 +440,26 @@ func usefulCompletion(name, pattern string) bool {
 		cand = cand[ix+1:]
 	}
 	return true
+}
+
+// funcSignature returns the parameters and results of the function fname
+// declared in f, for example "(a int, b string) (bool, error)". It returns the
+// empty string if there is no such function.
+//
+// Unlike funcParams, which builds snippet placeholders, this is display text:
+// an unnamed parameter keeps its type alone rather than becoming "_".
+func funcSignature(f *ast.File, fname string) string {
+	for _, n := range f.Decls {
+		fd, ok := n.(*ast.FuncDecl)
+		if !ok || fd.Recv != nil || fd.Name.Name != fname {
+			continue
+		}
+		var cfg printer.Config // slight overkill, as in funcParams
+		var buf strings.Builder
+		cfg.Fprint(&buf, token.NewFileSet(), fd.Type) // ignore error
+		return strings.TrimPrefix(buf.String(), "func")
+	}
+	return ""
 }
 
 // return a printed version of the function arguments for snippets

--- a/gopls/internal/golang/completion/unimported.go
+++ b/gopls/internal/golang/completion/unimported.go
@@ -229,8 +229,10 @@ func (c *completer) pkgIDmatches(ctx context.Context, ids []metadata.PackageID, 
 					fh, _ := c.snapshot.ReadFile(ctx, foundURI)
 					pgf, err := c.snapshot.ParseGo(ctx, fh, 0)
 					if err == nil {
-						params = funcParams(pgf.File, sym.Name)
-						labelDetail = funcSignature(pgf.File, sym.Name)
+						if fd := findFunc(pgf.File, sym.Name); fd != nil {
+							params = funcParams(fd)
+							labelDetail = funcSignature(fd)
+						}
 					}
 					kind = protocol.FunctionCompletion
 					detail = fmt.Sprintf("func (from %q)", pkg.PkgPath)
@@ -442,58 +444,51 @@ func usefulCompletion(name, pattern string) bool {
 	return true
 }
 
-// funcSignature returns the parameters and results of the function fname
-// declared in f, for example "(a int, b string) (bool, error)". It returns the
-// empty string if there is no such function.
+// findFunc returns the declaration of the function fname in f, or nil if there
+// is none. A method cannot be completed as a package member, so a declaration
+// with a receiver does not match.
+func findFunc(f *ast.File, fname string) *ast.FuncDecl {
+	for _, n := range f.Decls {
+		if fd, ok := n.(*ast.FuncDecl); ok && fd.Recv == nil && fd.Name.Name == fname {
+			return fd
+		}
+	}
+	return nil
+}
+
+// funcSignature returns the parameters and results of fd, for example
+// "(a int, b string) (bool, error)".
 //
 // Unlike funcParams, which builds snippet placeholders, this is display text:
 // an unnamed parameter keeps its type alone rather than becoming "_".
-func funcSignature(f *ast.File, fname string) string {
-	for _, n := range f.Decls {
-		fd, ok := n.(*ast.FuncDecl)
-		if !ok || fd.Recv != nil || fd.Name.Name != fname {
-			continue
-		}
-		var cfg printer.Config // slight overkill, as in funcParams
-		var buf strings.Builder
-		cfg.Fprint(&buf, token.NewFileSet(), fd.Type) // ignore error
-		return strings.TrimPrefix(buf.String(), "func")
-	}
-	return ""
+func funcSignature(fd *ast.FuncDecl) string {
+	var cfg printer.Config // slight overkill, as in funcParams
+	var buf strings.Builder
+	cfg.Fprint(&buf, token.NewFileSet(), fd.Type) // ignore error
+	return strings.TrimPrefix(buf.String(), "func")
 }
 
 // return a printed version of the function arguments for snippets
-func funcParams(f *ast.File, fname string) []string {
-	var params []string
-	setParams := func(list *ast.FieldList) {
-		if list == nil {
-			return
-		}
-		var cfg printer.Config // slight overkill
-		param := func(name string, typ ast.Expr) {
-			var buf strings.Builder
-			buf.WriteString(name)
-			buf.WriteByte(' ')
-			cfg.Fprint(&buf, token.NewFileSet(), typ) // ignore error
-			params = append(params, buf.String())
-		}
-
-		for _, field := range list.List {
-			if field.Names != nil {
-				for _, name := range field.Names {
-					param(name.Name, field.Type)
-				}
-			} else {
-				param("_", field.Type)
-			}
-		}
+func funcParams(fd *ast.FuncDecl) []string {
+	if fd.Type.Params == nil {
+		return nil
 	}
-	for _, n := range f.Decls {
-		switch x := n.(type) {
-		case *ast.FuncDecl:
-			if x.Recv == nil && x.Name.Name == fname {
-				setParams(x.Type.Params)
+	var params []string
+	var cfg printer.Config // slight overkill
+	param := func(name string, typ ast.Expr) {
+		var buf strings.Builder
+		buf.WriteString(name)
+		buf.WriteByte(' ')
+		cfg.Fprint(&buf, token.NewFileSet(), typ) // ignore error
+		params = append(params, buf.String())
+	}
+	for _, field := range fd.Type.Params.List {
+		if field.Names != nil {
+			for _, name := range field.Names {
+				param(name.Name, field.Type)
 			}
+		} else {
+			param("_", field.Type)
 		}
 	}
 	return params

--- a/gopls/internal/golang/completion/unimported.go
+++ b/gopls/internal/golang/completion/unimported.go
@@ -242,11 +242,14 @@ func (c *completer) pkgIDmatches(ctx context.Context, ids []metadata.PackageID, 
 				default:
 					continue
 				}
-				got = c.appendNewItem(got, sym.Name,
-					detail,
-					pkg.PkgPath,
-					kind,
-					pkgname, params)
+				got = c.appendNewItem(got, symbolInfo{
+					name:   sym.Name,
+					kind:   kind,
+					detail: detail,
+					path:   pkg.PkgPath,
+					pkg:    pkgname,
+					params: params,
+				})
 			}
 		}
 	}
@@ -289,11 +292,14 @@ func (c *completer) stdlibMatches(pkgs []metadata.PackagePath, pkg metadata.Pack
 				default:
 					continue
 				}
-				got = c.appendNewItem(got, sym.Name,
-					detail,
-					candpkg,
-					kind,
-					pkg, params)
+				got = c.appendNewItem(got, symbolInfo{
+					name:   sym.Name,
+					kind:   kind,
+					detail: detail,
+					path:   candpkg,
+					pkg:    pkg,
+					params: params,
+				})
 			}
 		}
 	}
@@ -336,33 +342,51 @@ func (c *completer) modcacheMatches(pkg metadata.PackageName, prefix string) ([]
 		default:
 			continue
 		}
-		got = c.appendNewItem(got, cand.Name,
-			detail,
-			metadata.PackagePath(cand.ImportPath),
-			kind,
-			pkg, params)
+		got = c.appendNewItem(got, symbolInfo{
+			name:   cand.Name,
+			kind:   kind,
+			detail: detail,
+			path:   metadata.PackagePath(cand.ImportPath),
+			pkg:    pkg,
+			params: params,
+		})
 	}
 	return got, nil
 }
 
-func (c *completer) appendNewItem(got []CompletionItem, name, detail string, path metadata.PackagePath, kind protocol.CompletionItemKind, pkg metadata.PackageName, params []string) []CompletionItem {
+// symbolInfo describes a symbol of an unimported package, found by one of the
+// three searches above.
+type symbolInfo struct {
+	name   string
+	kind   protocol.CompletionItemKind
+	detail string
+	path   metadata.PackagePath
+	pkg    metadata.PackageName
+
+	// params holds the parameters of a function, for the call snippet, and is
+	// nil for any other symbol.
+	params []string
+}
+
+// appendNewItem appends a completion item for an unimported symbol.
+func (c *completer) appendNewItem(got []CompletionItem, sym symbolInfo) []CompletionItem {
 	item := CompletionItem{
-		Label:      name,
-		Detail:     detail,
-		InsertText: name,
-		Kind:       kind,
+		Label:      sym.name,
+		Detail:     sym.detail,
+		InsertText: sym.name,
+		Kind:       sym.kind,
 	}
 	imp := importInfo{
-		importPath: string(path),
-		name:       string(pkg),
+		importPath: string(sym.path),
+		name:       string(sym.pkg),
 	}
-	if imports.ImportPathToAssumedName(string(path)) == string(pkg) {
+	if imports.ImportPathToAssumedName(string(sym.path)) == string(sym.pkg) {
 		imp.name = ""
 	}
 	item.AdditionalTextEdits, _ = c.importEdits(&imp)
-	if params != nil {
+	if sym.params != nil {
 		var sn snippet.Builder
-		c.functionCallSnippet(name, nil, params, &sn)
+		c.functionCallSnippet(sym.name, nil, sym.params, &sn)
 		item.snippet = &sn
 	}
 	got = append(got, item)

--- a/gopls/internal/golang/completion/unimported_test.go
+++ b/gopls/internal/golang/completion/unimported_test.go
@@ -44,12 +44,23 @@ func (r recv) Method() {}
 		{"Variadic", "(format string, a ...any) string"},
 		{"Unnamed", "(int, string) bool"},
 		{"NoParams", "()"},
-		{"Method", ""},  // has a receiver, so it is not an import candidate
-		{"Missing", ""}, // no such function
 	}
 	for _, test := range tests {
-		if got := funcSignature(f, test.fname); got != test.want {
+		fd := findFunc(f, test.fname)
+		if fd == nil {
+			t.Errorf("findFunc(%q) = nil, want the declaration", test.fname)
+			continue
+		}
+		if got := funcSignature(fd); got != test.want {
 			t.Errorf("funcSignature(%q) = %q, want %q", test.fname, got, test.want)
+		}
+	}
+
+	// A method has a receiver, so it is not a candidate for an import, and
+	// there is no function named Missing at all.
+	for _, fname := range []string{"Method", "Missing"} {
+		if fd := findFunc(f, fname); fd != nil {
+			t.Errorf("findFunc(%q) = %v, want nil", fname, fd.Name)
 		}
 	}
 }

--- a/gopls/internal/golang/completion/unimported_test.go
+++ b/gopls/internal/golang/completion/unimported_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package completion
+
+import (
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+func TestFuncSignature(t *testing.T) {
+	const src = `package p
+
+func NoResult(a int) {}
+
+func OneResult(a, b int) string { return "" }
+
+func TwoResults(v any) ([]byte, error) { return nil, nil }
+
+func NamedResults(r io.Reader) (n int, err error) { return }
+
+func Variadic(format string, a ...any) string { return "" }
+
+func Unnamed(int, string) bool { return false }
+
+func NoParams() {}
+
+func (r recv) Method() {}
+`
+	f, err := parser.ParseFile(token.NewFileSet(), "p.go", src, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		fname string
+		want  string
+	}{
+		{"NoResult", "(a int)"},
+		{"OneResult", "(a, b int) string"}, // the printer keeps the grouping
+		{"TwoResults", "(v any) ([]byte, error)"},
+		{"NamedResults", "(r io.Reader) (n int, err error)"},
+		{"Variadic", "(format string, a ...any) string"},
+		{"Unnamed", "(int, string) bool"},
+		{"NoParams", "()"},
+		{"Method", ""},  // has a receiver, so it is not an import candidate
+		{"Missing", ""}, // no such function
+	}
+	for _, test := range tests {
+		if got := funcSignature(f, test.fname); got != test.want {
+			t.Errorf("funcSignature(%q) = %q, want %q", test.fname, got, test.want)
+		}
+	}
+}

--- a/gopls/internal/server/completion.go
+++ b/gopls/internal/server/completion.go
@@ -206,6 +206,9 @@ func toProtocolCompletionItems(candidates []completion.CompletionItem, surroundi
 			Tags:          protocol.NonNilSlice(candidate.Tags),
 			Deprecated:    candidate.Deprecated,
 		}
+		if options.LabelDetailsSupported {
+			item.LabelDetails = candidate.LabelDetails
+		}
 		items = append(items, item)
 	}
 	return items, nil

--- a/gopls/internal/settings/settings.go
+++ b/gopls/internal/settings/settings.go
@@ -90,6 +90,7 @@ type ClientOptions struct {
 	ClientInfo                                 protocol.ClientInfo
 	InsertTextFormat                           protocol.InsertTextFormat
 	InsertReplaceSupported                     bool
+	LabelDetailsSupported                      bool
 	ConfigurationSupported                     bool
 	DynamicConfigurationSupported              bool
 	DynamicRegistrationSemanticTokensSupported bool
@@ -1083,6 +1084,7 @@ func (o *Options) ForClientCapabilities(clientInfo *protocol.ClientInfo, caps pr
 		o.InsertTextFormat = protocol.SnippetTextFormat
 	}
 	o.InsertReplaceSupported = caps.TextDocument.Completion.CompletionItem.InsertReplaceSupport
+	o.LabelDetailsSupported = caps.TextDocument.Completion.CompletionItem.LabelDetailsSupport
 	if caps.Window.ShowDocument != nil {
 		o.ShowDocumentSupported = caps.Window.ShowDocument.Support
 	}

--- a/gopls/internal/test/integration/completion/completion_test.go
+++ b/gopls/internal/test/integration/completion/completion_test.go
@@ -1718,3 +1718,69 @@ func f[T ~[]int](x T) {
 		env.Completion(loc)
 	})
 }
+
+func TestCompletionLabelDetails(t *testing.T) {
+	const src = `
+-- go.mod --
+module mod.com
+
+go 1.21
+
+-- main.go --
+package main
+
+import "math"
+
+func main() {
+	math.Sqr
+}
+`
+	for _, supported := range []bool{true, false} {
+		t.Run(fmt.Sprintf("labelDetailsSupport=%v", supported), func(t *testing.T) {
+			capabilities := fmt.Sprintf(
+				`{"textDocument":{"completion":{"completionItem":{"labelDetailsSupport":%t}}}}`,
+				supported)
+			WithOptions(
+				CapabilitiesJSON([]byte(capabilities)),
+			).Run(t, src, func(t *testing.T, env *Env) {
+				env.OpenFile("main.go")
+				env.Await(env.DoneWithOpen())
+				loc := env.RegexpSearch("main.go", "Sqr()")
+
+				var item *protocol.CompletionItem
+				for _, got := range env.Completion(loc).Items {
+					if got.Label == "Sqrt" {
+						item = &got
+						break
+					}
+				}
+				if item == nil {
+					t.Fatal("no completion item labelled Sqrt")
+				}
+
+				// Detail is unchanged, whether or not the client asked for
+				// label details.
+				if want := "func(x float64) float64"; item.Detail != want {
+					t.Errorf("Detail = %q, want %q", item.Detail, want)
+				}
+
+				if !supported {
+					if item.LabelDetails != nil {
+						t.Errorf("LabelDetails = %+v, want nil", *item.LabelDetails)
+					}
+					return
+				}
+				if item.LabelDetails == nil {
+					t.Fatal("LabelDetails = nil, want the signature")
+				}
+				if want := "(x float64) float64"; item.LabelDetails.Detail != want {
+					t.Errorf("LabelDetails.Detail = %q, want %q", item.LabelDetails.Detail, want)
+				}
+				// math is already imported, so accepting the item adds nothing.
+				if item.LabelDetails.Description != "" {
+					t.Errorf("LabelDetails.Description = %q, want %q", item.LabelDetails.Description, "")
+				}
+			})
+		})
+	}
+}

--- a/gopls/internal/test/integration/completion/completion_test.go
+++ b/gopls/internal/test/integration/completion/completion_test.go
@@ -1832,3 +1832,61 @@ func main() {
 		}
 	})
 }
+
+func TestCompletionLabelDetailsLiteral(t *testing.T) {
+	const src = `
+-- go.mod --
+module mod.com
+
+go 1.21
+
+-- point/point.go --
+package point
+
+type Point struct{}
+
+-- decl.go --
+package main
+
+import "mod.com/point"
+
+func f(p point.Point) {}
+
+-- main.go --
+package main
+
+func main() {
+	f(Poi)
+}
+`
+	const capabilities = `{"textDocument":{"completion":{"completionItem":{"labelDetailsSupport":true}}}}`
+	WithOptions(
+		CapabilitiesJSON([]byte(capabilities)),
+	).Run(t, src, func(t *testing.T, env *Env) {
+		env.OpenFile("main.go")
+		env.Await(env.DoneWithOpen())
+		loc := env.RegexpSearch("main.go", `f\(Poi()\)`)
+
+		var item *protocol.CompletionItem
+		for _, got := range env.Completion(loc).Items {
+			if got.Label == "point.Point{}" {
+				item = &got
+				break
+			}
+		}
+		if item == nil {
+			t.Fatal("no completion item labelled point.Point{}")
+		}
+
+		if item.LabelDetails == nil {
+			t.Fatal("LabelDetails = nil, want the import path")
+		}
+		// The label of a literal is already its type, so nothing goes beside it.
+		if item.LabelDetails.Detail != "" {
+			t.Errorf("LabelDetails.Detail = %q, want %q", item.LabelDetails.Detail, "")
+		}
+		if want := "mod.com/point"; item.LabelDetails.Description != want {
+			t.Errorf("LabelDetails.Description = %q, want %q", item.LabelDetails.Description, want)
+		}
+	})
+}

--- a/gopls/internal/test/integration/completion/completion_test.go
+++ b/gopls/internal/test/integration/completion/completion_test.go
@@ -1784,3 +1784,51 @@ func main() {
 		})
 	}
 }
+
+func TestCompletionLabelDetailsUnimported(t *testing.T) {
+	const src = `
+-- go.mod --
+module mod.com
+
+go 1.21
+
+-- main.go --
+package main
+
+func main() {
+	math.Sqr
+}
+`
+	const capabilities = `{"textDocument":{"completion":{"completionItem":{"labelDetailsSupport":true}}}}`
+	WithOptions(
+		CapabilitiesJSON([]byte(capabilities)),
+	).Run(t, src, func(t *testing.T, env *Env) {
+		env.OpenFile("main.go")
+		env.Await(env.DoneWithOpen())
+		loc := env.RegexpSearch("main.go", "Sqr()")
+
+		var item *protocol.CompletionItem
+		for _, got := range env.Completion(loc).Items {
+			if got.Label == "Sqrt" {
+				item = &got
+				break
+			}
+		}
+		if item == nil {
+			t.Fatal("no completion item labelled Sqrt")
+		}
+
+		if want := `func (from "math")`; item.Detail != want {
+			t.Errorf("Detail = %q, want %q", item.Detail, want)
+		}
+		if item.LabelDetails == nil {
+			t.Fatal("LabelDetails = nil, want the signature and the import path")
+		}
+		if want := "(x float64) float64"; item.LabelDetails.Detail != want {
+			t.Errorf("LabelDetails.Detail = %q, want %q", item.LabelDetails.Detail, want)
+		}
+		if want := "math"; item.LabelDetails.Description != want {
+			t.Errorf("LabelDetails.Description = %q, want %q", item.LabelDetails.Description, want)
+		}
+	})
+}

--- a/gopls/internal/test/integration/completion/postfix_snippet_test.go
+++ b/gopls/internal/test/integration/completion/postfix_snippet_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"golang.org/x/tools/gopls/internal/protocol"
 	. "golang.org/x/tools/gopls/internal/test/integration"
 )
 
@@ -757,6 +758,56 @@ func _() {
 					t.Errorf("\nGOT:\n%s\nEXPECTED:\n%s", buf, c.after)
 				}
 			})
+		}
+	})
+}
+
+func TestPostfixSnippetLabelDetails(t *testing.T) {
+	const mod = `
+-- go.mod --
+module mod.com
+
+go 1.12
+-- foo.go --
+package foo
+
+func _() {
+	var foo []int
+	foo.sort
+}
+`
+	const capabilities = `{"textDocument":{"completion":{"completionItem":{"labelDetailsSupport":true}}}}`
+	WithOptions(
+		CapabilitiesJSON([]byte(capabilities)),
+		Settings{
+			"experimentalPostfixCompletions": true,
+		},
+	).Run(t, mod, func(t *testing.T, env *Env) {
+		env.OpenFile("foo.go")
+		env.Await(env.DoneWithOpen())
+		loc := env.RegexpSearch("foo.go", `foo\.sort()`)
+
+		var item *protocol.CompletionItem
+		for _, got := range env.Completion(loc).Items {
+			if got.Label == "sort!" {
+				item = &got
+				break
+			}
+		}
+		if item == nil {
+			t.Fatal("no completion item labelled sort!")
+		}
+
+		if item.LabelDetails == nil {
+			t.Fatal("LabelDetails = nil, want the import path")
+		}
+		// The label of a snippet names no symbol of the package, so only the
+		// import it adds is reported.
+		if item.LabelDetails.Detail != "" {
+			t.Errorf("LabelDetails.Detail = %q, want %q", item.LabelDetails.Detail, "")
+		}
+		if want := "sort"; item.LabelDetails.Description != want {
+			t.Errorf("LabelDetails.Description = %q, want %q", item.LabelDetails.Description, want)
 		}
 	})
 }


### PR DESCRIPTION
A completion menu gives no sign that accepting an item will add an
import. A symbol from an unimported package and one from a package
already in the file look identical, so picking the wrong one silently
rewrites the import block and has to be undone.

Fill in CompletionItem.labelDetails, added in LSP 3.17: the type goes in
labelDetails.detail and the import path in labelDetails.description.
Both were packed into CompletionItem.detail as one string, such as
func(...) (from "encoding/json"), which a client can only print as a
whole. As separate fields they can be laid out or filtered on their own,
and description is non-empty exactly when accepting the item adds an
import. CompletionItem.detail is unchanged, and labelDetails is sent
only to a client that advertises labelDetailsSupport.

The import path of a candidate now goes in description even when the
candidate is a package name. It was left out of detail in that case
because detail already holds the quoted import path, but description is
a separate field, so there is nothing to duplicate.

Updates golang/go#70975
