### PR TITLE
go/ssa: instantiate method wrappers before adapting receivers

### DIFF
--- a/go/ssa/generic_methods_test.go
+++ b/go/ssa/generic_methods_test.go
@@ -340,6 +340,24 @@ func TestGenericMethods(t *testing.T) {
 		// instantiate same signature with value / pointer receivers
 		fmt.Sprintf(g, "_ = g.M[bool]; _ = g.N[bool]"),
 		fmt.Sprintf(n, "_ = n.M[bool]; _ = n.N[bool]"),
+		// Method expressions inside a generic function specialize both the
+		// receiver and the method's independent type parameters.
+		`package p
+type G[P any] struct { x P }
+func (g G[P]) M[Q any](q Q) (P, Q) { return g.x, q }
+func (g *G[P]) N[Q any](q Q) (P, Q) { return g.x, q }
+type Outer[P any] struct { G[P] }
+func value[P, Q any]() func(G[P], Q) (P, Q) { return G[P].M[Q] }
+func pointer[P, Q any]() func(*G[P], Q) (P, Q) { return (*G[P]).N[Q] }
+func promoted[P, Q any]() func(Outer[P], Q) (P, Q) { return Outer[P].M[Q] }
+func same[P, Q any](q Q) (P, Q) { var p P; return p, q }
+func f() {
+    _, _ = same[int, string]("canonical function signature without a receiver")
+    g := G[int]{42}
+    value[int, string]()(g, "value")
+    pointer[int, string]()(&g, "pointer")
+    promoted[int, string]()(Outer[int]{g}, "promoted")
+}`,
 	}
 
 	for _, prog := range testBuilds {

--- a/go/ssa/wrappers.go
+++ b/go/ssa/wrappers.go
@@ -46,7 +46,17 @@ import (
 //   - the result may be a thunk or a wrapper.
 func createWrapper(prog *Program, sel *selection, targs []types.Type) *Function {
 	obj := sel.obj.(*types.Func) // the declared function
-	name, sig := maybeInstance(prog, obj.Name(), sel.typ.(*types.Signature), targs)
+	// Specialize method type parameters before adapting the receiver. A
+	// selection reconstructed inside a generic function has already adapted
+	// its signature, and changeRecv/recvAsFirstArg discard type parameters.
+	methodSig := obj.Type().(*types.Signature)
+	name, sig := maybeInstance(prog, obj.Name(), methodSig, targs)
+	// Canonical signatures compare equal regardless of their receiver.
+	// Restore the selected receiver from the method, not the canonical type.
+	sig = changeRecv(sig, newVar(methodSig.Recv().Name(), sel.recv))
+	if sel.kind == types.MethodExpr {
+		sig = recvAsFirstArg(sig)
+	}
 
 	var recv *types.Var // wrapper's receiver or thunk's params[0]
 	var description string


### PR DESCRIPTION
When a generic function's method expression is specialized, its
reconstructed selection signature has already adapted the receiver and
lost the method type parameters. Instantiating that signature with the
method's type arguments panics in go/types.

Instantiate the selected method object's signature before adapting its
receiver. Restore the selected receiver explicitly, since canonical
signature identity ignores receivers and may return a signature with a
different receiver or no receiver.

Add regression coverage for method expressions with value, pointer, and
promoted receivers inside generic functions. Also prime the canonical
signature cache with an equivalent function signature without a receiver.

The regression and a standalone SSA reproducer fail on the current
master and pass with this change. Tested the tools root module with
go test ./..., plus ten race-enabled repetitions of TestGenericMethods,
using Go 1.27.0 on darwin/arm64. The same fix also lets LLGo compile and
run Go 1.27's full test/genmeth1.go with its build cache disabled.

Fixes golang/go#81385
