### PR TITLE
internal/imports: import "embed" for files with //go:embed directives

### DIFF
--- a/internal/imports/fix.go
+++ b/internal/imports/fix.go
@@ -588,6 +588,87 @@ func getFixes(ctx context.Context, fset *token.FileSet, f *ast.File, filename st
 }
 
 func getFixesWithSource(ctx context.Context, fset *token.FileSet, f *ast.File, filename string, goroot string, logf func(string, ...any), source Source) ([]*ImportFix, error) {
+	fixes, err := computeFixesWithSource(ctx, fset, f, filename, goroot, logf, source)
+	if err != nil {
+		return nil, err
+	}
+	return ensureEmbedImport(f, fixes), nil
+}
+
+// ensureEmbedImport makes sure a file containing a //go:embed directive
+// imports "embed" once fixes are applied. The compiler requires the import
+// whenever a //go:embed directive is present, even when the embedded
+// variable's type (string or []byte) means the package is never referenced by
+// name. Any import of "embed" (renamed or blank) satisfies it.
+func ensureEmbedImport(f *ast.File, fixes []*ImportFix) []*ImportFix {
+	if !hasEmbedDirective(f) {
+		return fixes
+	}
+	// Work out the state of the "embed" import once fixes are applied. It may
+	// already be imported (under any name), be added by normal resolution (as
+	// for an embed.FS variable), or be deleted as an unused import.
+	imported := importsEmbed(f)
+	deleteFix := -1
+	for i, fix := range fixes {
+		if fix.StmtInfo.ImportPath != "embed" {
+			continue
+		}
+		switch fix.FixType {
+		case AddImport:
+			imported = true
+		case DeleteImport:
+			imported = false
+			deleteFix = i
+		}
+	}
+	if imported {
+		return fixes
+	}
+	blankEmbed := &ImportFix{
+		StmtInfo:  ImportInfo{ImportPath: "embed", Name: "_"},
+		IdentName: "_",
+		Relevance: MaxRelevance,
+	}
+	if deleteFix >= 0 {
+		// The file imports "embed" but the import is about to be removed as
+		// unused. Keep it as a blank import instead of deleting it and adding
+		// a new one back.
+		blankEmbed.FixType = SetImportName
+		fixes[deleteFix] = blankEmbed
+		return fixes
+	}
+	blankEmbed.FixType = AddImport
+	return append(fixes, blankEmbed)
+}
+
+// hasEmbedDirective reports whether f contains a //go:embed directive.
+func hasEmbedDirective(f *ast.File) bool {
+	for _, cg := range f.Comments {
+		for _, c := range cg.List {
+			// A //go:embed directive is the text "//go:embed" followed by
+			// whitespace and the patterns (see go/build.parseGoEmbed). The
+			// whitespace is what distinguishes it from an ordinary comment
+			// such as "//go:embedded".
+			if rest, ok := strings.CutPrefix(c.Text, "//go:embed"); ok &&
+				len(rest) > 0 && (rest[0] == ' ' || rest[0] == '\t') {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// importsEmbed reports whether f imports the "embed" package under any name.
+func importsEmbed(f *ast.File) bool {
+	for _, imp := range f.Imports {
+		if imp.Path.Value == `"embed"` {
+			return true
+		}
+	}
+	return false
+}
+
+func computeFixesWithSource(ctx context.Context, fset *token.FileSet, f *ast.File, filename string, goroot string, logf func(string, ...any), source Source) ([]*ImportFix, error) {
 	// This logic is defensively duplicated from getFixes.
 	abs, err := filepath.Abs(filename)
 	if err != nil {

--- a/internal/imports/fix_test.go
+++ b/internal/imports/fix_test.go
@@ -9,6 +9,8 @@ import (
 	"flag"
 	"fmt"
 	"go/build"
+	"go/parser"
+	"go/token"
 	"log"
 	"os"
 	"path"
@@ -1672,6 +1674,174 @@ var _ = rc4.NewCipher
 			t.Errorf("Got:\n%s\nWant:\n%s", got, input)
 		}
 	})
+}
+
+// A file with a //go:embed directive must import "embed"; goimports adds a
+// blank import when the embedded variable's type does not reference the
+// package. See golang/go#50414.
+func TestEmbedDirective(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string // if empty, the input is expected to be unchanged
+	}{
+		{
+			name: "blank import added when unreferenced",
+			input: `package p
+
+//go:embed data.txt
+var s string
+`,
+			want: `package p
+
+import _ "embed"
+
+//go:embed data.txt
+var s string
+`,
+		},
+		{
+			// The directive may be separated from its patterns by a tab.
+			name:  "tab-separated directive",
+			input: "package p\n\n//go:embed\tdata.txt\nvar s string\n",
+			want:  "package p\n\nimport _ \"embed\"\n\n//go:embed\tdata.txt\nvar s string\n",
+		},
+		{
+			// A comment that merely mentions the directive text, or one
+			// without the required trailing whitespace, is not a directive.
+			name: "non-directive comment is ignored",
+			input: `package p
+
+// we don't need //go:embed here
+var s string
+`,
+		},
+		{
+			// An embed.FS variable references the package, so it is imported
+			// through the normal mechanism; no duplicate blank import is added.
+			name: "embed.FS imported normally",
+			input: `package p
+
+//go:embed data.txt
+var f embed.FS
+`,
+			want: `package p
+
+import "embed"
+
+//go:embed data.txt
+var f embed.FS
+`,
+		},
+		{
+			// An existing import of "embed" under any name already satisfies
+			// the compiler.
+			name: "existing named import unchanged",
+			input: `package p
+
+import embed2 "embed"
+
+//go:embed data.txt
+var f embed2.FS
+`,
+		},
+		{
+			name: "existing blank import unchanged",
+			input: `package p
+
+import _ "embed"
+
+//go:embed data.txt
+var s string
+`,
+		},
+		{
+			// A plain unused import would otherwise be deleted, leaving the
+			// directive without its import; it is made blank instead.
+			name: "unused import converted to blank",
+			input: `package p
+
+import "embed"
+
+//go:embed data.txt
+var s string
+`,
+			want: `package p
+
+import _ "embed"
+
+//go:embed data.txt
+var s string
+`,
+		},
+		{
+			name: "multiple directives add a single import",
+			input: `package p
+
+//go:embed data.txt
+var s string
+
+//go:embed other.txt
+var u string
+`,
+			want: `package p
+
+import _ "embed"
+
+//go:embed data.txt
+var s string
+
+//go:embed other.txt
+var u string
+`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			want := tt.want
+			if want == "" {
+				want = tt.input
+			}
+			testConfig{
+				module: packagestest.Module{
+					Name:  "golang.org/fake",
+					Files: fm{"x.go": tt.input, "data.txt": "hello", "other.txt": "world"},
+				},
+			}.processTest(t, "golang.org/fake", "x.go", nil, nil, want)
+		})
+	}
+}
+
+// TestEnsureEmbedImport checks that when a file already imports "embed" but the
+// import is unused (and would be deleted), ensureEmbedImport replaces the
+// delete with a single fix that makes the import blank, rather than deleting
+// and re-adding it.
+func TestEnsureEmbedImport(t *testing.T) {
+	const src = `package p
+
+import "embed"
+
+//go:embed data.txt
+var s string
+`
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "x.go", src, parser.ParseComments)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The fix goimports computes on its own for the unused import.
+	deleteEmbed := &ImportFix{
+		StmtInfo:  ImportInfo{ImportPath: "embed"},
+		IdentName: "embed",
+		FixType:   DeleteImport,
+	}
+	got := ensureEmbedImport(f, []*ImportFix{deleteEmbed})
+	if len(got) != 1 {
+		t.Fatalf("ensureEmbedImport returned %d fixes, want 1: %+v", len(got), got)
+	}
+	if fix := got[0]; fix.FixType != SetImportName || fix.StmtInfo.ImportPath != "embed" || fix.StmtInfo.Name != "_" {
+		t.Errorf("got fix %+v; want a SetImportName of \"embed\" to \"_\"", fix)
+	}
 }
 
 type testConfig struct {


### PR DESCRIPTION
A file that contains a //go:embed directive must import "embed", but
goimports did not add the import when the embedded variable's type
(string or []byte) meant the package was never referenced by name,
leaving the file failing to compile.

Add a blank import of "embed" for such files, unless applying the other
fixes already leaves the file importing "embed" under some name (for
example when the variable has type embed.FS, which references the
package). A plain, name-unused "embed" import that would otherwise be
removed is converted to a blank import instead.

Fixes golang/go#50414
